### PR TITLE
[WIP] Fix StackOverflowError in DLPortletDataHandlerTest.testDeleteAllFolders by calling the LocalRepository instead of the remote one in method DLFolderTrashHandler.deleteTrashEntry(DLFolderTrashHandler.java:83)

### DIFF
--- a/modules/frontend/frontend-themes-web/build.xml
+++ b/modules/frontend/frontend-themes-web/build.xml
@@ -192,14 +192,14 @@
 				<replaceregexp match="^// INSERT CUSTOM VARS" replace="@import &quot;../../aui_variables&quot;;" byline="true">
 					<fileset
 						dir="${lexicon.deploy.theme.dir}"
-						includes="atlas.scss,bootstrap.scss,lexicon.scss"
+						includes="atlas.scss,bootstrap.scss,lexicon-base.scss"
 					/>
 				</replaceregexp>
 
 				<replaceregexp match="^// INSERT CUSTOM EXTENSIONS" replace="@import &quot;../../aui_custom&quot;;${line.separator}@import &quot;../../liferay_custom&quot;;${line.separator}@import &quot;../alloy-font-awesome/scss/font-awesome&quot;;" byline="true">
 					<fileset
 						dir="${lexicon.deploy.theme.dir}"
-						includes="atlas.scss,bootstrap.scss,lexicon.scss"
+						includes="atlas.scss,bootstrap.scss,lexicon-base.scss"
 					/>
 				</replaceregexp>
 			</then>

--- a/portal-impl/src/com/liferay/portal/repository/capabilities/ConfigurationCapabilityImpl.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/ConfigurationCapabilityImpl.java
@@ -22,21 +22,25 @@ import com.liferay.portal.kernel.repository.capabilities.ConfigurationCapability
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.model.Repository;
-import com.liferay.portal.service.RepositoryLocalServiceUtil;
+import com.liferay.portal.repository.capabilities.util.RepositoryServiceAdapter;
 
 /**
  * @author Iván Zaera
  */
 public class ConfigurationCapabilityImpl implements ConfigurationCapability {
 
-	public ConfigurationCapabilityImpl(DocumentRepository repository) {
+	public ConfigurationCapabilityImpl(
+		DocumentRepository repository,
+		RepositoryServiceAdapter repositoryServiceAdapter) {
+
 		_repository = repository;
+		_repositoryServiceAdapter = repositoryServiceAdapter;
 	}
 
 	@Override
 	public String getProperty(Class<? extends Capability> owner, String key) {
 		try {
-			Repository repository = RepositoryLocalServiceUtil.getRepository(
+			Repository repository = _repositoryServiceAdapter.getRepository(
 				_repository.getRepositoryId());
 
 			UnicodeProperties typeSettingsProperties =
@@ -56,7 +60,7 @@ public class ConfigurationCapabilityImpl implements ConfigurationCapability {
 		Class<? extends Capability> owner, String key, String value) {
 
 		try {
-			Repository repository = RepositoryLocalServiceUtil.getRepository(
+			Repository repository = _repositoryServiceAdapter.getRepository(
 				_repository.getRepositoryId());
 
 			UnicodeProperties typeSettingsProperties =
@@ -67,7 +71,7 @@ public class ConfigurationCapabilityImpl implements ConfigurationCapability {
 
 			repository.setTypeSettingsProperties(typeSettingsProperties);
 
-			RepositoryLocalServiceUtil.updateRepository(repository);
+			_repositoryServiceAdapter.updateRepository(repository);
 		}
 		catch (PortalException pe) {
 			throw new SystemException(
@@ -84,5 +88,6 @@ public class ConfigurationCapabilityImpl implements ConfigurationCapability {
 	}
 
 	private final DocumentRepository _repository;
+	private final RepositoryServiceAdapter _repositoryServiceAdapter;
 
 }

--- a/portal-impl/src/com/liferay/portal/repository/capabilities/LiferayBulkOperationCapability.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/LiferayBulkOperationCapability.java
@@ -23,12 +23,12 @@ import com.liferay.portal.kernel.repository.capabilities.BulkOperationCapability
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.repository.model.RepositoryModelOperation;
+import com.liferay.portal.repository.capabilities.util.DLFileEntryServiceAdapter;
+import com.liferay.portal.repository.capabilities.util.DLFolderServiceAdapter;
 import com.liferay.portal.repository.liferayrepository.model.LiferayFileEntry;
 import com.liferay.portal.repository.liferayrepository.model.LiferayFolder;
 import com.liferay.portlet.documentlibrary.model.DLFileEntry;
 import com.liferay.portlet.documentlibrary.model.DLFolder;
-import com.liferay.portlet.documentlibrary.service.DLFileEntryLocalServiceUtil;
-import com.liferay.portlet.documentlibrary.service.DLFolderLocalServiceUtil;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -39,9 +39,13 @@ import java.util.Map;
 public class LiferayBulkOperationCapability implements BulkOperationCapability {
 
 	public LiferayBulkOperationCapability(
-		DocumentRepository documentRepository) {
+		DocumentRepository documentRepository,
+		DLFileEntryServiceAdapter dlFileEntryServiceAdapter,
+		DLFolderServiceAdapter dlFolderServiceAdapter) {
 
 		_documentRepository = documentRepository;
+		_dlFileEntryServiceAdapter = dlFileEntryServiceAdapter;
+		_dlFolderServiceAdapter = dlFolderServiceAdapter;
 	}
 
 	@Override
@@ -66,7 +70,7 @@ public class LiferayBulkOperationCapability implements BulkOperationCapability {
 		throws PortalException {
 
 		ActionableDynamicQuery actionableDynamicQuery =
-			DLFileEntryLocalServiceUtil.getActionableDynamicQuery();
+			_dlFileEntryServiceAdapter.getActionableDynamicQuery();
 
 		actionableDynamicQuery.setAddCriteriaMethod(
 			new RepositoryModelAddCriteriaMethod(filter));
@@ -81,7 +85,7 @@ public class LiferayBulkOperationCapability implements BulkOperationCapability {
 		throws PortalException {
 
 		ActionableDynamicQuery actionableDynamicQuery =
-			DLFolderLocalServiceUtil.getActionableDynamicQuery();
+			_dlFolderServiceAdapter.getActionableDynamicQuery();
 
 		actionableDynamicQuery.setAddCriteriaMethod(
 			new RepositoryModelAddCriteriaMethod(filter));
@@ -98,6 +102,8 @@ public class LiferayBulkOperationCapability implements BulkOperationCapability {
 		_fieldNames.put(Field.CreateDate.class, "createDate");
 	}
 
+	private final DLFileEntryServiceAdapter _dlFileEntryServiceAdapter;
+	private final DLFolderServiceAdapter _dlFolderServiceAdapter;
 	private final DocumentRepository _documentRepository;
 
 	private static class FileEntryPerformActionMethod

--- a/portal-impl/src/com/liferay/portal/repository/capabilities/LiferaySyncCapability.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/LiferaySyncCapability.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageBusUtil;
+import com.liferay.portal.kernel.repository.DocumentRepository;
 import com.liferay.portal.kernel.repository.LocalRepository;
 import com.liferay.portal.kernel.repository.Repository;
 import com.liferay.portal.kernel.repository.capabilities.BulkOperationCapability;
@@ -33,14 +34,15 @@ import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.repository.registry.RepositoryEventRegistry;
 import com.liferay.portal.kernel.transaction.TransactionCommitCallbackRegistryUtil;
 import com.liferay.portal.model.Group;
+import com.liferay.portal.repository.capabilities.util.GroupServiceAdapter;
 import com.liferay.portal.repository.liferayrepository.LiferaySyncLocalRepositoryWrapper;
 import com.liferay.portal.repository.liferayrepository.LiferaySyncRepositoryWrapper;
 import com.liferay.portal.repository.liferayrepository.model.LiferayFileEntry;
 import com.liferay.portal.repository.liferayrepository.model.LiferayFolder;
 import com.liferay.portal.repository.util.RepositoryWrapperAware;
-import com.liferay.portal.service.GroupLocalServiceUtil;
 import com.liferay.portlet.documentlibrary.model.DLSyncConstants;
 import com.liferay.portlet.documentlibrary.model.DLSyncEvent;
+import com.liferay.portlet.documentlibrary.service.DLSyncEventLocalService;
 import com.liferay.portlet.documentlibrary.service.DLSyncEventLocalServiceUtil;
 
 import java.util.HashMap;
@@ -54,14 +56,21 @@ public class LiferaySyncCapability
 	implements RepositoryEventAware, RepositoryWrapperAware, SyncCapability {
 
 	public LiferaySyncCapability(
-		BulkOperationCapability bulkOperationCapability) {
+		DocumentRepository documentRepository,
+		DLSyncEventLocalService dlSyncEventLocalService,
+		GroupServiceAdapter groupServiceAdapter) {
 
-		_bulkOperationCapability = bulkOperationCapability;
+		_documentRepository = documentRepository;
+		_dlSyncEventLocalService = dlSyncEventLocalService;
+		_groupServiceAdapter = groupServiceAdapter;
 	}
 
 	@Override
 	public void destroyDocumentRepository() throws PortalException {
-		_bulkOperationCapability.execute(new DeleteRepositoryModelOperation());
+		BulkOperationCapability bulkOperationCapability =
+			_documentRepository.getCapability(BulkOperationCapability.class);
+
+		bulkOperationCapability.execute(new DeleteRepositoryModelOperation());
 	}
 
 	@Override
@@ -121,43 +130,6 @@ public class LiferaySyncCapability
 		return new LiferaySyncRepositoryWrapper(repository, this);
 	}
 
-	protected static boolean isStagingGroup(long groupId) {
-		try {
-			Group group = GroupLocalServiceUtil.getGroup(groupId);
-
-			return group.isStagingGroup();
-		}
-		catch (Exception e) {
-			return false;
-		}
-	}
-
-	protected static void registerDLSyncEventCallback(
-		String event, FileEntry fileEntry) {
-
-		if (isStagingGroup(fileEntry.getGroupId()) ||
-			!(fileEntry instanceof LiferayFileEntry)) {
-
-			return;
-		}
-
-		registerDLSyncEventCallback(
-			event, DLSyncConstants.TYPE_FILE, fileEntry.getFileEntryId());
-	}
-
-	protected static void registerDLSyncEventCallback(
-		String event, Folder folder) {
-
-		if (isStagingGroup(folder.getGroupId()) ||
-			!(folder instanceof LiferayFolder)) {
-
-			return;
-		}
-
-		registerDLSyncEventCallback(
-			event, DLSyncConstants.TYPE_FOLDER, folder.getFolderId());
-	}
-
 	protected static void registerDLSyncEventCallback(
 		final String event, final String type, final long typePK) {
 
@@ -193,80 +165,133 @@ public class LiferaySyncCapability
 		);
 	}
 
-	private static final RepositoryEventListener
+	protected boolean isStagingGroup(long groupId) {
+		try {
+			Group group = _groupServiceAdapter.getGroup(groupId);
+
+			return group.isStagingGroup();
+		}
+		catch (Exception e) {
+			return false;
+		}
+	}
+
+	protected void registerDLSyncEventCallback(
+		String event, FileEntry fileEntry) {
+
+		if (isStagingGroup(fileEntry.getGroupId()) ||
+			!(fileEntry instanceof LiferayFileEntry)) {
+
+			return;
+		}
+
+		registerDLSyncEventCallback(
+			event, DLSyncConstants.TYPE_FILE, fileEntry.getFileEntryId());
+	}
+
+	protected void registerDLSyncEventCallback(String event, Folder folder) {
+		if (isStagingGroup(folder.getGroupId()) ||
+			!(folder instanceof LiferayFolder)) {
+
+			return;
+		}
+
+		registerDLSyncEventCallback(
+			event, DLSyncConstants.TYPE_FOLDER, folder.getFolderId());
+	}
+
+	private final RepositoryEventListener
 		<RepositoryEventType.Add, Folder> ADD_FOLDER_EVENT_LISTENER =
 			new SyncFolderRepositoryEventListener<>(DLSyncConstants.EVENT_ADD);
 
-	private static final RepositoryEventListener
+	private final RepositoryEventListener
 		<RepositoryEventType.Delete, FileEntry>
 			DELETE_FILE_ENTRY_EVENT_LISTENER =
 				new SyncFileEntryRepositoryEventListener<>(
 					DLSyncConstants.EVENT_DELETE);
 
-	private static final RepositoryEventListener
+	private final RepositoryEventListener
 		<RepositoryEventType.Delete, Folder> DELETE_FOLDER_EVENT_LISTENER =
 			new SyncFolderRepositoryEventListener<>(
 				DLSyncConstants.EVENT_DELETE);
 
-	private static final RepositoryEventListener
+	private final RepositoryEventListener
 		<RepositoryEventType.Move, FileEntry> MOVE_FILE_ENTRY_EVENT_LISTENER =
 			new SyncFileEntryRepositoryEventListener<>(
 				DLSyncConstants.EVENT_MOVE);
 
-	private static final RepositoryEventListener
+	private final RepositoryEventListener
 		<RepositoryEventType.Move, Folder> MOVE_FOLDER_EVENT_LISTENER =
 			new SyncFolderRepositoryEventListener<>(DLSyncConstants.EVENT_MOVE);
 
-	private static final RepositoryEventListener
+	private final RepositoryEventListener
 		<TrashRepositoryEventType.EntryRestored, FileEntry>
 			RESTORE_FILE_ENTRY_EVENT_LISTENER =
 				new SyncFileEntryRepositoryEventListener<>(
 					DLSyncConstants.EVENT_RESTORE);
 
-	private static final RepositoryEventListener
+	private final RepositoryEventListener
 		<TrashRepositoryEventType.EntryRestored, Folder>
 			RESTORE_FOLDER_EVENT_LISTENER =
 				new SyncFolderRepositoryEventListener<>(
 					DLSyncConstants.EVENT_RESTORE);
 
-	private static final RepositoryEventListener
+	private final RepositoryEventListener
 		<TrashRepositoryEventType.EntryTrashed, FileEntry>
 			TRASH_FILE_ENTRY_EVENT_LISTENER =
 				new SyncFileEntryRepositoryEventListener<>(
 					DLSyncConstants.EVENT_TRASH);
 
-	private static final RepositoryEventListener
+	private final RepositoryEventListener
 		<TrashRepositoryEventType.EntryTrashed, Folder>
 			TRASH_FOLDER_EVENT_LISTENER =
 				new SyncFolderRepositoryEventListener<>(
 					DLSyncConstants.EVENT_TRASH);
 
-	private static final RepositoryEventListener
+	private final RepositoryEventListener
 		<RepositoryEventType.Update, FileEntry>
 			UPDATE_FILE_ENTRY_EVENT_LISTENER =
 				new SyncFileEntryRepositoryEventListener<>(
 					DLSyncConstants.EVENT_UPDATE);
 
-	private static final RepositoryEventListener
+	private final RepositoryEventListener
 		<RepositoryEventType.Update, Folder> UPDATE_FOLDER_EVENT_LISTENER =
 			new SyncFolderRepositoryEventListener<>(
 				DLSyncConstants.EVENT_UPDATE);
 
-	private static final RepositoryEventListener
+	private final RepositoryEventListener
 		<WorkflowRepositoryEventType.Add, FileEntry>
 			WORKFLOW_ADD_FILE_ENTRY_EVENT_LISTENER =
 				new SyncFileEntryRepositoryEventListener<>(
 					DLSyncConstants.EVENT_ADD);
 
-	private static final RepositoryEventListener
+	private final RepositoryEventListener
 		<WorkflowRepositoryEventType.Update, FileEntry>
 			WORKFLOW_UPDATE_FILE_ENTRY_EVENT_LISTENER =
 				new SyncFileEntryRepositoryEventListener<>(
 					DLSyncConstants.EVENT_UPDATE);
 
-	private final BulkOperationCapability _bulkOperationCapability;
+	private final DLSyncEventLocalService _dlSyncEventLocalService;
+	private final DocumentRepository _documentRepository;
+	private final GroupServiceAdapter _groupServiceAdapter;
 
-	private static class SyncFileEntryRepositoryEventListener
+	private class DeleteRepositoryModelOperation
+		extends BaseRepositoryModelOperation {
+
+		@Override
+		public void execute(FileEntry fileEntry) {
+			registerDLSyncEventCallback(
+				DLSyncConstants.EVENT_DELETE, fileEntry);
+		}
+
+		@Override
+		public void execute(Folder folder) {
+			registerDLSyncEventCallback(DLSyncConstants.EVENT_DELETE, folder);
+		}
+
+	}
+
+	private class SyncFileEntryRepositoryEventListener
 			<S extends RepositoryEventType>
 		implements RepositoryEventListener<S, FileEntry> {
 
@@ -283,7 +308,7 @@ public class LiferaySyncCapability
 
 	}
 
-	private static class SyncFolderRepositoryEventListener
+	private class SyncFolderRepositoryEventListener
 			<S extends RepositoryEventType>
 		implements RepositoryEventListener<S, Folder> {
 
@@ -297,22 +322,6 @@ public class LiferaySyncCapability
 		}
 
 		private final String _syncEvent;
-
-	}
-
-	private class DeleteRepositoryModelOperation
-		extends BaseRepositoryModelOperation {
-
-		@Override
-		public void execute(FileEntry fileEntry) {
-			registerDLSyncEventCallback(
-				DLSyncConstants.EVENT_DELETE, fileEntry);
-		}
-
-		@Override
-		public void execute(Folder folder) {
-			registerDLSyncEventCallback(DLSyncConstants.EVENT_DELETE, folder);
-		}
 
 	}
 

--- a/portal-impl/src/com/liferay/portal/repository/capabilities/LiferaySyncCapability.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/LiferaySyncCapability.java
@@ -130,10 +130,10 @@ public class LiferaySyncCapability
 		return new LiferaySyncRepositoryWrapper(repository, this);
 	}
 
-	protected static void registerDLSyncEventCallback(
+	protected void registerDLSyncEventCallback(
 		final String event, final String type, final long typePK) {
 
-		DLSyncEvent dlSyncEvent = DLSyncEventLocalServiceUtil.addDLSyncEvent(
+		DLSyncEvent dlSyncEvent = _dlSyncEventLocalService.addDLSyncEvent(
 			event, type, typePK);
 
 		final long modifiedTime = dlSyncEvent.getModifiedTime();

--- a/portal-impl/src/com/liferay/portal/repository/capabilities/LiferaySyncCapability.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/LiferaySyncCapability.java
@@ -43,7 +43,6 @@ import com.liferay.portal.repository.util.RepositoryWrapperAware;
 import com.liferay.portlet.documentlibrary.model.DLSyncConstants;
 import com.liferay.portlet.documentlibrary.model.DLSyncEvent;
 import com.liferay.portlet.documentlibrary.service.DLSyncEventLocalService;
-import com.liferay.portlet.documentlibrary.service.DLSyncEventLocalServiceUtil;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -130,41 +129,6 @@ public class LiferaySyncCapability
 		return new LiferaySyncRepositoryWrapper(repository, this);
 	}
 
-	protected void registerDLSyncEventCallback(
-		final String event, final String type, final long typePK) {
-
-		DLSyncEvent dlSyncEvent = _dlSyncEventLocalService.addDLSyncEvent(
-			event, type, typePK);
-
-		final long modifiedTime = dlSyncEvent.getModifiedTime();
-
-		TransactionCommitCallbackRegistryUtil.registerCallback(
-			new Callable<Void>() {
-
-				@Override
-				public Void call() throws Exception {
-					Message message = new Message();
-
-					Map<String, Object> values = new HashMap<>(4);
-
-					values.put("event", event);
-					values.put("modifiedTime", modifiedTime);
-					values.put("type", type);
-					values.put("typePK", typePK);
-
-					message.setValues(values);
-
-					MessageBusUtil.sendMessage(
-						DestinationNames.DOCUMENT_LIBRARY_SYNC_EVENT_PROCESSOR,
-						message);
-
-					return null;
-				}
-
-			}
-		);
-	}
-
 	protected boolean isStagingGroup(long groupId) {
 		try {
 			Group group = _groupServiceAdapter.getGroup(groupId);
@@ -198,6 +162,41 @@ public class LiferaySyncCapability
 
 		registerDLSyncEventCallback(
 			event, DLSyncConstants.TYPE_FOLDER, folder.getFolderId());
+	}
+
+	protected void registerDLSyncEventCallback(
+		final String event, final String type, final long typePK) {
+
+		DLSyncEvent dlSyncEvent = _dlSyncEventLocalService.addDLSyncEvent(
+			event, type, typePK);
+
+		final long modifiedTime = dlSyncEvent.getModifiedTime();
+
+		TransactionCommitCallbackRegistryUtil.registerCallback(
+			new Callable<Void>() {
+
+				@Override
+				public Void call() throws Exception {
+					Message message = new Message();
+
+					Map<String, Object> values = new HashMap<>(4);
+
+					values.put("event", event);
+					values.put("modifiedTime", modifiedTime);
+					values.put("type", type);
+					values.put("typePK", typePK);
+
+					message.setValues(values);
+
+					MessageBusUtil.sendMessage(
+						DestinationNames.DOCUMENT_LIBRARY_SYNC_EVENT_PROCESSOR,
+						message);
+
+					return null;
+				}
+
+			}
+		);
 	}
 
 	private final RepositoryEventListener

--- a/portal-impl/src/com/liferay/portal/repository/capabilities/LiferayTrashCapability.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/LiferayTrashCapability.java
@@ -28,21 +28,22 @@ import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.repository.registry.RepositoryEventRegistry;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.model.Repository;
+import com.liferay.portal.repository.capabilities.util.DLAppServiceAdapter;
+import com.liferay.portal.repository.capabilities.util.DLFileEntryServiceAdapter;
+import com.liferay.portal.repository.capabilities.util.DLFolderServiceAdapter;
+import com.liferay.portal.repository.capabilities.util.RepositoryServiceAdapter;
+import com.liferay.portal.repository.capabilities.util.TrashEntryServiceAdapter;
 import com.liferay.portal.repository.liferayrepository.model.LiferayFileEntry;
-import com.liferay.portal.service.RepositoryLocalServiceUtil;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portlet.documentlibrary.model.DLFileEntry;
 import com.liferay.portlet.documentlibrary.model.DLFileEntryConstants;
 import com.liferay.portlet.documentlibrary.model.DLFileVersion;
 import com.liferay.portlet.documentlibrary.model.DLFolder;
 import com.liferay.portlet.documentlibrary.model.DLFolderConstants;
-import com.liferay.portlet.documentlibrary.service.DLAppHelperLocalServiceUtil;
-import com.liferay.portlet.documentlibrary.service.DLAppLocalServiceUtil;
-import com.liferay.portlet.documentlibrary.service.DLFileEntryLocalServiceUtil;
+import com.liferay.portlet.documentlibrary.service.DLAppHelperLocalService;
 import com.liferay.portlet.documentlibrary.service.DLFolderLocalServiceUtil;
 import com.liferay.portlet.trash.model.TrashEntry;
-import com.liferay.portlet.trash.service.TrashEntryLocalServiceUtil;
-import com.liferay.portlet.trash.service.TrashVersionLocalServiceUtil;
+import com.liferay.portlet.trash.service.TrashVersionLocalService;
 
 import java.util.List;
 
@@ -52,17 +53,35 @@ import java.util.List;
 public class LiferayTrashCapability
 	implements RepositoryEventAware, TrashCapability {
 
+	public LiferayTrashCapability(
+		DLAppServiceAdapter dlAppServiceAdapter,
+		DLAppHelperLocalService dlAppHelperLocalService,
+		DLFileEntryServiceAdapter dlFileEntryServiceAdapter,
+		DLFolderServiceAdapter dlFolderServiceAdapter,
+		RepositoryServiceAdapter repositoryServiceAdapter,
+		TrashEntryServiceAdapter trashEntryServiceAdapter,
+		TrashVersionLocalService trashVersionLocalService) {
+
+		_dlAppServiceAdapter = dlAppServiceAdapter;
+		_dlAppHelperLocalService = dlAppHelperLocalService;
+		_dlFileEntryServiceAdapter = dlFileEntryServiceAdapter;
+		_dlFolderServiceAdapter = dlFolderServiceAdapter;
+		_repositoryServiceAdapter = repositoryServiceAdapter;
+		_trashEntryServiceAdapter = trashEntryServiceAdapter;
+		_trashVersionLocalService = trashVersionLocalService;
+	}
+
 	@Override
 	public void deleteFileEntry(FileEntry fileEntry) throws PortalException {
 		deleteTrashEntry(fileEntry);
 
-		DLAppLocalServiceUtil.deleteFileEntry(fileEntry.getFileEntryId());
+		_dlAppServiceAdapter.deleteFileEntry(fileEntry.getFileEntryId());
 	}
 
 	@Override
 	public void deleteFolder(Folder folder) throws PortalException {
 		List<DLFileEntry> dlFileEntries =
-			DLFileEntryLocalServiceUtil.getGroupFileEntries(
+			_dlFileEntryServiceAdapter.getGroupFileEntries(
 				folder.getGroupId(), 0, folder.getRepositoryId(),
 				folder.getFolderId(), QueryUtil.ALL_POS, QueryUtil.ALL_POS,
 				null);
@@ -70,16 +89,16 @@ public class LiferayTrashCapability
 		for (DLFileEntry dlFileEntry : dlFileEntries) {
 			FileEntry fileEntry = new LiferayFileEntry(dlFileEntry);
 
-			DLAppHelperLocalServiceUtil.deleteFileEntry(fileEntry);
+			_dlAppHelperLocalService.deleteFileEntry(fileEntry);
 
 			deleteTrashEntry(fileEntry);
 		}
 
-		DLAppHelperLocalServiceUtil.deleteFolder(folder);
+		_dlAppHelperLocalService.deleteFolder(folder);
 
 		deleteTrashEntry(folder);
 
-		DLFolderLocalServiceUtil.deleteFolder(folder.getFolderId(), false);
+		_dlFolderServiceAdapter.deleteFolder(folder.getFolderId(), false);
 	}
 
 	@Override
@@ -101,7 +120,7 @@ public class LiferayTrashCapability
 			newFolderId = newFolder.getFolderId();
 		}
 
-		return DLAppHelperLocalServiceUtil.moveFileEntryFromTrash(
+		return _dlAppHelperLocalService.moveFileEntryFromTrash(
 			userId, fileEntry, newFolderId, serviceContext);
 	}
 
@@ -109,8 +128,7 @@ public class LiferayTrashCapability
 	public FileEntry moveFileEntryToTrash(long userId, FileEntry fileEntry)
 		throws PortalException {
 
-		return DLAppHelperLocalServiceUtil.moveFileEntryToTrash(
-			userId, fileEntry);
+		return _dlAppHelperLocalService.moveFileEntryToTrash(userId, fileEntry);
 	}
 
 	@Override
@@ -125,7 +143,7 @@ public class LiferayTrashCapability
 			newFolderId = newFolder.getFolderId();
 		}
 
-		return DLAppHelperLocalServiceUtil.moveFileShortcutFromTrash(
+		return _dlAppHelperLocalService.moveFileShortcutFromTrash(
 			userId, fileShortcut, newFolderId, serviceContext);
 	}
 
@@ -134,7 +152,7 @@ public class LiferayTrashCapability
 			long userId, FileShortcut fileShortcut)
 		throws PortalException {
 
-		return DLAppHelperLocalServiceUtil.moveFileShortcutToTrash(
+		return _dlAppHelperLocalService.moveFileShortcutToTrash(
 			userId, fileShortcut);
 	}
 
@@ -150,7 +168,7 @@ public class LiferayTrashCapability
 			destinationFolderId = destinationFolder.getFolderId();
 		}
 
-		return DLAppHelperLocalServiceUtil.moveFolderFromTrash(
+		return _dlAppHelperLocalService.moveFolderFromTrash(
 			userId, folder, destinationFolderId, serviceContext);
 	}
 
@@ -158,7 +176,7 @@ public class LiferayTrashCapability
 	public Folder moveFolderToTrash(long userId, Folder folder)
 		throws PortalException {
 
-		return DLAppHelperLocalServiceUtil.moveFolderToTrash(userId, folder);
+		return _dlAppHelperLocalService.moveFolderToTrash(userId, folder);
 	}
 
 	@Override
@@ -180,8 +198,7 @@ public class LiferayTrashCapability
 	public void restoreFileEntryFromTrash(long userId, FileEntry fileEntry)
 		throws PortalException {
 
-		DLAppHelperLocalServiceUtil.restoreFileEntryFromTrash(
-			userId, fileEntry);
+		_dlAppHelperLocalService.restoreFileEntryFromTrash(userId, fileEntry);
 	}
 
 	@Override
@@ -189,7 +206,7 @@ public class LiferayTrashCapability
 			long userId, FileShortcut fileShortcut)
 		throws PortalException {
 
-		DLAppHelperLocalServiceUtil.restoreFileShortcutFromTrash(
+		_dlAppHelperLocalService.restoreFileShortcutFromTrash(
 			userId, fileShortcut);
 	}
 
@@ -197,24 +214,25 @@ public class LiferayTrashCapability
 	public void restoreFolderFromTrash(long userId, Folder folder)
 		throws PortalException {
 
-		DLAppHelperLocalServiceUtil.restoreFolderFromTrash(userId, folder);
+		_dlAppHelperLocalService.restoreFolderFromTrash(userId, folder);
 	}
 
 	protected void deleteRepositoryTrashEntries(
-		long repositoryId, String className) {
+			long repositoryId, String className)
+		throws PortalException {
 
-		List<TrashEntry> trashEntries = TrashEntryLocalServiceUtil.getEntries(
+		List<TrashEntry> trashEntries = _trashEntryServiceAdapter.getEntries(
 			repositoryId, className);
 
 		for (TrashEntry trashEntry : trashEntries) {
-			TrashEntryLocalServiceUtil.deleteTrashEntry(trashEntry);
+			_trashEntryServiceAdapter.deleteTrashEntry(trashEntry);
 		}
 	}
 
 	protected void deleteTrashEntries(long repositoryId)
 		throws PortalException {
 
-		Repository repository = RepositoryLocalServiceUtil.fetchRepository(
+		Repository repository = _repositoryServiceAdapter.fetchRepository(
 			repositoryId);
 
 		if (repository == null) {
@@ -265,7 +283,7 @@ public class LiferayTrashCapability
 		}
 
 		if (dlFileEntry.isInTrashExplicitly()) {
-			TrashEntryLocalServiceUtil.deleteEntry(
+			_trashEntryServiceAdapter.deleteEntry(
 				DLFileEntryConstants.getClassName(),
 				dlFileEntry.getFileEntryId());
 		}
@@ -274,7 +292,7 @@ public class LiferayTrashCapability
 				WorkflowConstants.STATUS_ANY);
 
 			for (DLFileVersion dlFileVersion : dlFileVersions) {
-				TrashVersionLocalServiceUtil.deleteTrashVersion(
+				_trashVersionLocalService.deleteTrashVersion(
 					DLFileVersion.class.getName(),
 					dlFileVersion.getFileVersionId());
 			}
@@ -287,11 +305,11 @@ public class LiferayTrashCapability
 		}
 
 		if (dlFolder.isInTrashExplicitly()) {
-			TrashEntryLocalServiceUtil.deleteEntry(
+			_trashEntryServiceAdapter.deleteEntry(
 				DLFolderConstants.getClassName(), dlFolder.getFolderId());
 		}
 		else {
-			TrashVersionLocalServiceUtil.deleteTrashVersion(
+			_trashVersionLocalService.deleteTrashVersion(
 				DLFolderConstants.getClassName(), dlFolder.getFolderId());
 		}
 	}
@@ -305,6 +323,14 @@ public class LiferayTrashCapability
 	protected void deleteTrashEntry(Folder folder) throws PortalException {
 		deleteTrashEntry((DLFolder)folder.getModel());
 	}
+
+	private final DLAppHelperLocalService _dlAppHelperLocalService;
+	private final DLAppServiceAdapter _dlAppServiceAdapter;
+	private final DLFileEntryServiceAdapter _dlFileEntryServiceAdapter;
+	private final DLFolderServiceAdapter _dlFolderServiceAdapter;
+	private final RepositoryServiceAdapter _repositoryServiceAdapter;
+	private final TrashEntryServiceAdapter _trashEntryServiceAdapter;
+	private final TrashVersionLocalService _trashVersionLocalService;
 
 	private class DeleteFileEntryRepositoryEventListener
 		implements RepositoryEventListener

--- a/portal-impl/src/com/liferay/portal/repository/capabilities/LiferayTrashCapability.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/LiferayTrashCapability.java
@@ -255,7 +255,7 @@ public class LiferayTrashCapability
 		queryDefinition.setStatus(WorkflowConstants.STATUS_ANY);
 
 		List<Object> foldersAndFileEntriesAndFileShortcuts =
-			DLFolderLocalServiceUtil.getFoldersAndFileEntriesAndFileShortcuts(
+			_dlFolderServiceAdapter.getFoldersAndFileEntriesAndFileShortcuts(
 				groupId, dlFolderId, null, true, queryDefinition);
 
 		for (Object folderFileEntryOrFileShortcut :

--- a/portal-impl/src/com/liferay/portal/repository/capabilities/LiferayTrashCapability.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/LiferayTrashCapability.java
@@ -41,7 +41,6 @@ import com.liferay.portlet.documentlibrary.model.DLFileVersion;
 import com.liferay.portlet.documentlibrary.model.DLFolder;
 import com.liferay.portlet.documentlibrary.model.DLFolderConstants;
 import com.liferay.portlet.documentlibrary.service.DLAppHelperLocalService;
-import com.liferay.portlet.documentlibrary.service.DLFolderLocalServiceUtil;
 import com.liferay.portlet.trash.model.TrashEntry;
 import com.liferay.portlet.trash.service.TrashVersionLocalService;
 

--- a/portal-impl/src/com/liferay/portal/repository/capabilities/LiferayWorkflowCapability.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/LiferayWorkflowCapability.java
@@ -22,6 +22,8 @@ import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.workflow.WorkflowThreadLocal;
+import com.liferay.portal.repository.capabilities.util.DLFileEntryServiceAdapter;
+import com.liferay.portal.repository.capabilities.util.DLFileVersionServiceAdapter;
 import com.liferay.portal.repository.liferayrepository.LiferayWorkflowLocalRepositoryWrapper;
 import com.liferay.portal.repository.liferayrepository.LiferayWorkflowRepositoryWrapper;
 import com.liferay.portal.repository.util.RepositoryWrapperAware;
@@ -30,8 +32,6 @@ import com.liferay.portlet.documentlibrary.model.DLFileEntry;
 import com.liferay.portlet.documentlibrary.model.DLFileEntryConstants;
 import com.liferay.portlet.documentlibrary.model.DLFileVersion;
 import com.liferay.portlet.documentlibrary.model.DLSyncConstants;
-import com.liferay.portlet.documentlibrary.service.DLFileEntryLocalServiceUtil;
-import com.liferay.portlet.documentlibrary.service.DLFileVersionLocalServiceUtil;
 import com.liferay.portlet.documentlibrary.util.DLAppHelperThreadLocal;
 import com.liferay.portlet.documentlibrary.util.DLUtil;
 
@@ -40,6 +40,14 @@ import com.liferay.portlet.documentlibrary.util.DLUtil;
  */
 public class LiferayWorkflowCapability
 	implements RepositoryWrapperAware, WorkflowCapability, WorkflowSupport {
+
+	public LiferayWorkflowCapability(
+		DLFileEntryServiceAdapter dlFileEntryServiceAdapter,
+		DLFileVersionServiceAdapter dlFileVersionServiceAdapter) {
+
+		_dlFileEntryServiceAdapter = dlFileEntryServiceAdapter;
+		_dlFileVersionServiceAdapter = dlFileVersionServiceAdapter;
+	}
 
 	@Override
 	public void addFileEntry(
@@ -72,7 +80,7 @@ public class LiferayWorkflowCapability
 		throws PortalException {
 
 		boolean keepFileVersionLabel =
-			DLFileEntryLocalServiceUtil.isKeepFileVersionLabel(
+			_dlFileEntryServiceAdapter.isKeepFileVersionLabel(
 				fileEntry.getFileEntryId(), serviceContext);
 
 		if ((serviceContext.getWorkflowAction() ==
@@ -80,7 +88,7 @@ public class LiferayWorkflowCapability
 			!keepFileVersionLabel) {
 
 			DLFileVersion latestDLFileVersion =
-				DLFileVersionLocalServiceUtil.getLatestFileVersion(
+				_dlFileVersionServiceAdapter.getLatestFileVersion(
 					fileEntry.getFileEntryId(), false);
 
 			DLUtil.startWorkflowInstance(
@@ -128,7 +136,7 @@ public class LiferayWorkflowCapability
 			long fileEntryId, ServiceContext serviceContext)
 		throws PortalException {
 
-		DLFileEntry dlFileEntry = DLFileEntryLocalServiceUtil.getDLFileEntry(
+		DLFileEntry dlFileEntry = _dlFileEntryServiceAdapter.getDLFileEntry(
 			fileEntryId);
 
 		if (dlFileEntry.isCheckedOut()) {
@@ -136,7 +144,7 @@ public class LiferayWorkflowCapability
 		}
 
 		DLFileVersion dlFileVersion =
-			DLFileVersionLocalServiceUtil.getLatestFileVersion(
+			_dlFileVersionServiceAdapter.getLatestFileVersion(
 				fileEntryId, true);
 
 		if (dlFileVersion.isApproved() ||
@@ -179,5 +187,8 @@ public class LiferayWorkflowCapability
 
 		_startWorkflowInstance(userId, dlFileVersion, serviceContext);
 	}
+
+	private final DLFileEntryServiceAdapter _dlFileEntryServiceAdapter;
+	private final DLFileVersionServiceAdapter _dlFileVersionServiceAdapter;
 
 }

--- a/portal-impl/src/com/liferay/portal/repository/capabilities/MinimalWorkflowCapability.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/MinimalWorkflowCapability.java
@@ -21,12 +21,12 @@ import com.liferay.portal.kernel.repository.capabilities.WorkflowCapability;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.repository.capabilities.util.DLFileEntryServiceAdapter;
 import com.liferay.portal.repository.liferayrepository.LiferayWorkflowLocalRepositoryWrapper;
 import com.liferay.portal.repository.liferayrepository.LiferayWorkflowRepositoryWrapper;
 import com.liferay.portal.repository.util.RepositoryWrapperAware;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portlet.documentlibrary.model.DLFileEntry;
-import com.liferay.portlet.documentlibrary.service.DLFileEntryLocalServiceUtil;
 
 import java.io.Serializable;
 
@@ -38,6 +38,12 @@ import java.util.Map;
  */
 public class MinimalWorkflowCapability
 	implements RepositoryWrapperAware, WorkflowCapability, WorkflowSupport {
+
+	public MinimalWorkflowCapability(
+		DLFileEntryServiceAdapter dlFileEntryServiceAdapter) {
+
+		_dlFileEntryServiceAdapter = dlFileEntryServiceAdapter;
+	}
 
 	@Override
 	public void addFileEntry(
@@ -98,9 +104,11 @@ public class MinimalWorkflowCapability
 
 		FileVersion fileVersion = fileEntry.getFileVersion();
 
-		DLFileEntryLocalServiceUtil.updateStatus(
+		_dlFileEntryServiceAdapter.updateStatus(
 			userId, fileVersion.getFileVersionId(),
 			WorkflowConstants.STATUS_APPROVED, serviceContext, workflowContext);
 	}
+
+	private final DLFileEntryServiceAdapter _dlFileEntryServiceAdapter;
 
 }

--- a/portal-impl/src/com/liferay/portal/repository/capabilities/util/DLAppServiceAdapter.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/util/DLAppServiceAdapter.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.repository.capabilities.util;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portlet.documentlibrary.service.DLAppLocalService;
+import com.liferay.portlet.documentlibrary.service.DLAppService;
+
+/**
+ * @author Iván Zaera
+ */
+public class DLAppServiceAdapter {
+
+	public DLAppServiceAdapter(DLAppLocalService dlAppLocalService) {
+		this(dlAppLocalService, null);
+	}
+
+	public DLAppServiceAdapter(
+		DLAppLocalService dlAppLocalService, DLAppService dlAppService) {
+
+		_dlAppLocalService = dlAppLocalService;
+		_dlAppService = dlAppService;
+	}
+
+	public void deleteFileEntry(long fileEntryId) throws PortalException {
+		if (_dlAppService != null) {
+			_dlAppService.deleteFileEntry(fileEntryId);
+		}
+		else {
+			_dlAppLocalService.deleteFileEntry(fileEntryId);
+		}
+	}
+
+	private final DLAppLocalService _dlAppLocalService;
+	private final DLAppService _dlAppService;
+
+}

--- a/portal-impl/src/com/liferay/portal/repository/capabilities/util/DLFileEntryServiceAdapter.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/util/DLFileEntryServiceAdapter.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.repository.capabilities.util;
+
+import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.security.auth.PrincipalException;
+import com.liferay.portal.service.ServiceContext;
+import com.liferay.portlet.documentlibrary.model.DLFileEntry;
+import com.liferay.portlet.documentlibrary.service.DLFileEntryLocalService;
+import com.liferay.portlet.documentlibrary.service.DLFileEntryService;
+
+import java.io.Serializable;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Iván Zaera
+ */
+public class DLFileEntryServiceAdapter {
+
+	public DLFileEntryServiceAdapter(
+		DLFileEntryLocalService dlFileEntryLocalService) {
+
+		this(dlFileEntryLocalService, null);
+	}
+
+	public DLFileEntryServiceAdapter(
+		DLFileEntryLocalService dlFileEntryLocalService,
+		DLFileEntryService dlFileEntryService) {
+
+		_dlFileEntryLocalService = dlFileEntryLocalService;
+		_dlFileEntryService = dlFileEntryService;
+	}
+
+	public DLFileEntry fetchDLFileEntryByImageId(long imageId)
+		throws PortalException {
+
+		DLFileEntry dlFileEntry = null;
+
+		if (_dlFileEntryService != null) {
+			dlFileEntry = _dlFileEntryService.fetchFileEntryByImageId(imageId);
+		}
+		else {
+			dlFileEntry = _dlFileEntryLocalService.fetchFileEntryByAnyImageId(
+				imageId);
+		}
+
+		return dlFileEntry;
+	}
+
+	public ActionableDynamicQuery getActionableDynamicQuery()
+		throws PortalException {
+
+		if (_dlFileEntryService != null) {
+			throw new PrincipalException(
+				"Actionable dynamic query cannot be used with the Repository " +
+					"interface");
+		}
+
+		return _dlFileEntryLocalService.getActionableDynamicQuery();
+	}
+
+	public DLFileEntry getDLFileEntry(long fileEntryId) throws PortalException {
+		DLFileEntry dlFileEntry = null;
+
+		if (_dlFileEntryService != null) {
+			dlFileEntry = _dlFileEntryService.getFileEntry(fileEntryId);
+		}
+		else {
+			dlFileEntry = _dlFileEntryLocalService.getFileEntry(fileEntryId);
+		}
+
+		return dlFileEntry;
+	}
+
+	public List<DLFileEntry> getGroupFileEntries(
+			long groupId, int userId, long repositoryId, long folderId,
+			int start, int end, OrderByComparator<DLFileEntry> obc)
+		throws PortalException {
+
+		List<DLFileEntry> dlFileEntries = null;
+
+		if (_dlFileEntryService != null) {
+			dlFileEntries = _dlFileEntryService.getGroupFileEntries(
+				groupId, userId, repositoryId, folderId, null,
+				WorkflowConstants.STATUS_ANY, start, end, obc);
+		}
+		else {
+			dlFileEntries = _dlFileEntryLocalService.getGroupFileEntries(
+				groupId, userId, repositoryId, folderId, start, end, obc);
+		}
+
+		return dlFileEntries;
+	}
+
+	public DLFileEntry updateStatus(
+			long userId, long fileVersionId, int status,
+			ServiceContext serviceContext,
+			Map<String, Serializable> workflowContext)
+		throws PortalException {
+
+		DLFileEntry dlFileEntry = null;
+
+		if (_dlFileEntryService != null) {
+			dlFileEntry = _dlFileEntryService.updateStatus(
+				userId, fileVersionId, status, serviceContext, workflowContext);
+		}
+		else {
+			dlFileEntry = _dlFileEntryLocalService.updateStatus(
+				userId, fileVersionId, status, serviceContext, workflowContext);
+		}
+
+		return dlFileEntry;
+	}
+
+	private final DLFileEntryLocalService _dlFileEntryLocalService;
+	private final DLFileEntryService _dlFileEntryService;
+
+}

--- a/portal-impl/src/com/liferay/portal/repository/capabilities/util/DLFileEntryServiceAdapter.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/util/DLFileEntryServiceAdapter.java
@@ -109,6 +109,20 @@ public class DLFileEntryServiceAdapter {
 		return dlFileEntries;
 	}
 
+	public boolean isKeepFileVersionLabel(
+			long fileEntryId, ServiceContext serviceContext)
+		throws PortalException {
+
+		if (_dlFileEntryService != null) {
+			return _dlFileEntryService.isKeepFileVersionLabel(
+				fileEntryId, serviceContext);
+		}
+		else {
+			return _dlFileEntryLocalService.isKeepFileVersionLabel(
+				fileEntryId, serviceContext);
+		}
+	}
+
 	public DLFileEntry updateStatus(
 			long userId, long fileVersionId, int status,
 			ServiceContext serviceContext,

--- a/portal-impl/src/com/liferay/portal/repository/capabilities/util/DLFileVersionServiceAdapter.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/util/DLFileVersionServiceAdapter.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.repository.capabilities.util;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portlet.documentlibrary.model.DLFileVersion;
+import com.liferay.portlet.documentlibrary.service.DLFileVersionLocalService;
+import com.liferay.portlet.documentlibrary.service.DLFileVersionService;
+
+/**
+ * @author Iván Zaera
+ */
+public class DLFileVersionServiceAdapter {
+
+	public DLFileVersionServiceAdapter(
+		DLFileVersionLocalService dlFileVersionLocalService) {
+
+		this(dlFileVersionLocalService, null);
+	}
+
+	public DLFileVersionServiceAdapter(
+		DLFileVersionLocalService dlFileVersionLocalService,
+		DLFileVersionService dlFileVersionService) {
+
+		_dlFileVersionLocalService = dlFileVersionLocalService;
+		_dlFileVersionService = dlFileVersionService;
+	}
+
+	public DLFileVersion getLatestFileVersion(
+			long fileEntryId, boolean excludeWorkingCopy)
+		throws PortalException {
+
+		DLFileVersion dlFileVersion = null;
+
+		if (_dlFileVersionService != null) {
+			dlFileVersion = _dlFileVersionService.getLatestFileVersion(
+				fileEntryId, excludeWorkingCopy);
+		}
+		else {
+			dlFileVersion = _dlFileVersionLocalService.getLatestFileVersion(
+				fileEntryId, excludeWorkingCopy);
+		}
+
+		return dlFileVersion;
+	}
+
+	private final DLFileVersionLocalService _dlFileVersionLocalService;
+	private final DLFileVersionService _dlFileVersionService;
+
+}

--- a/portal-impl/src/com/liferay/portal/repository/capabilities/util/DLFolderServiceAdapter.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/util/DLFolderServiceAdapter.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.repository.capabilities.util;
+
+import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.QueryDefinition;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.security.auth.PrincipalException;
+import com.liferay.portlet.documentlibrary.service.DLFolderLocalService;
+import com.liferay.portlet.documentlibrary.service.DLFolderService;
+
+import java.util.List;
+
+/**
+ * @author Iván Zaera
+ */
+public class DLFolderServiceAdapter {
+
+	public DLFolderServiceAdapter(DLFolderLocalService dlFolderLocalService) {
+		this(dlFolderLocalService, null);
+	}
+
+	public DLFolderServiceAdapter(
+		DLFolderLocalService dlFolderLocalService,
+		DLFolderService dlFolderService) {
+
+		_dlFolderLocalService = dlFolderLocalService;
+		_dlFolderService = dlFolderService;
+	}
+
+	public void deleteFolder(long folderId, boolean includeTrashedEntries)
+		throws PortalException {
+
+		if (_dlFolderService != null) {
+			_dlFolderService.deleteFolder(folderId, includeTrashedEntries);
+		}
+		else {
+			_dlFolderLocalService.deleteFolder(folderId, includeTrashedEntries);
+		}
+	}
+
+	public ActionableDynamicQuery getActionableDynamicQuery()
+		throws PortalException {
+
+		if (_dlFolderService != null) {
+			throw new PrincipalException(
+				"Actionable dynamic query cannot be used with the Repository " +
+					"interface");
+		}
+
+		return _dlFolderLocalService.getActionableDynamicQuery();
+	}
+
+	public List<Object> getFoldersAndFileEntriesAndFileShortcuts(
+			long groupId, long folderId, String[] mimeTypes,
+			boolean includeMountFolders, QueryDefinition<?> queryDefinition)
+		throws PortalException {
+
+		List<Object> objects = null;
+
+		if (_dlFolderService != null) {
+			objects = _dlFolderService.getFoldersAndFileEntriesAndFileShortcuts(
+				groupId, folderId, mimeTypes, includeMountFolders,
+				queryDefinition);
+		}
+		else {
+			objects =
+				_dlFolderLocalService.getFoldersAndFileEntriesAndFileShortcuts(
+					groupId, folderId, mimeTypes, includeMountFolders,
+					queryDefinition);
+		}
+
+		return objects;
+	}
+
+	private final DLFolderLocalService _dlFolderLocalService;
+	private final DLFolderService _dlFolderService;
+
+}

--- a/portal-impl/src/com/liferay/portal/repository/capabilities/util/GroupServiceAdapter.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/util/GroupServiceAdapter.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.repository.capabilities.util;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.model.Group;
+import com.liferay.portal.service.GroupLocalService;
+import com.liferay.portal.service.GroupService;
+
+/**
+ * @author Iván Zaera
+ */
+public class GroupServiceAdapter {
+
+	public GroupServiceAdapter(GroupLocalService repositoryLocalService) {
+		this(repositoryLocalService, null);
+	}
+
+	public GroupServiceAdapter(
+		GroupLocalService repositoryLocalService,
+		GroupService repositoryService) {
+
+		_groupLocalService = repositoryLocalService;
+		_groupService = repositoryService;
+	}
+
+	public Group getGroup(long groupId) throws PortalException {
+		Group group = null;
+
+		if (_groupService != null) {
+			group = _groupService.getGroup(groupId);
+		}
+		else {
+			group = _groupLocalService.getGroup(groupId);
+		}
+
+		return group;
+	}
+
+	private final GroupLocalService _groupLocalService;
+	private final GroupService _groupService;
+
+}

--- a/portal-impl/src/com/liferay/portal/repository/capabilities/util/RepositoryServiceAdapter.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/util/RepositoryServiceAdapter.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.repository.capabilities.util;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.model.Repository;
+import com.liferay.portal.security.auth.PrincipalException;
+import com.liferay.portal.service.RepositoryLocalService;
+import com.liferay.portal.service.RepositoryService;
+
+/**
+ * @author Iván Zaera
+ */
+public class RepositoryServiceAdapter {
+
+	public RepositoryServiceAdapter(
+		RepositoryLocalService repositoryLocalService) {
+
+		this(repositoryLocalService, null);
+	}
+
+	public RepositoryServiceAdapter(
+		RepositoryLocalService repositoryLocalService,
+		RepositoryService repositoryService) {
+
+		_repositoryLocalService = repositoryLocalService;
+		_repositoryService = repositoryService;
+	}
+
+	public Repository fetchRepository(long repositoryId)
+		throws PortalException {
+
+		Repository repository = null;
+
+		if (_repositoryService != null) {
+			repository = _repositoryLocalService.fetchRepository(repositoryId);
+
+			if (repository != null) {
+				repository = _repositoryService.getRepository(repositoryId);
+			}
+		}
+		else {
+			repository = _repositoryLocalService.fetchRepository(repositoryId);
+		}
+
+		return repository;
+	}
+
+	public Repository getRepository(long repositoryId) throws PortalException {
+		Repository repository = null;
+
+		if (_repositoryService != null) {
+			repository = _repositoryService.getRepository(repositoryId);
+		}
+		else {
+			repository = _repositoryLocalService.getRepository(repositoryId);
+		}
+
+		return repository;
+	}
+
+	public Repository updateRepository(Repository repository)
+		throws PrincipalException {
+
+		if (_repositoryService != null) {
+			throw new PrincipalException(
+				"Update is forbidden when using the Repository interface");
+		}
+
+		return _repositoryLocalService.updateRepository(repository);
+	}
+
+	private final RepositoryLocalService _repositoryLocalService;
+	private final RepositoryService _repositoryService;
+
+}

--- a/portal-impl/src/com/liferay/portal/repository/capabilities/util/TrashEntryServiceAdapter.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/util/TrashEntryServiceAdapter.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.repository.capabilities.util;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portlet.trash.model.TrashEntry;
+import com.liferay.portlet.trash.service.TrashEntryLocalService;
+import com.liferay.portlet.trash.service.TrashEntryService;
+
+import java.util.List;
+
+/**
+ * @author Iván Zaera
+ */
+public class TrashEntryServiceAdapter {
+
+	public TrashEntryServiceAdapter(
+		TrashEntryLocalService trashEntryLocalService) {
+
+		this(trashEntryLocalService, null);
+	}
+
+	public TrashEntryServiceAdapter(
+		TrashEntryLocalService trashEntryLocalService,
+		TrashEntryService trashEntryService) {
+
+		_trashEntryLocalService = trashEntryLocalService;
+		_trashEntryService = trashEntryService;
+	}
+
+	public void deleteEntry(String className, long classPK)
+		throws PortalException {
+
+		if (_trashEntryService != null) {
+			_trashEntryService.deleteEntry(className, classPK);
+		}
+		else {
+			_trashEntryLocalService.deleteEntry(className, classPK);
+		}
+	}
+
+	public void deleteTrashEntry(TrashEntry trashEntry) throws PortalException {
+		if (_trashEntryService != null) {
+			_trashEntryService.deleteEntry(trashEntry.getEntryId());
+		}
+		else {
+			_trashEntryLocalService.deleteTrashEntry(trashEntry);
+		}
+	}
+
+	public List<TrashEntry> getEntries(long repositoryId, String className)
+		throws PortalException {
+
+		List<TrashEntry> trashEntries = null;
+
+		if (_trashEntryService != null) {
+			trashEntries = _trashEntryService.getEntries(
+				repositoryId, className);
+		}
+		else {
+			trashEntries = _trashEntryLocalService.getEntries(
+				repositoryId, className);
+		}
+
+		return trashEntries;
+	}
+
+	private final TrashEntryLocalService _trashEntryLocalService;
+	private final TrashEntryService _trashEntryService;
+
+}

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepositoryDefiner.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepositoryDefiner.java
@@ -41,9 +41,15 @@ import com.liferay.portal.repository.capabilities.LiferaySyncCapability;
 import com.liferay.portal.repository.capabilities.LiferayThumbnailCapability;
 import com.liferay.portal.repository.capabilities.LiferayTrashCapability;
 import com.liferay.portal.repository.capabilities.LiferayWorkflowCapability;
+import com.liferay.portal.repository.capabilities.util.DLFileEntryServiceAdapter;
+import com.liferay.portal.repository.capabilities.util.DLFolderServiceAdapter;
 import com.liferay.portal.repository.capabilities.util.RepositoryEntryChecker;
 import com.liferay.portal.repository.capabilities.util.RepositoryEntryConverter;
 import com.liferay.portal.util.PropsValues;
+import com.liferay.portlet.documentlibrary.service.DLFileEntryLocalServiceUtil;
+import com.liferay.portlet.documentlibrary.service.DLFileEntryServiceUtil;
+import com.liferay.portlet.documentlibrary.service.DLFolderLocalServiceUtil;
+import com.liferay.portlet.documentlibrary.service.DLFolderServiceUtil;
 
 /**
  * @author Adolfo Pérez
@@ -71,8 +77,30 @@ public class LiferayRepositoryDefiner extends BaseRepositoryDefiner {
 
 		DocumentRepository documentRepository = capabilityRegistry.getTarget();
 
+		DLFileEntryServiceAdapter dlFileEntryServiceAdapter = null;
+		DLFolderServiceAdapter dlFolderServiceAdapter = null;
+
+		if (documentRepository instanceof LocalRepository) {
+			dlFileEntryServiceAdapter = new DLFileEntryServiceAdapter(
+				DLFileEntryLocalServiceUtil.getService());
+
+			dlFolderServiceAdapter = new DLFolderServiceAdapter(
+				DLFolderLocalServiceUtil.getService());
+		}
+		else {
+			dlFileEntryServiceAdapter = new DLFileEntryServiceAdapter(
+				DLFileEntryLocalServiceUtil.getService(),
+				DLFileEntryServiceUtil.getService());
+
+			dlFolderServiceAdapter = new DLFolderServiceAdapter(
+				DLFolderLocalServiceUtil.getService(),
+				DLFolderServiceUtil.getService());
+		}
+
 		BulkOperationCapability bulkOperationCapability =
-			new LiferayBulkOperationCapability(documentRepository);
+			new LiferayBulkOperationCapability(
+				documentRepository, dlFileEntryServiceAdapter,
+				dlFolderServiceAdapter);
 
 		capabilityRegistry.addExportedCapability(
 			BulkOperationCapability.class, bulkOperationCapability);

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepositoryDefiner.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepositoryDefiner.java
@@ -43,6 +43,7 @@ import com.liferay.portal.repository.capabilities.LiferayTrashCapability;
 import com.liferay.portal.repository.capabilities.LiferayWorkflowCapability;
 import com.liferay.portal.repository.capabilities.util.DLAppServiceAdapter;
 import com.liferay.portal.repository.capabilities.util.DLFileEntryServiceAdapter;
+import com.liferay.portal.repository.capabilities.util.DLFileVersionServiceAdapter;
 import com.liferay.portal.repository.capabilities.util.DLFolderServiceAdapter;
 import com.liferay.portal.repository.capabilities.util.GroupServiceAdapter;
 import com.liferay.portal.repository.capabilities.util.RepositoryEntryChecker;
@@ -59,6 +60,8 @@ import com.liferay.portlet.documentlibrary.service.DLAppLocalServiceUtil;
 import com.liferay.portlet.documentlibrary.service.DLAppServiceUtil;
 import com.liferay.portlet.documentlibrary.service.DLFileEntryLocalServiceUtil;
 import com.liferay.portlet.documentlibrary.service.DLFileEntryServiceUtil;
+import com.liferay.portlet.documentlibrary.service.DLFileVersionLocalServiceUtil;
+import com.liferay.portlet.documentlibrary.service.DLFileVersionServiceUtil;
 import com.liferay.portlet.documentlibrary.service.DLFolderLocalServiceUtil;
 import com.liferay.portlet.documentlibrary.service.DLFolderServiceUtil;
 import com.liferay.portlet.documentlibrary.service.DLSyncEventLocalServiceUtil;
@@ -91,6 +94,7 @@ public class LiferayRepositoryDefiner extends BaseRepositoryDefiner {
 
 		DLAppServiceAdapter dlAppServiceAdapter = null;
 		DLFileEntryServiceAdapter dlFileEntryServiceAdapter = null;
+		DLFileVersionServiceAdapter dlFileVersionServiceAdapter = null;
 		DLFolderServiceAdapter dlFolderServiceAdapter = null;
 		GroupServiceAdapter groupServiceAdapter = null;
 		RepositoryServiceAdapter repositoryServiceAdapter = null;
@@ -102,6 +106,9 @@ public class LiferayRepositoryDefiner extends BaseRepositoryDefiner {
 
 			dlFileEntryServiceAdapter = new DLFileEntryServiceAdapter(
 				DLFileEntryLocalServiceUtil.getService());
+
+			dlFileVersionServiceAdapter = new DLFileVersionServiceAdapter(
+				DLFileVersionLocalServiceUtil.getService());
 
 			dlFolderServiceAdapter = new DLFolderServiceAdapter(
 				DLFolderLocalServiceUtil.getService());
@@ -123,6 +130,10 @@ public class LiferayRepositoryDefiner extends BaseRepositoryDefiner {
 			dlFileEntryServiceAdapter = new DLFileEntryServiceAdapter(
 				DLFileEntryLocalServiceUtil.getService(),
 				DLFileEntryServiceUtil.getService());
+
+			dlFileVersionServiceAdapter = new DLFileVersionServiceAdapter(
+				DLFileVersionLocalServiceUtil.getService(),
+				DLFileVersionServiceUtil.getService());
 
 			dlFolderServiceAdapter = new DLFolderServiceAdapter(
 				DLFolderLocalServiceUtil.getService(),
@@ -171,9 +182,10 @@ public class LiferayRepositoryDefiner extends BaseRepositoryDefiner {
 			ThumbnailCapability.class,
 			new LiferayThumbnailCapability(
 				repositoryEntryConverter, repositoryEntryChecker));
-
 		capabilityRegistry.addExportedCapability(
-			WorkflowCapability.class, _workflowCapability);
+			WorkflowCapability.class,
+			new LiferayWorkflowCapability(
+				dlFileEntryServiceAdapter, dlFileVersionServiceAdapter));
 
 		if (PropsValues.DL_FILE_ENTRY_COMMENTS_ENABLED) {
 			capabilityRegistry.addSupportedCapability(
@@ -206,8 +218,6 @@ public class LiferayRepositoryDefiner extends BaseRepositoryDefiner {
 	private final ProcessorCapability _processorCapability =
 		new LiferayProcessorCapability();
 	private RepositoryFactory _repositoryFactory;
-	private final WorkflowCapability _workflowCapability =
-		new LiferayWorkflowCapability();
 
 	private class LiferayRepositoryFactoryWrapper implements RepositoryFactory {
 

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepositoryDefiner.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepositoryDefiner.java
@@ -41,19 +41,30 @@ import com.liferay.portal.repository.capabilities.LiferaySyncCapability;
 import com.liferay.portal.repository.capabilities.LiferayThumbnailCapability;
 import com.liferay.portal.repository.capabilities.LiferayTrashCapability;
 import com.liferay.portal.repository.capabilities.LiferayWorkflowCapability;
+import com.liferay.portal.repository.capabilities.util.DLAppServiceAdapter;
 import com.liferay.portal.repository.capabilities.util.DLFileEntryServiceAdapter;
 import com.liferay.portal.repository.capabilities.util.DLFolderServiceAdapter;
 import com.liferay.portal.repository.capabilities.util.GroupServiceAdapter;
 import com.liferay.portal.repository.capabilities.util.RepositoryEntryChecker;
 import com.liferay.portal.repository.capabilities.util.RepositoryEntryConverter;
+import com.liferay.portal.repository.capabilities.util.RepositoryServiceAdapter;
+import com.liferay.portal.repository.capabilities.util.TrashEntryServiceAdapter;
 import com.liferay.portal.service.GroupLocalServiceUtil;
 import com.liferay.portal.service.GroupServiceUtil;
+import com.liferay.portal.service.RepositoryLocalServiceUtil;
+import com.liferay.portal.service.RepositoryServiceUtil;
 import com.liferay.portal.util.PropsValues;
+import com.liferay.portlet.documentlibrary.service.DLAppHelperLocalServiceUtil;
+import com.liferay.portlet.documentlibrary.service.DLAppLocalServiceUtil;
+import com.liferay.portlet.documentlibrary.service.DLAppServiceUtil;
 import com.liferay.portlet.documentlibrary.service.DLFileEntryLocalServiceUtil;
 import com.liferay.portlet.documentlibrary.service.DLFileEntryServiceUtil;
 import com.liferay.portlet.documentlibrary.service.DLFolderLocalServiceUtil;
 import com.liferay.portlet.documentlibrary.service.DLFolderServiceUtil;
 import com.liferay.portlet.documentlibrary.service.DLSyncEventLocalServiceUtil;
+import com.liferay.portlet.trash.service.TrashEntryLocalServiceUtil;
+import com.liferay.portlet.trash.service.TrashEntryServiceUtil;
+import com.liferay.portlet.trash.service.TrashVersionLocalServiceUtil;
 
 /**
  * @author Adolfo Pérez
@@ -76,16 +87,19 @@ public class LiferayRepositoryDefiner extends BaseRepositoryDefiner {
 	public void registerCapabilities(
 		CapabilityRegistry<DocumentRepository> capabilityRegistry) {
 
-		capabilityRegistry.addExportedCapability(
-			TrashCapability.class, _trashCapability);
-
 		DocumentRepository documentRepository = capabilityRegistry.getTarget();
 
+		DLAppServiceAdapter dlAppServiceAdapter = null;
 		DLFileEntryServiceAdapter dlFileEntryServiceAdapter = null;
 		DLFolderServiceAdapter dlFolderServiceAdapter = null;
 		GroupServiceAdapter groupServiceAdapter = null;
+		RepositoryServiceAdapter repositoryServiceAdapter = null;
+		TrashEntryServiceAdapter trashEntryServiceAdapter = null;
 
 		if (documentRepository instanceof LocalRepository) {
+			dlAppServiceAdapter = new DLAppServiceAdapter(
+				DLAppLocalServiceUtil.getService());
+
 			dlFileEntryServiceAdapter = new DLFileEntryServiceAdapter(
 				DLFileEntryLocalServiceUtil.getService());
 
@@ -94,8 +108,18 @@ public class LiferayRepositoryDefiner extends BaseRepositoryDefiner {
 
 			groupServiceAdapter = new GroupServiceAdapter(
 				GroupLocalServiceUtil.getService());
+
+			repositoryServiceAdapter = new RepositoryServiceAdapter(
+				RepositoryLocalServiceUtil.getService());
+
+			trashEntryServiceAdapter = new TrashEntryServiceAdapter(
+				TrashEntryLocalServiceUtil.getService());
 		}
 		else {
+			dlAppServiceAdapter = new DLAppServiceAdapter(
+				DLAppLocalServiceUtil.getService(),
+				DLAppServiceUtil.getService());
+
 			dlFileEntryServiceAdapter = new DLFileEntryServiceAdapter(
 				DLFileEntryLocalServiceUtil.getService(),
 				DLFileEntryServiceUtil.getService());
@@ -107,7 +131,24 @@ public class LiferayRepositoryDefiner extends BaseRepositoryDefiner {
 			groupServiceAdapter = new GroupServiceAdapter(
 				GroupLocalServiceUtil.getService(),
 				GroupServiceUtil.getService());
+
+			repositoryServiceAdapter = new RepositoryServiceAdapter(
+				RepositoryLocalServiceUtil.getService(),
+				RepositoryServiceUtil.getService());
+
+			trashEntryServiceAdapter = new TrashEntryServiceAdapter(
+				TrashEntryLocalServiceUtil.getService(),
+				TrashEntryServiceUtil.getService());
 		}
+
+		TrashCapability trashCapability = new LiferayTrashCapability(
+			dlAppServiceAdapter, DLAppHelperLocalServiceUtil.getService(),
+			dlFileEntryServiceAdapter, dlFolderServiceAdapter,
+			repositoryServiceAdapter, trashEntryServiceAdapter,
+			TrashVersionLocalServiceUtil.getService());
+
+		capabilityRegistry.addExportedCapability(
+			TrashCapability.class, trashCapability);
 
 		BulkOperationCapability bulkOperationCapability =
 			new LiferayBulkOperationCapability(
@@ -165,8 +206,6 @@ public class LiferayRepositoryDefiner extends BaseRepositoryDefiner {
 	private final ProcessorCapability _processorCapability =
 		new LiferayProcessorCapability();
 	private RepositoryFactory _repositoryFactory;
-	private final TrashCapability _trashCapability =
-		new LiferayTrashCapability();
 	private final WorkflowCapability _workflowCapability =
 		new LiferayWorkflowCapability();
 

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepositoryDefiner.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepositoryDefiner.java
@@ -43,13 +43,17 @@ import com.liferay.portal.repository.capabilities.LiferayTrashCapability;
 import com.liferay.portal.repository.capabilities.LiferayWorkflowCapability;
 import com.liferay.portal.repository.capabilities.util.DLFileEntryServiceAdapter;
 import com.liferay.portal.repository.capabilities.util.DLFolderServiceAdapter;
+import com.liferay.portal.repository.capabilities.util.GroupServiceAdapter;
 import com.liferay.portal.repository.capabilities.util.RepositoryEntryChecker;
 import com.liferay.portal.repository.capabilities.util.RepositoryEntryConverter;
+import com.liferay.portal.service.GroupLocalServiceUtil;
+import com.liferay.portal.service.GroupServiceUtil;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.portlet.documentlibrary.service.DLFileEntryLocalServiceUtil;
 import com.liferay.portlet.documentlibrary.service.DLFileEntryServiceUtil;
 import com.liferay.portlet.documentlibrary.service.DLFolderLocalServiceUtil;
 import com.liferay.portlet.documentlibrary.service.DLFolderServiceUtil;
+import com.liferay.portlet.documentlibrary.service.DLSyncEventLocalServiceUtil;
 
 /**
  * @author Adolfo Pérez
@@ -79,6 +83,7 @@ public class LiferayRepositoryDefiner extends BaseRepositoryDefiner {
 
 		DLFileEntryServiceAdapter dlFileEntryServiceAdapter = null;
 		DLFolderServiceAdapter dlFolderServiceAdapter = null;
+		GroupServiceAdapter groupServiceAdapter = null;
 
 		if (documentRepository instanceof LocalRepository) {
 			dlFileEntryServiceAdapter = new DLFileEntryServiceAdapter(
@@ -86,6 +91,9 @@ public class LiferayRepositoryDefiner extends BaseRepositoryDefiner {
 
 			dlFolderServiceAdapter = new DLFolderServiceAdapter(
 				DLFolderLocalServiceUtil.getService());
+
+			groupServiceAdapter = new GroupServiceAdapter(
+				GroupLocalServiceUtil.getService());
 		}
 		else {
 			dlFileEntryServiceAdapter = new DLFileEntryServiceAdapter(
@@ -95,6 +103,10 @@ public class LiferayRepositoryDefiner extends BaseRepositoryDefiner {
 			dlFolderServiceAdapter = new DLFolderServiceAdapter(
 				DLFolderLocalServiceUtil.getService(),
 				DLFolderServiceUtil.getService());
+
+			groupServiceAdapter = new GroupServiceAdapter(
+				GroupLocalServiceUtil.getService(),
+				GroupServiceUtil.getService());
 		}
 
 		BulkOperationCapability bulkOperationCapability =
@@ -131,7 +143,9 @@ public class LiferayRepositoryDefiner extends BaseRepositoryDefiner {
 			ProcessorCapability.class, _processorCapability);
 		capabilityRegistry.addSupportedCapability(
 			SyncCapability.class,
-			new LiferaySyncCapability(bulkOperationCapability));
+			new LiferaySyncCapability(
+				documentRepository, DLSyncEventLocalServiceUtil.getService(),
+				groupServiceAdapter));
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/repository/portletrepository/PortletRepositoryDefiner.java
+++ b/portal-impl/src/com/liferay/portal/repository/portletrepository/PortletRepositoryDefiner.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.repository.portletrepository;
 
 import com.liferay.portal.kernel.repository.DocumentRepository;
+import com.liferay.portal.kernel.repository.LocalRepository;
 import com.liferay.portal.kernel.repository.RepositoryFactory;
 import com.liferay.portal.kernel.repository.capabilities.RelatedModelCapability;
 import com.liferay.portal.kernel.repository.capabilities.TrashCapability;
@@ -25,8 +26,25 @@ import com.liferay.portal.kernel.repository.registry.RepositoryFactoryRegistry;
 import com.liferay.portal.repository.capabilities.LiferayRelatedModelCapability;
 import com.liferay.portal.repository.capabilities.LiferayTrashCapability;
 import com.liferay.portal.repository.capabilities.MinimalWorkflowCapability;
+import com.liferay.portal.repository.capabilities.util.DLAppServiceAdapter;
+import com.liferay.portal.repository.capabilities.util.DLFileEntryServiceAdapter;
+import com.liferay.portal.repository.capabilities.util.DLFolderServiceAdapter;
 import com.liferay.portal.repository.capabilities.util.RepositoryEntryChecker;
 import com.liferay.portal.repository.capabilities.util.RepositoryEntryConverter;
+import com.liferay.portal.repository.capabilities.util.RepositoryServiceAdapter;
+import com.liferay.portal.repository.capabilities.util.TrashEntryServiceAdapter;
+import com.liferay.portal.service.RepositoryLocalServiceUtil;
+import com.liferay.portal.service.RepositoryServiceUtil;
+import com.liferay.portlet.documentlibrary.service.DLAppHelperLocalServiceUtil;
+import com.liferay.portlet.documentlibrary.service.DLAppLocalServiceUtil;
+import com.liferay.portlet.documentlibrary.service.DLAppServiceUtil;
+import com.liferay.portlet.documentlibrary.service.DLFileEntryLocalServiceUtil;
+import com.liferay.portlet.documentlibrary.service.DLFileEntryServiceUtil;
+import com.liferay.portlet.documentlibrary.service.DLFolderLocalServiceUtil;
+import com.liferay.portlet.documentlibrary.service.DLFolderServiceUtil;
+import com.liferay.portlet.trash.service.TrashEntryLocalServiceUtil;
+import com.liferay.portlet.trash.service.TrashEntryServiceUtil;
+import com.liferay.portlet.trash.service.TrashVersionLocalServiceUtil;
 
 /**
  * @author Adolfo Pérez
@@ -49,13 +67,66 @@ public class PortletRepositoryDefiner extends BaseRepositoryDefiner {
 
 		DocumentRepository documentRepository = capabilityRegistry.getTarget();
 
+		DLAppServiceAdapter dlAppServiceAdapter = null;
+		DLFileEntryServiceAdapter dlFileEntryServiceAdapter = null;
+		DLFolderServiceAdapter dlFolderServiceAdapter = null;
+		RepositoryServiceAdapter repositoryServiceAdapter = null;
+		TrashEntryServiceAdapter trashEntryServiceAdapter = null;
+
+		if (documentRepository instanceof LocalRepository) {
+			dlAppServiceAdapter = new DLAppServiceAdapter(
+				DLAppLocalServiceUtil.getService());
+
+			dlFileEntryServiceAdapter = new DLFileEntryServiceAdapter(
+				DLFileEntryLocalServiceUtil.getService());
+
+			dlFolderServiceAdapter = new DLFolderServiceAdapter(
+				DLFolderLocalServiceUtil.getService());
+
+			repositoryServiceAdapter = new RepositoryServiceAdapter(
+				RepositoryLocalServiceUtil.getService());
+
+			trashEntryServiceAdapter = new TrashEntryServiceAdapter(
+				TrashEntryLocalServiceUtil.getService());
+		}
+		else {
+			dlAppServiceAdapter = new DLAppServiceAdapter(
+				DLAppLocalServiceUtil.getService(),
+				DLAppServiceUtil.getService());
+
+			dlFileEntryServiceAdapter = new DLFileEntryServiceAdapter(
+				DLFileEntryLocalServiceUtil.getService(),
+				DLFileEntryServiceUtil.getService());
+
+			dlFolderServiceAdapter = new DLFolderServiceAdapter(
+				DLFolderLocalServiceUtil.getService(),
+				DLFolderServiceUtil.getService());
+
+			repositoryServiceAdapter = new RepositoryServiceAdapter(
+				RepositoryLocalServiceUtil.getService(),
+				RepositoryServiceUtil.getService());
+
+			trashEntryServiceAdapter = new TrashEntryServiceAdapter(
+				TrashEntryLocalServiceUtil.getService(),
+				TrashEntryServiceUtil.getService());
+		}
+
 		capabilityRegistry.addExportedCapability(
 			RelatedModelCapability.class,
+
 			new LiferayRelatedModelCapability(
 				new RepositoryEntryConverter(),
 				new RepositoryEntryChecker(documentRepository)));
+
+		TrashCapability trashCapability = new LiferayTrashCapability(
+			dlAppServiceAdapter, DLAppHelperLocalServiceUtil.getService(),
+			dlFileEntryServiceAdapter, dlFolderServiceAdapter,
+			repositoryServiceAdapter, trashEntryServiceAdapter,
+			TrashVersionLocalServiceUtil.getService());
+
 		capabilityRegistry.addExportedCapability(
-			TrashCapability.class, new LiferayTrashCapability());
+			TrashCapability.class, trashCapability);
+
 		capabilityRegistry.addExportedCapability(
 			WorkflowCapability.class, new MinimalWorkflowCapability());
 	}

--- a/portal-impl/src/com/liferay/portal/repository/portletrepository/PortletRepositoryDefiner.java
+++ b/portal-impl/src/com/liferay/portal/repository/portletrepository/PortletRepositoryDefiner.java
@@ -128,7 +128,8 @@ public class PortletRepositoryDefiner extends BaseRepositoryDefiner {
 			TrashCapability.class, trashCapability);
 
 		capabilityRegistry.addExportedCapability(
-			WorkflowCapability.class, new MinimalWorkflowCapability());
+			WorkflowCapability.class,
+			new MinimalWorkflowCapability(dlFileEntryServiceAdapter));
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/repository/registry/RepositoryClassDefinition.java
+++ b/portal-impl/src/com/liferay/portal/repository/registry/RepositoryClassDefinition.java
@@ -31,6 +31,9 @@ import com.liferay.portal.repository.capabilities.CapabilityLocalRepository;
 import com.liferay.portal.repository.capabilities.CapabilityRepository;
 import com.liferay.portal.repository.capabilities.ConfigurationCapabilityImpl;
 import com.liferay.portal.repository.capabilities.LiferayRepositoryEventTriggerCapability;
+import com.liferay.portal.repository.capabilities.util.RepositoryServiceAdapter;
+import com.liferay.portal.service.RepositoryLocalServiceUtil;
+import com.liferay.portal.service.RepositoryServiceUtil;
 
 import java.util.Locale;
 
@@ -178,9 +181,22 @@ public class RepositoryClassDefinition
 		if (!capabilityRegistry.isCapabilityProvided(
 				ConfigurationCapability.class)) {
 
+			RepositoryServiceAdapter repositoryServiceAdapter = null;
+
+			if (documentRepository instanceof LocalRepository) {
+				repositoryServiceAdapter = new RepositoryServiceAdapter(
+					RepositoryLocalServiceUtil.getService());
+			}
+			else {
+				repositoryServiceAdapter = new RepositoryServiceAdapter(
+					RepositoryLocalServiceUtil.getService(),
+					RepositoryServiceUtil.getService());
+			}
+
 			capabilityRegistry.addExportedCapability(
 				ConfigurationCapability.class,
-				new ConfigurationCapabilityImpl(documentRepository));
+				new ConfigurationCapabilityImpl(
+					documentRepository, repositoryServiceAdapter));
 		}
 
 		if (!capabilityRegistry.isCapabilityProvided(

--- a/portal-impl/src/com/liferay/portal/repository/temporaryrepository/TemporaryFileEntryRepositoryDefiner.java
+++ b/portal-impl/src/com/liferay/portal/repository/temporaryrepository/TemporaryFileEntryRepositoryDefiner.java
@@ -87,7 +87,8 @@ public class TemporaryFileEntryRepositoryDefiner extends BaseRepositoryDefiner {
 			new TemporaryFileEntriesCapabilityImpl(documentRepository));
 
 		capabilityRegistry.addSupportedCapability(
-			WorkflowCapability.class, new MinimalWorkflowCapability());
+			WorkflowCapability.class,
+			new MinimalWorkflowCapability(dlFileEntryServiceAdapter));
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/repository/temporaryrepository/TemporaryFileEntryRepositoryDefiner.java
+++ b/portal-impl/src/com/liferay/portal/repository/temporaryrepository/TemporaryFileEntryRepositoryDefiner.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.repository.temporaryrepository;
 
 import com.liferay.portal.kernel.repository.DocumentRepository;
+import com.liferay.portal.kernel.repository.LocalRepository;
 import com.liferay.portal.kernel.repository.RepositoryFactory;
 import com.liferay.portal.kernel.repository.capabilities.BulkOperationCapability;
 import com.liferay.portal.kernel.repository.capabilities.TemporaryFileEntriesCapability;
@@ -25,6 +26,12 @@ import com.liferay.portal.kernel.repository.registry.RepositoryFactoryRegistry;
 import com.liferay.portal.repository.capabilities.LiferayBulkOperationCapability;
 import com.liferay.portal.repository.capabilities.MinimalWorkflowCapability;
 import com.liferay.portal.repository.capabilities.TemporaryFileEntriesCapabilityImpl;
+import com.liferay.portal.repository.capabilities.util.DLFileEntryServiceAdapter;
+import com.liferay.portal.repository.capabilities.util.DLFolderServiceAdapter;
+import com.liferay.portlet.documentlibrary.service.DLFileEntryLocalServiceUtil;
+import com.liferay.portlet.documentlibrary.service.DLFileEntryServiceUtil;
+import com.liferay.portlet.documentlibrary.service.DLFolderLocalServiceUtil;
+import com.liferay.portlet.documentlibrary.service.DLFolderServiceUtil;
 
 /**
  * @author Iván Zaera
@@ -50,9 +57,31 @@ public class TemporaryFileEntryRepositoryDefiner extends BaseRepositoryDefiner {
 
 		DocumentRepository documentRepository = capabilityRegistry.getTarget();
 
+		DLFileEntryServiceAdapter dlFileEntryServiceAdapter = null;
+		DLFolderServiceAdapter dlFolderServiceAdapter = null;
+
+		if (documentRepository instanceof LocalRepository) {
+			dlFileEntryServiceAdapter = new DLFileEntryServiceAdapter(
+				DLFileEntryLocalServiceUtil.getService());
+
+			dlFolderServiceAdapter = new DLFolderServiceAdapter(
+				DLFolderLocalServiceUtil.getService());
+		}
+		else {
+			dlFileEntryServiceAdapter = new DLFileEntryServiceAdapter(
+				DLFileEntryLocalServiceUtil.getService(),
+				DLFileEntryServiceUtil.getService());
+
+			dlFolderServiceAdapter = new DLFolderServiceAdapter(
+				DLFolderLocalServiceUtil.getService(),
+				DLFolderServiceUtil.getService());
+		}
+
 		capabilityRegistry.addExportedCapability(
 			BulkOperationCapability.class,
-			new LiferayBulkOperationCapability(documentRepository));
+			new LiferayBulkOperationCapability(
+				documentRepository, dlFileEntryServiceAdapter,
+				dlFolderServiceAdapter));
 		capabilityRegistry.addExportedCapability(
 			TemporaryFileEntriesCapability.class,
 			new TemporaryFileEntriesCapabilityImpl(documentRepository));

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/http/DLFileEntryServiceHttp.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/http/DLFileEntryServiceHttp.java
@@ -1229,13 +1229,47 @@ public class DLFileEntryServiceHttp {
 		}
 	}
 
+	public static boolean isKeepFileVersionLabel(HttpPrincipal httpPrincipal,
+		long fileEntryId,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		try {
+			MethodKey methodKey = new MethodKey(DLFileEntryServiceUtil.class,
+					"isKeepFileVersionLabel",
+					_isKeepFileVersionLabelParameterTypes37);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey,
+					fileEntryId, serviceContext);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return ((Boolean)returnObj).booleanValue();
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
 	public static com.liferay.portlet.documentlibrary.model.DLFileEntry moveFileEntry(
 		HttpPrincipal httpPrincipal, long fileEntryId, long newFolderId,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(DLFileEntryServiceUtil.class,
-					"moveFileEntry", _moveFileEntryParameterTypes37);
+					"moveFileEntry", _moveFileEntryParameterTypes38);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					fileEntryId, newFolderId, serviceContext);
@@ -1269,7 +1303,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(DLFileEntryServiceUtil.class,
 					"refreshFileEntryLock",
-					_refreshFileEntryLockParameterTypes38);
+					_refreshFileEntryLockParameterTypes39);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					lockUuid, companyId, expirationTime);
@@ -1302,7 +1336,7 @@ public class DLFileEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(DLFileEntryServiceUtil.class,
-					"revertFileEntry", _revertFileEntryParameterTypes39);
+					"revertFileEntry", _revertFileEntryParameterTypes40);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					fileEntryId, version, serviceContext);
@@ -1331,7 +1365,7 @@ public class DLFileEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(DLFileEntryServiceUtil.class,
-					"search", _searchParameterTypes40);
+					"search", _searchParameterTypes41);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					creatorUserId, status, start, end);
@@ -1364,7 +1398,7 @@ public class DLFileEntryServiceHttp {
 		int end) throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(DLFileEntryServiceUtil.class,
-					"search", _searchParameterTypes41);
+					"search", _searchParameterTypes42);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					creatorUserId, folderId, mimeTypes, status, start, end);
@@ -1402,12 +1436,46 @@ public class DLFileEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(DLFileEntryServiceUtil.class,
-					"updateFileEntry", _updateFileEntryParameterTypes42);
+					"updateFileEntry", _updateFileEntryParameterTypes43);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					fileEntryId, sourceFileName, mimeType, title, description,
 					changeLog, majorVersion, fileEntryTypeId, ddmFormValuesMap,
 					file, is, size, serviceContext);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return (com.liferay.portlet.documentlibrary.model.DLFileEntry)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
+	public static com.liferay.portlet.documentlibrary.model.DLFileEntry updateStatus(
+		HttpPrincipal httpPrincipal, long userId, long fileVersionId,
+		int status, com.liferay.portal.service.ServiceContext serviceContext,
+		java.util.Map<java.lang.String, java.io.Serializable> workflowContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		try {
+			MethodKey methodKey = new MethodKey(DLFileEntryServiceUtil.class,
+					"updateStatus", _updateStatusParameterTypes44);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey, userId,
+					fileVersionId, status, serviceContext, workflowContext);
 
 			Object returnObj = null;
 
@@ -1437,7 +1505,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(DLFileEntryServiceUtil.class,
 					"verifyFileEntryCheckOut",
-					_verifyFileEntryCheckOutParameterTypes43);
+					_verifyFileEntryCheckOutParameterTypes45);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					fileEntryId, lockUuid);
@@ -1469,7 +1537,7 @@ public class DLFileEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(DLFileEntryServiceUtil.class,
-					"verifyFileEntryLock", _verifyFileEntryLockParameterTypes44);
+					"verifyFileEntryLock", _verifyFileEntryLockParameterTypes46);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					fileEntryId, lockUuid);
@@ -1626,35 +1694,42 @@ public class DLFileEntryServiceHttp {
 	private static final Class<?>[] _isFileEntryCheckedOutParameterTypes36 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _moveFileEntryParameterTypes37 = new Class[] {
+	private static final Class<?>[] _isKeepFileVersionLabelParameterTypes37 = new Class[] {
+			long.class, com.liferay.portal.service.ServiceContext.class
+		};
+	private static final Class<?>[] _moveFileEntryParameterTypes38 = new Class[] {
 			long.class, long.class,
 			com.liferay.portal.service.ServiceContext.class
 		};
-	private static final Class<?>[] _refreshFileEntryLockParameterTypes38 = new Class[] {
+	private static final Class<?>[] _refreshFileEntryLockParameterTypes39 = new Class[] {
 			java.lang.String.class, long.class, long.class
 		};
-	private static final Class<?>[] _revertFileEntryParameterTypes39 = new Class[] {
+	private static final Class<?>[] _revertFileEntryParameterTypes40 = new Class[] {
 			long.class, java.lang.String.class,
 			com.liferay.portal.service.ServiceContext.class
 		};
-	private static final Class<?>[] _searchParameterTypes40 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes41 = new Class[] {
 			long.class, long.class, int.class, int.class, int.class
 		};
-	private static final Class<?>[] _searchParameterTypes41 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes42 = new Class[] {
 			long.class, long.class, long.class, java.lang.String[].class,
 			int.class, int.class, int.class
 		};
-	private static final Class<?>[] _updateFileEntryParameterTypes42 = new Class[] {
+	private static final Class<?>[] _updateFileEntryParameterTypes43 = new Class[] {
 			long.class, java.lang.String.class, java.lang.String.class,
 			java.lang.String.class, java.lang.String.class,
 			java.lang.String.class, boolean.class, long.class,
 			java.util.Map.class, java.io.File.class, java.io.InputStream.class,
 			long.class, com.liferay.portal.service.ServiceContext.class
 		};
-	private static final Class<?>[] _verifyFileEntryCheckOutParameterTypes43 = new Class[] {
+	private static final Class<?>[] _updateStatusParameterTypes44 = new Class[] {
+			long.class, long.class, int.class,
+			com.liferay.portal.service.ServiceContext.class, java.util.Map.class
+		};
+	private static final Class<?>[] _verifyFileEntryCheckOutParameterTypes45 = new Class[] {
 			long.class, java.lang.String.class
 		};
-	private static final Class<?>[] _verifyFileEntryLockParameterTypes44 = new Class[] {
+	private static final Class<?>[] _verifyFileEntryLockParameterTypes46 = new Class[] {
 			long.class, java.lang.String.class
 		};
 }

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/http/DLFileEntryServiceSoap.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/http/DLFileEntryServiceSoap.java
@@ -607,6 +607,22 @@ public class DLFileEntryServiceSoap {
 		}
 	}
 
+	public static boolean isKeepFileVersionLabel(long fileEntryId,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws RemoteException {
+		try {
+			boolean returnValue = DLFileEntryServiceUtil.isKeepFileVersionLabel(fileEntryId,
+					serviceContext);
+
+			return returnValue;
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
 	public static com.liferay.portlet.documentlibrary.model.DLFileEntrySoap moveFileEntry(
 		long fileEntryId, long newFolderId,
 		com.liferay.portal.service.ServiceContext serviceContext)

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/http/DLFileVersionServiceHttp.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/http/DLFileVersionServiceHttp.java
@@ -183,6 +183,39 @@ public class DLFileVersionServiceHttp {
 		}
 	}
 
+	public static com.liferay.portlet.documentlibrary.model.DLFileVersion getLatestFileVersion(
+		HttpPrincipal httpPrincipal, long fileEntryId,
+		boolean excludeWorkingCopy)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		try {
+			MethodKey methodKey = new MethodKey(DLFileVersionServiceUtil.class,
+					"getLatestFileVersion", _getLatestFileVersionParameterTypes4);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey,
+					fileEntryId, excludeWorkingCopy);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return (com.liferay.portlet.documentlibrary.model.DLFileVersion)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
 	private static Log _log = LogFactoryUtil.getLog(DLFileVersionServiceHttp.class);
 	private static final Class<?>[] _getFileVersionParameterTypes0 = new Class[] {
 			long.class
@@ -195,5 +228,8 @@ public class DLFileVersionServiceHttp {
 		};
 	private static final Class<?>[] _getLatestFileVersionParameterTypes3 = new Class[] {
 			long.class
+		};
+	private static final Class<?>[] _getLatestFileVersionParameterTypes4 = new Class[] {
+			long.class, boolean.class
 		};
 }

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/http/DLFileVersionServiceSoap.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/http/DLFileVersionServiceSoap.java
@@ -123,5 +123,20 @@ public class DLFileVersionServiceSoap {
 		}
 	}
 
+	public static com.liferay.portlet.documentlibrary.model.DLFileVersionSoap getLatestFileVersion(
+		long fileEntryId, boolean excludeWorkingCopy) throws RemoteException {
+		try {
+			com.liferay.portlet.documentlibrary.model.DLFileVersion returnValue = DLFileVersionServiceUtil.getLatestFileVersion(fileEntryId,
+					excludeWorkingCopy);
+
+			return com.liferay.portlet.documentlibrary.model.DLFileVersionSoap.toSoapModel(returnValue);
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
 	private static Log _log = LogFactoryUtil.getLog(DLFileVersionServiceSoap.class);
 }

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/http/DLFolderServiceHttp.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/http/DLFolderServiceHttp.java
@@ -509,6 +509,41 @@ public class DLFolderServiceHttp {
 		}
 	}
 
+	public static java.util.List<java.lang.Object> getFoldersAndFileEntriesAndFileShortcuts(
+		HttpPrincipal httpPrincipal, long groupId, long folderId,
+		java.lang.String[] mimeTypes, boolean includeMountFolders,
+		com.liferay.portal.kernel.dao.orm.QueryDefinition<?> queryDefinition)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		try {
+			MethodKey methodKey = new MethodKey(DLFolderServiceUtil.class,
+					"getFoldersAndFileEntriesAndFileShortcuts",
+					_getFoldersAndFileEntriesAndFileShortcutsParameterTypes14);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
+					folderId, mimeTypes, includeMountFolders, queryDefinition);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return (java.util.List<java.lang.Object>)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
 	public static int getFoldersAndFileEntriesAndFileShortcutsCount(
 		HttpPrincipal httpPrincipal, long groupId, long folderId, int status,
 		boolean includeMountFolders)
@@ -516,7 +551,7 @@ public class DLFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(DLFolderServiceUtil.class,
 					"getFoldersAndFileEntriesAndFileShortcutsCount",
-					_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes14);
+					_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					folderId, status, includeMountFolders);
@@ -550,7 +585,7 @@ public class DLFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(DLFolderServiceUtil.class,
 					"getFoldersAndFileEntriesAndFileShortcutsCount",
-					_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes15);
+					_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					folderId, status, mimeTypes, includeMountFolders);
@@ -582,7 +617,7 @@ public class DLFolderServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(DLFolderServiceUtil.class,
-					"getFoldersCount", _getFoldersCountParameterTypes16);
+					"getFoldersCount", _getFoldersCountParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					parentFolderId);
@@ -615,7 +650,7 @@ public class DLFolderServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(DLFolderServiceUtil.class,
-					"getFoldersCount", _getFoldersCountParameterTypes17);
+					"getFoldersCount", _getFoldersCountParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					parentFolderId, status, includeMountfolders);
@@ -649,7 +684,7 @@ public class DLFolderServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(DLFolderServiceUtil.class,
-					"getMountFolders", _getMountFoldersParameterTypes18);
+					"getMountFolders", _getMountFoldersParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					parentFolderId, start, end, obc);
@@ -682,7 +717,7 @@ public class DLFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(DLFolderServiceUtil.class,
 					"getMountFoldersCount",
-					_getMountFoldersCountParameterTypes19);
+					_getMountFoldersCountParameterTypes20);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					parentFolderId);
@@ -714,7 +749,7 @@ public class DLFolderServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(DLFolderServiceUtil.class,
-					"getSubfolderIds", _getSubfolderIdsParameterTypes20);
+					"getSubfolderIds", _getSubfolderIdsParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					folderIds, groupId, folderId);
@@ -743,7 +778,7 @@ public class DLFolderServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(DLFolderServiceUtil.class,
-					"getSubfolderIds", _getSubfolderIdsParameterTypes21);
+					"getSubfolderIds", _getSubfolderIdsParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					folderIds, groupId, folderId, recurse);
@@ -772,7 +807,7 @@ public class DLFolderServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(DLFolderServiceUtil.class,
-					"getSubfolderIds", _getSubfolderIdsParameterTypes22);
+					"getSubfolderIds", _getSubfolderIdsParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					folderId, recurse);
@@ -804,7 +839,7 @@ public class DLFolderServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(DLFolderServiceUtil.class,
-					"hasFolderLock", _hasFolderLockParameterTypes23);
+					"hasFolderLock", _hasFolderLockParameterTypes24);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, folderId);
 
@@ -835,7 +870,7 @@ public class DLFolderServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(DLFolderServiceUtil.class,
-					"hasInheritableLock", _hasInheritableLockParameterTypes24);
+					"hasInheritableLock", _hasInheritableLockParameterTypes25);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, folderId);
 
@@ -865,7 +900,7 @@ public class DLFolderServiceHttp {
 		long folderId) {
 		try {
 			MethodKey methodKey = new MethodKey(DLFolderServiceUtil.class,
-					"isFolderLocked", _isFolderLockedParameterTypes25);
+					"isFolderLocked", _isFolderLockedParameterTypes26);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, folderId);
 
@@ -892,7 +927,7 @@ public class DLFolderServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(DLFolderServiceUtil.class,
-					"lockFolder", _lockFolderParameterTypes26);
+					"lockFolder", _lockFolderParameterTypes27);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, folderId);
 
@@ -924,7 +959,7 @@ public class DLFolderServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(DLFolderServiceUtil.class,
-					"lockFolder", _lockFolderParameterTypes27);
+					"lockFolder", _lockFolderParameterTypes28);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					folderId, owner, inheritable, expirationTime);
@@ -957,7 +992,7 @@ public class DLFolderServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(DLFolderServiceUtil.class,
-					"moveFolder", _moveFolderParameterTypes28);
+					"moveFolder", _moveFolderParameterTypes29);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					folderId, parentFolderId, serviceContext);
@@ -990,7 +1025,7 @@ public class DLFolderServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(DLFolderServiceUtil.class,
-					"refreshFolderLock", _refreshFolderLockParameterTypes29);
+					"refreshFolderLock", _refreshFolderLockParameterTypes30);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					lockUuid, companyId, expirationTime);
@@ -1022,7 +1057,7 @@ public class DLFolderServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(DLFolderServiceUtil.class,
-					"unlockFolder", _unlockFolderParameterTypes30);
+					"unlockFolder", _unlockFolderParameterTypes31);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					parentFolderId, name, lockUuid);
@@ -1050,7 +1085,7 @@ public class DLFolderServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(DLFolderServiceUtil.class,
-					"unlockFolder", _unlockFolderParameterTypes31);
+					"unlockFolder", _unlockFolderParameterTypes32);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					folderId, lockUuid);
@@ -1082,7 +1117,7 @@ public class DLFolderServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(DLFolderServiceUtil.class,
-					"updateFolder", _updateFolderParameterTypes32);
+					"updateFolder", _updateFolderParameterTypes33);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					folderId, parentFolderId, name, description,
@@ -1120,7 +1155,7 @@ public class DLFolderServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(DLFolderServiceUtil.class,
-					"updateFolder", _updateFolderParameterTypes33);
+					"updateFolder", _updateFolderParameterTypes34);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					folderId, name, description, defaultFileEntryTypeId,
@@ -1156,7 +1191,7 @@ public class DLFolderServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(DLFolderServiceUtil.class,
-					"updateFolder", _updateFolderParameterTypes34);
+					"updateFolder", _updateFolderParameterTypes35);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					folderId, name, description, defaultFileEntryTypeId,
@@ -1190,7 +1225,7 @@ public class DLFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(DLFolderServiceUtil.class,
 					"verifyInheritableLock",
-					_verifyInheritableLockParameterTypes35);
+					_verifyInheritableLockParameterTypes36);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					folderId, lockUuid);
@@ -1266,80 +1301,85 @@ public class DLFolderServiceHttp {
 			boolean.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes14 =
-		new Class[] { long.class, long.class, int.class, boolean.class };
+	private static final Class<?>[] _getFoldersAndFileEntriesAndFileShortcutsParameterTypes14 =
+		new Class[] {
+			long.class, long.class, java.lang.String[].class, boolean.class,
+			com.liferay.portal.kernel.dao.orm.QueryDefinition.class
+		};
 	private static final Class<?>[] _getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes15 =
+		new Class[] { long.class, long.class, int.class, boolean.class };
+	private static final Class<?>[] _getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes16 =
 		new Class[] {
 			long.class, long.class, int.class, java.lang.String[].class,
 			boolean.class
 		};
-	private static final Class<?>[] _getFoldersCountParameterTypes16 = new Class[] {
+	private static final Class<?>[] _getFoldersCountParameterTypes17 = new Class[] {
 			long.class, long.class
 		};
-	private static final Class<?>[] _getFoldersCountParameterTypes17 = new Class[] {
+	private static final Class<?>[] _getFoldersCountParameterTypes18 = new Class[] {
 			long.class, long.class, int.class, boolean.class
 		};
-	private static final Class<?>[] _getMountFoldersParameterTypes18 = new Class[] {
+	private static final Class<?>[] _getMountFoldersParameterTypes19 = new Class[] {
 			long.class, long.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getMountFoldersCountParameterTypes19 = new Class[] {
+	private static final Class<?>[] _getMountFoldersCountParameterTypes20 = new Class[] {
 			long.class, long.class
 		};
-	private static final Class<?>[] _getSubfolderIdsParameterTypes20 = new Class[] {
+	private static final Class<?>[] _getSubfolderIdsParameterTypes21 = new Class[] {
 			java.util.List.class, long.class, long.class
 		};
-	private static final Class<?>[] _getSubfolderIdsParameterTypes21 = new Class[] {
+	private static final Class<?>[] _getSubfolderIdsParameterTypes22 = new Class[] {
 			java.util.List.class, long.class, long.class, boolean.class
 		};
-	private static final Class<?>[] _getSubfolderIdsParameterTypes22 = new Class[] {
+	private static final Class<?>[] _getSubfolderIdsParameterTypes23 = new Class[] {
 			long.class, long.class, boolean.class
 		};
-	private static final Class<?>[] _hasFolderLockParameterTypes23 = new Class[] {
+	private static final Class<?>[] _hasFolderLockParameterTypes24 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _hasInheritableLockParameterTypes24 = new Class[] {
+	private static final Class<?>[] _hasInheritableLockParameterTypes25 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _isFolderLockedParameterTypes25 = new Class[] {
-			long.class
-		};
-	private static final Class<?>[] _lockFolderParameterTypes26 = new Class[] {
+	private static final Class<?>[] _isFolderLockedParameterTypes26 = new Class[] {
 			long.class
 		};
 	private static final Class<?>[] _lockFolderParameterTypes27 = new Class[] {
+			long.class
+		};
+	private static final Class<?>[] _lockFolderParameterTypes28 = new Class[] {
 			long.class, java.lang.String.class, boolean.class, long.class
 		};
-	private static final Class<?>[] _moveFolderParameterTypes28 = new Class[] {
+	private static final Class<?>[] _moveFolderParameterTypes29 = new Class[] {
 			long.class, long.class,
 			com.liferay.portal.service.ServiceContext.class
 		};
-	private static final Class<?>[] _refreshFolderLockParameterTypes29 = new Class[] {
+	private static final Class<?>[] _refreshFolderLockParameterTypes30 = new Class[] {
 			java.lang.String.class, long.class, long.class
 		};
-	private static final Class<?>[] _unlockFolderParameterTypes30 = new Class[] {
+	private static final Class<?>[] _unlockFolderParameterTypes31 = new Class[] {
 			long.class, long.class, java.lang.String.class,
 			java.lang.String.class
 		};
-	private static final Class<?>[] _unlockFolderParameterTypes31 = new Class[] {
+	private static final Class<?>[] _unlockFolderParameterTypes32 = new Class[] {
 			long.class, java.lang.String.class
 		};
-	private static final Class<?>[] _updateFolderParameterTypes32 = new Class[] {
+	private static final Class<?>[] _updateFolderParameterTypes33 = new Class[] {
 			long.class, long.class, java.lang.String.class,
 			java.lang.String.class, long.class, java.util.List.class, int.class,
 			com.liferay.portal.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateFolderParameterTypes33 = new Class[] {
+	private static final Class<?>[] _updateFolderParameterTypes34 = new Class[] {
 			long.class, java.lang.String.class, java.lang.String.class,
 			long.class, java.util.List.class, boolean.class,
 			com.liferay.portal.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateFolderParameterTypes34 = new Class[] {
+	private static final Class<?>[] _updateFolderParameterTypes35 = new Class[] {
 			long.class, java.lang.String.class, java.lang.String.class,
 			long.class, java.util.List.class, int.class,
 			com.liferay.portal.service.ServiceContext.class
 		};
-	private static final Class<?>[] _verifyInheritableLockParameterTypes35 = new Class[] {
+	private static final Class<?>[] _verifyInheritableLockParameterTypes36 = new Class[] {
 			long.class, java.lang.String.class
 		};
 }

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryServiceImpl.java
@@ -39,6 +39,7 @@ import com.liferay.portlet.dynamicdatamapping.storage.DDMFormValues;
 
 import java.io.File;
 import java.io.InputStream;
+import java.io.Serializable;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -613,6 +614,20 @@ public class DLFileEntryServiceImpl extends DLFileEntryServiceBaseImpl {
 	}
 
 	@Override
+	public boolean isKeepFileVersionLabel(
+			long fileEntryId, ServiceContext serviceContext)
+		throws PortalException {
+
+		PermissionChecker permissionChecker = getPermissionChecker();
+
+		DLFileEntryPermission.check(
+			permissionChecker, fileEntryId, ActionKeys.VIEW);
+
+		return dlFileEntryLocalService.isKeepFileVersionLabel(
+			fileEntryId, serviceContext);
+	}
+
+	@Override
 	public DLFileEntry moveFileEntry(
 			long fileEntryId, long newFolderId, ServiceContext serviceContext)
 		throws PortalException {
@@ -686,6 +701,24 @@ public class DLFileEntryServiceImpl extends DLFileEntryServiceBaseImpl {
 			getUserId(), fileEntryId, sourceFileName, mimeType, title,
 			description, changeLog, majorVersion, fileEntryTypeId,
 			ddmFormValuesMap, file, is, size, serviceContext);
+	}
+
+	@Override
+	public DLFileEntry updateStatus(
+			long userId, long fileVersionId, int status,
+			ServiceContext serviceContext,
+			Map<String, Serializable> workflowContext)
+		throws PortalException {
+
+		DLFileVersion dlFileVersion = dlFileVersionLocalService.getFileVersion(
+			fileVersionId);
+
+		DLFileEntryPermission.check(
+			getPermissionChecker(), dlFileVersion.getFileEntryId(),
+			ActionKeys.UPDATE);
+
+		return dlFileEntryLocalService.updateStatus(
+			userId, fileVersionId, status, serviceContext, workflowContext);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileVersionServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileVersionServiceImpl.java
@@ -72,4 +72,16 @@ public class DLFileVersionServiceImpl extends DLFileVersionServiceBaseImpl {
 			getGuestOrUserId(), fileEntryId);
 	}
 
+	@Override
+	public DLFileVersion getLatestFileVersion(
+			long fileEntryId, boolean excludeWorkingCopy)
+		throws PortalException {
+
+		DLFileEntryPermission.check(
+			getPermissionChecker(), fileEntryId, ActionKeys.VIEW);
+
+		return dlFileVersionLocalService.getLatestFileVersion(
+			fileEntryId, excludeWorkingCopy);
+	}
+
 }

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFolderServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFolderServiceImpl.java
@@ -254,6 +254,22 @@ public class DLFolderServiceImpl extends DLFolderServiceBaseImpl {
 	}
 
 	@Override
+	public List<Object> getFoldersAndFileEntriesAndFileShortcuts(
+			long groupId, long folderId, String[] mimeTypes,
+			boolean includeMountFolders, QueryDefinition<?> queryDefinition)
+		throws PortalException {
+
+		if (!DLFolderPermission.contains(
+				getPermissionChecker(), groupId, folderId, ActionKeys.VIEW)) {
+
+			return Collections.emptyList();
+		}
+
+		return dlFolderFinder.filterFindF_FE_FS_ByG_F_M_M(
+			groupId, folderId, mimeTypes, includeMountFolders, queryDefinition);
+	}
+
+	@Override
 	public int getFoldersAndFileEntriesAndFileShortcutsCount(
 			long groupId, long folderId, int status,
 			boolean includeMountFolders)

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/trash/DLBaseTrashHandler.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/trash/DLBaseTrashHandler.java
@@ -17,6 +17,7 @@ package com.liferay.portlet.documentlibrary.trash;
 import com.liferay.portal.InvalidRepositoryException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.repository.LocalRepository;
 import com.liferay.portal.kernel.repository.Repository;
 import com.liferay.portal.kernel.repository.RepositoryProviderUtil;
 import com.liferay.portal.kernel.repository.capabilities.TrashCapability;
@@ -71,9 +72,9 @@ public abstract class DLBaseTrashHandler extends BaseTrashHandler {
 			long classPK, long parentContainerModelId, int start, int end)
 		throws PortalException {
 
-		Repository repository = getRepository(classPK);
+		LocalRepository localRepository = getLocalRepository(classPK);
 
-		List<Folder> folders = repository.getFolders(
+		List<Folder> folders = localRepository.getFolders(
 			parentContainerModelId, false, start, end, null);
 
 		List<ContainerModel> containerModels = new ArrayList<>(folders.size());
@@ -90,9 +91,9 @@ public abstract class DLBaseTrashHandler extends BaseTrashHandler {
 			long classPK, long parentContainerModelId)
 		throws PortalException {
 
-		Repository repository = getRepository(classPK);
+		LocalRepository localRepository = getLocalRepository(classPK);
 
-		return repository.getFoldersCount(parentContainerModelId, false);
+		return localRepository.getFoldersCount(parentContainerModelId, false);
 	}
 
 	@Override
@@ -144,9 +145,9 @@ public abstract class DLBaseTrashHandler extends BaseTrashHandler {
 	public int getTrashContainedModelsCount(long classPK)
 		throws PortalException {
 
-		Repository repository = getRepository(classPK);
+		LocalRepository localRepository = getLocalRepository(classPK);
 
-		return repository.getFileEntriesAndFileShortcutsCount(
+		return localRepository.getFileEntriesAndFileShortcutsCount(
 			classPK, WorkflowConstants.STATUS_IN_TRASH);
 	}
 
@@ -157,10 +158,10 @@ public abstract class DLBaseTrashHandler extends BaseTrashHandler {
 
 		List<TrashRenderer> trashRenderers = new ArrayList<>();
 
-		Repository repository = getRepository(classPK);
+		LocalRepository localRepository = getLocalRepository(classPK);
 
 		List<RepositoryEntry> repositoryEntries =
-			repository.getFileEntriesAndFileShortcuts(
+			localRepository.getFileEntriesAndFileShortcuts(
 				classPK, WorkflowConstants.STATUS_IN_TRASH, start, end);
 
 		for (RepositoryEntry repositoryEntry : repositoryEntries) {
@@ -204,9 +205,9 @@ public abstract class DLBaseTrashHandler extends BaseTrashHandler {
 	public int getTrashContainerModelsCount(long classPK)
 		throws PortalException {
 
-		Repository repository = getRepository(classPK);
+		LocalRepository localRepository = getLocalRepository(classPK);
 
-		return repository.getFoldersCount(
+		return localRepository.getFoldersCount(
 			classPK, WorkflowConstants.STATUS_IN_TRASH, false);
 	}
 
@@ -217,9 +218,9 @@ public abstract class DLBaseTrashHandler extends BaseTrashHandler {
 
 		List<TrashRenderer> trashRenderers = new ArrayList<>();
 
-		Repository repository = getRepository(classPK);
+		LocalRepository localRepository = getLocalRepository(classPK);
 
-		List<Folder> folders = repository.getFolders(
+		List<Folder> folders = localRepository.getFolders(
 			classPK, WorkflowConstants.STATUS_IN_TRASH, false, start, end,
 			null);
 
@@ -270,7 +271,10 @@ public abstract class DLBaseTrashHandler extends BaseTrashHandler {
 		return (DLFolder)folder.getModel();
 	}
 
-	protected abstract Repository getRepository(long classPK)
+	protected abstract LocalRepository getLocalRepository(long classPK)
+		throws PortalException;
+
+	protected abstract LocalRepository getRepository(long classPK)
 		throws PortalException;
 
 }

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/trash/DLFileEntryTrashHandler.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/trash/DLFileEntryTrashHandler.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.documentlibrary.trash;
 
 import com.liferay.portal.InvalidRepositoryException;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.repository.LocalRepository;
 import com.liferay.portal.kernel.repository.Repository;
 import com.liferay.portal.kernel.repository.RepositoryProviderUtil;
 import com.liferay.portal.kernel.repository.capabilities.TrashCapability;
@@ -86,12 +87,12 @@ public class DLFileEntryTrashHandler extends DLBaseTrashHandler {
 
 	@Override
 	public void deleteTrashEntry(long classPK) throws PortalException {
-		Repository repository = getRepository(classPK);
+		LocalRepository localRepository = getLocalRepository(classPK);
 
-		TrashCapability trashCapability = repository.getCapability(
+		TrashCapability trashCapability = localRepository.getCapability(
 			TrashCapability.class);
 
-		trashCapability.deleteFileEntry(repository.getFileEntry(classPK));
+		trashCapability.deleteFileEntry(localRepository.getFileEntry(classPK));
 	}
 
 	@Override
@@ -249,10 +250,10 @@ public class DLFileEntryTrashHandler extends DLBaseTrashHandler {
 			ServiceContext serviceContext)
 		throws PortalException {
 
-		Repository repository = getRepository(classPK);
+		LocalRepository localRepository = getLocalRepository(classPK);
 
 		RepositoryTrashUtil.moveFileEntryFromTrash(
-			userId, repository.getRepositoryId(), classPK, containerModelId,
+			userId, localRepository.getRepositoryId(), classPK, containerModelId,
 			serviceContext);
 	}
 
@@ -397,17 +398,19 @@ public class DLFileEntryTrashHandler extends DLBaseTrashHandler {
 	}
 
 	@Override
-	protected Repository getRepository(long classPK) throws PortalException {
-		Repository repository = RepositoryProviderUtil.getFileEntryRepository(
-			classPK);
+	protected LocalRepository getLocalRepository(long classPK)
+		throws PortalException {
 
-		if (!repository.isCapabilityProvided(TrashCapability.class)) {
+		LocalRepository localRepository =
+			RepositoryProviderUtil.getFileEntryLocalRepository(classPK);
+
+		if (!localRepository.isCapabilityProvided(TrashCapability.class)) {
 			throw new InvalidRepositoryException(
-				"Repository " + repository.getRepositoryId() +
+				"Repository " + localRepository.getRepositoryId() +
 					" does not support trash operations");
 		}
 
-		return repository;
+		return localRepository;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/trash/DLFileShortcutTrashHandler.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/trash/DLFileShortcutTrashHandler.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.documentlibrary.trash;
 
 import com.liferay.portal.InvalidRepositoryException;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.repository.LocalRepository;
 import com.liferay.portal.kernel.repository.Repository;
 import com.liferay.portal.kernel.repository.RepositoryProviderUtil;
 import com.liferay.portal.kernel.repository.capabilities.TrashCapability;
@@ -191,18 +192,18 @@ public class DLFileShortcutTrashHandler extends DLBaseTrashHandler {
 			ServiceContext serviceContext)
 		throws PortalException {
 
-		Repository repository = getRepository(classPK);
+		LocalRepository localRepository = getLocalRepository(classPK);
 
-		TrashCapability trashCapability = repository.getCapability(
+		TrashCapability trashCapability = localRepository.getCapability(
 			TrashCapability.class);
 
 		Folder newFolder = null;
 
 		if (containerModelId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
-			newFolder = repository.getFolder(containerModelId);
+			newFolder = localRepository.getFolder(containerModelId);
 		}
 
-		FileShortcut fileShortcut = repository.getFileShortcut(classPK);
+		FileShortcut fileShortcut = localRepository.getFileShortcut(classPK);
 
 		trashCapability.moveFileShortcutFromTrash(
 			userId, fileShortcut, newFolder, serviceContext);
@@ -212,12 +213,12 @@ public class DLFileShortcutTrashHandler extends DLBaseTrashHandler {
 	public void restoreTrashEntry(long userId, long classPK)
 		throws PortalException {
 
-		Repository repository = getRepository(classPK);
+		LocalRepository localRepository = getLocalRepository(classPK);
 
-		TrashCapability trashCapability = repository.getCapability(
+		TrashCapability trashCapability = localRepository.getCapability(
 			TrashCapability.class);
 
-		FileShortcut fileShortcut = repository.getFileShortcut(classPK);
+		FileShortcut fileShortcut = localRepository.getFileShortcut(classPK);
 
 		trashCapability.restoreFileShortcutFromTrash(userId, fileShortcut);
 	}
@@ -240,17 +241,19 @@ public class DLFileShortcutTrashHandler extends DLBaseTrashHandler {
 	}
 
 	@Override
-	protected Repository getRepository(long classPK) throws PortalException {
-		Repository repository =
-			RepositoryProviderUtil.getFileShortcutRepository(classPK);
+	protected LocalRepository getLocalRepository(long classPK)
+		throws PortalException {
 
-		if (!repository.isCapabilityProvided(TrashCapability.class)) {
+		LocalRepository localRepository =
+			RepositoryProviderUtil.getFileShortcutLocalRepository(classPK);
+
+		if (!localRepository.isCapabilityProvided(TrashCapability.class)) {
 			throw new InvalidRepositoryException(
-				"Repository " + repository.getRepositoryId() +
+				"Repository " + localRepository.getRepositoryId() +
 					" does not support trash operations");
 		}
 
-		return repository;
+		return localRepository;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/trash/DLFolderTrashHandler.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/trash/DLFolderTrashHandler.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.documentlibrary.trash;
 
 import com.liferay.portal.InvalidRepositoryException;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.repository.LocalRepository;
 import com.liferay.portal.kernel.repository.Repository;
 import com.liferay.portal.kernel.repository.RepositoryProviderUtil;
 import com.liferay.portal.kernel.repository.capabilities.TrashCapability;
@@ -73,12 +74,12 @@ public class DLFolderTrashHandler extends DLBaseTrashHandler {
 
 	@Override
 	public void deleteTrashEntry(long classPK) throws PortalException {
-		Repository repository = getRepository(classPK);
+		LocalRepository localRepository = getLocalRepository(classPK);
 
-		TrashCapability trashCapability = repository.getCapability(
+		TrashCapability trashCapability = localRepository.getCapability(
 			TrashCapability.class);
 
-		Folder folder = repository.getFolder(classPK);
+		Folder folder = localRepository.getFolder(classPK);
 
 		trashCapability.deleteFolder(folder);
 	}
@@ -239,17 +240,17 @@ public class DLFolderTrashHandler extends DLBaseTrashHandler {
 			ServiceContext serviceContext)
 		throws PortalException {
 
-		Repository repository = getRepository(classPK);
+		LocalRepository localRepository = getLocalRepository(classPK);
 
-		TrashCapability trashCapability = repository.getCapability(
+		TrashCapability trashCapability = localRepository.getCapability(
 			TrashCapability.class);
 
-		Folder folder = repository.getFolder(classPK);
+		Folder folder = localRepository.getFolder(classPK);
 
 		Folder destinationFolder = null;
 
 		if (containerModelId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
-			destinationFolder = repository.getFolder(containerModelId);
+			destinationFolder = localRepository.getFolder(containerModelId);
 		}
 
 		trashCapability.moveFolderFromTrash(
@@ -260,12 +261,12 @@ public class DLFolderTrashHandler extends DLBaseTrashHandler {
 	public void restoreTrashEntry(long userId, long classPK)
 		throws PortalException {
 
-		Repository repository = getRepository(classPK);
+		LocalRepository localRepository = getLocalRepository(classPK);
 
-		TrashCapability trashCapability = repository.getCapability(
+		TrashCapability trashCapability = localRepository.getCapability(
 			TrashCapability.class);
 
-		Folder folder = repository.getFolder(classPK);
+		Folder folder = localRepository.getFolder(classPK);
 
 		trashCapability.restoreFolderFromTrash(userId, folder);
 	}
@@ -326,17 +327,19 @@ public class DLFolderTrashHandler extends DLBaseTrashHandler {
 	}
 
 	@Override
-	protected Repository getRepository(long classPK) throws PortalException {
-		Repository repository = RepositoryProviderUtil.getFolderRepository(
-			classPK);
+	protected LocalRepository getLocalRepository(long classPK)
+		throws PortalException {
 
-		if (!repository.isCapabilityProvided(TrashCapability.class)) {
+		LocalRepository localRepository =
+			RepositoryProviderUtil.getFolderLocalRepository(classPK);
+
+		if (!localRepository.isCapabilityProvided(TrashCapability.class)) {
 			throw new InvalidRepositoryException(
-				"Repository " + repository.getRepositoryId() +
+				"LocalRepository " + localRepository.getRepositoryId() +
 					" does not support trash operations");
 		}
 
-		return repository;
+		return localRepository;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/trash/service/http/TrashEntryServiceHttp.java
+++ b/portal-impl/src/com/liferay/portlet/trash/service/http/TrashEntryServiceHttp.java
@@ -226,6 +226,38 @@ public class TrashEntryServiceHttp {
 		}
 	}
 
+	public static java.util.List<com.liferay.portlet.trash.model.TrashEntry> getEntries(
+		HttpPrincipal httpPrincipal, long groupId, java.lang.String className)
+		throws com.liferay.portal.security.auth.PrincipalException {
+		try {
+			MethodKey methodKey = new MethodKey(TrashEntryServiceUtil.class,
+					"getEntries", _getEntriesParameterTypes6);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
+					className);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.security.auth.PrincipalException) {
+					throw (com.liferay.portal.security.auth.PrincipalException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return (java.util.List<com.liferay.portlet.trash.model.TrashEntry>)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
 	public static void moveEntry(HttpPrincipal httpPrincipal,
 		java.lang.String className, long classPK,
 		long destinationContainerModelId,
@@ -233,7 +265,7 @@ public class TrashEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(TrashEntryServiceUtil.class,
-					"moveEntry", _moveEntryParameterTypes6);
+					"moveEntry", _moveEntryParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					className, classPK, destinationContainerModelId,
@@ -262,7 +294,7 @@ public class TrashEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(TrashEntryServiceUtil.class,
-					"restoreEntry", _restoreEntryParameterTypes7);
+					"restoreEntry", _restoreEntryParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId);
 
@@ -294,7 +326,7 @@ public class TrashEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(TrashEntryServiceUtil.class,
-					"restoreEntry", _restoreEntryParameterTypes8);
+					"restoreEntry", _restoreEntryParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId,
 					overrideClassPK, name);
@@ -326,7 +358,7 @@ public class TrashEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(TrashEntryServiceUtil.class,
-					"restoreEntry", _restoreEntryParameterTypes9);
+					"restoreEntry", _restoreEntryParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					className, classPK);
@@ -359,7 +391,7 @@ public class TrashEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(TrashEntryServiceUtil.class,
-					"restoreEntry", _restoreEntryParameterTypes10);
+					"restoreEntry", _restoreEntryParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					className, classPK, overrideClassPK, name);
@@ -406,20 +438,23 @@ public class TrashEntryServiceHttp {
 			long.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _moveEntryParameterTypes6 = new Class[] {
+	private static final Class<?>[] _getEntriesParameterTypes6 = new Class[] {
+			long.class, java.lang.String.class
+		};
+	private static final Class<?>[] _moveEntryParameterTypes7 = new Class[] {
 			java.lang.String.class, long.class, long.class,
 			com.liferay.portal.service.ServiceContext.class
 		};
-	private static final Class<?>[] _restoreEntryParameterTypes7 = new Class[] {
+	private static final Class<?>[] _restoreEntryParameterTypes8 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _restoreEntryParameterTypes8 = new Class[] {
+	private static final Class<?>[] _restoreEntryParameterTypes9 = new Class[] {
 			long.class, long.class, java.lang.String.class
 		};
-	private static final Class<?>[] _restoreEntryParameterTypes9 = new Class[] {
+	private static final Class<?>[] _restoreEntryParameterTypes10 = new Class[] {
 			java.lang.String.class, long.class
 		};
-	private static final Class<?>[] _restoreEntryParameterTypes10 = new Class[] {
+	private static final Class<?>[] _restoreEntryParameterTypes11 = new Class[] {
 			java.lang.String.class, long.class, long.class,
 			java.lang.String.class
 		};

--- a/portal-impl/src/com/liferay/portlet/trash/service/http/TrashEntryServiceSoap.java
+++ b/portal-impl/src/com/liferay/portlet/trash/service/http/TrashEntryServiceSoap.java
@@ -205,6 +205,21 @@ public class TrashEntryServiceSoap {
 		}
 	}
 
+	public static com.liferay.portlet.trash.model.TrashEntrySoap[] getEntries(
+		long groupId, java.lang.String className) throws RemoteException {
+		try {
+			java.util.List<com.liferay.portlet.trash.model.TrashEntry> returnValue =
+				TrashEntryServiceUtil.getEntries(groupId, className);
+
+			return com.liferay.portlet.trash.model.TrashEntrySoap.toSoapModels(returnValue);
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
 	/**
 	* Moves the trash entry with the entity class name and primary key,
 	* restoring it to a new location identified by the destination container

--- a/portal-impl/src/com/liferay/portlet/trash/service/impl/TrashEntryServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/trash/service/impl/TrashEntryServiceImpl.java
@@ -268,6 +268,40 @@ public class TrashEntryServiceImpl extends TrashEntryServiceBaseImpl {
 		return trashEntriesList;
 	}
 
+	@Override
+	public List<TrashEntry> getEntries(long groupId, String className)
+		throws PrincipalException {
+
+		long classNameId = classNameLocalService.getClassNameId(className);
+
+		List<TrashEntry> entries = trashEntryPersistence.findByG_C(
+			groupId, classNameId);
+
+		List<TrashEntry> filteredEntries = new ArrayList<>();
+
+		PermissionChecker permissionChecker = getPermissionChecker();
+
+		for (TrashEntry entry : entries) {
+			long classPK = entry.getClassPK();
+
+			try {
+				TrashHandler trashHandler =
+					TrashHandlerRegistryUtil.getTrashHandler(className);
+
+				if (trashHandler.hasTrashPermission(
+						permissionChecker, 0, classPK, ActionKeys.VIEW)) {
+
+					filteredEntries.add(entry);
+				}
+			}
+			catch (Exception e) {
+				_log.error(e, e);
+			}
+		}
+
+		return filteredEntries;
+	}
+
 	/**
 	 * Moves the trash entry with the entity class name and primary key,
 	 * restoring it to a new location identified by the destination container

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileEntryService.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileEntryService.java
@@ -236,6 +236,11 @@ public interface DLFileEntryService extends BaseService {
 	public boolean isFileEntryCheckedOut(long fileEntryId)
 		throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public boolean isKeepFileVersionLabel(long fileEntryId,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws PortalException;
+
 	public com.liferay.portlet.documentlibrary.model.DLFileEntry moveFileEntry(
 		long fileEntryId, long newFolderId,
 		com.liferay.portal.service.ServiceContext serviceContext)
@@ -274,6 +279,12 @@ public interface DLFileEntryService extends BaseService {
 		java.util.Map<java.lang.String, com.liferay.portlet.dynamicdatamapping.storage.DDMFormValues> ddmFormValuesMap,
 		java.io.File file, java.io.InputStream is, long size,
 		com.liferay.portal.service.ServiceContext serviceContext)
+		throws PortalException;
+
+	public com.liferay.portlet.documentlibrary.model.DLFileEntry updateStatus(
+		long userId, long fileVersionId, int status,
+		com.liferay.portal.service.ServiceContext serviceContext,
+		java.util.Map<java.lang.String, java.io.Serializable> workflowContext)
 		throws PortalException;
 
 	public boolean verifyFileEntryCheckOut(long fileEntryId,

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileEntryServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileEntryServiceUtil.java
@@ -323,6 +323,12 @@ public class DLFileEntryServiceUtil {
 		return getService().isFileEntryCheckedOut(fileEntryId);
 	}
 
+	public static boolean isKeepFileVersionLabel(long fileEntryId,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return getService().isKeepFileVersionLabel(fileEntryId, serviceContext);
+	}
+
 	public static com.liferay.portlet.documentlibrary.model.DLFileEntry moveFileEntry(
 		long fileEntryId, long newFolderId,
 		com.liferay.portal.service.ServiceContext serviceContext)
@@ -382,6 +388,16 @@ public class DLFileEntryServiceUtil {
 				   .updateFileEntry(fileEntryId, sourceFileName, mimeType,
 			title, description, changeLog, majorVersion, fileEntryTypeId,
 			ddmFormValuesMap, file, is, size, serviceContext);
+	}
+
+	public static com.liferay.portlet.documentlibrary.model.DLFileEntry updateStatus(
+		long userId, long fileVersionId, int status,
+		com.liferay.portal.service.ServiceContext serviceContext,
+		java.util.Map<java.lang.String, java.io.Serializable> workflowContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return getService()
+				   .updateStatus(userId, fileVersionId, status, serviceContext,
+			workflowContext);
 	}
 
 	public static boolean verifyFileEntryCheckOut(long fileEntryId,

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileEntryServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileEntryServiceWrapper.java
@@ -345,6 +345,14 @@ public class DLFileEntryServiceWrapper implements DLFileEntryService,
 	}
 
 	@Override
+	public boolean isKeepFileVersionLabel(long fileEntryId,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return _dlFileEntryService.isKeepFileVersionLabel(fileEntryId,
+			serviceContext);
+	}
+
+	@Override
 	public com.liferay.portlet.documentlibrary.model.DLFileEntry moveFileEntry(
 		long fileEntryId, long newFolderId,
 		com.liferay.portal.service.ServiceContext serviceContext)
@@ -408,6 +416,16 @@ public class DLFileEntryServiceWrapper implements DLFileEntryService,
 		return _dlFileEntryService.updateFileEntry(fileEntryId, sourceFileName,
 			mimeType, title, description, changeLog, majorVersion,
 			fileEntryTypeId, ddmFormValuesMap, file, is, size, serviceContext);
+	}
+
+	@Override
+	public com.liferay.portlet.documentlibrary.model.DLFileEntry updateStatus(
+		long userId, long fileVersionId, int status,
+		com.liferay.portal.service.ServiceContext serviceContext,
+		java.util.Map<java.lang.String, java.io.Serializable> workflowContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return _dlFileEntryService.updateStatus(userId, fileVersionId, status,
+			serviceContext, workflowContext);
 	}
 
 	@Override

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileVersionService.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileVersionService.java
@@ -71,6 +71,10 @@ public interface DLFileVersionService extends BaseService {
 	public com.liferay.portlet.documentlibrary.model.DLFileVersion getLatestFileVersion(
 		long fileEntryId) throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public com.liferay.portlet.documentlibrary.model.DLFileVersion getLatestFileVersion(
+		long fileEntryId, boolean excludeWorkingCopy) throws PortalException;
+
 	/**
 	* Sets the Spring bean ID for this bean.
 	*

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileVersionServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileVersionServiceUtil.java
@@ -73,6 +73,12 @@ public class DLFileVersionServiceUtil {
 		return getService().getLatestFileVersion(fileEntryId);
 	}
 
+	public static com.liferay.portlet.documentlibrary.model.DLFileVersion getLatestFileVersion(
+		long fileEntryId, boolean excludeWorkingCopy)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return getService().getLatestFileVersion(fileEntryId, excludeWorkingCopy);
+	}
+
 	/**
 	* Sets the Spring bean ID for this bean.
 	*

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileVersionServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileVersionServiceWrapper.java
@@ -70,6 +70,14 @@ public class DLFileVersionServiceWrapper implements DLFileVersionService,
 		return _dlFileVersionService.getLatestFileVersion(fileEntryId);
 	}
 
+	@Override
+	public com.liferay.portlet.documentlibrary.model.DLFileVersion getLatestFileVersion(
+		long fileEntryId, boolean excludeWorkingCopy)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return _dlFileVersionService.getLatestFileVersion(fileEntryId,
+			excludeWorkingCopy);
+	}
+
 	/**
 	* Sets the Spring bean ID for this bean.
 	*

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFolderService.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFolderService.java
@@ -110,6 +110,13 @@ public interface DLFolderService extends BaseService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<java.lang.Object> getFoldersAndFileEntriesAndFileShortcuts(
+		long groupId, long folderId, java.lang.String[] mimeTypes,
+		boolean includeMountFolders,
+		com.liferay.portal.kernel.dao.orm.QueryDefinition<?> queryDefinition)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<java.lang.Object> getFoldersAndFileEntriesAndFileShortcuts(
 		long groupId, long folderId, int status, boolean includeMountFolders,
 		int start, int end,
 		com.liferay.portal.kernel.util.OrderByComparator<?> obc)

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFolderServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFolderServiceUtil.java
@@ -136,6 +136,16 @@ public class DLFolderServiceUtil {
 	}
 
 	public static java.util.List<java.lang.Object> getFoldersAndFileEntriesAndFileShortcuts(
+		long groupId, long folderId, java.lang.String[] mimeTypes,
+		boolean includeMountFolders,
+		com.liferay.portal.kernel.dao.orm.QueryDefinition<?> queryDefinition)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return getService()
+				   .getFoldersAndFileEntriesAndFileShortcuts(groupId, folderId,
+			mimeTypes, includeMountFolders, queryDefinition);
+	}
+
+	public static java.util.List<java.lang.Object> getFoldersAndFileEntriesAndFileShortcuts(
 		long groupId, long folderId, int status, boolean includeMountFolders,
 		int start, int end,
 		com.liferay.portal.kernel.util.OrderByComparator<?> obc)

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFolderServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFolderServiceWrapper.java
@@ -137,6 +137,16 @@ public class DLFolderServiceWrapper implements DLFolderService,
 
 	@Override
 	public java.util.List<java.lang.Object> getFoldersAndFileEntriesAndFileShortcuts(
+		long groupId, long folderId, java.lang.String[] mimeTypes,
+		boolean includeMountFolders,
+		com.liferay.portal.kernel.dao.orm.QueryDefinition<?> queryDefinition)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return _dlFolderService.getFoldersAndFileEntriesAndFileShortcuts(groupId,
+			folderId, mimeTypes, includeMountFolders, queryDefinition);
+	}
+
+	@Override
+	public java.util.List<java.lang.Object> getFoldersAndFileEntriesAndFileShortcuts(
 		long groupId, long folderId, int status, boolean includeMountFolders,
 		int start, int end,
 		com.liferay.portal.kernel.util.OrderByComparator<?> obc)

--- a/portal-service/src/com/liferay/portlet/trash/service/TrashEntryService.java
+++ b/portal-service/src/com/liferay/portlet/trash/service/TrashEntryService.java
@@ -126,6 +126,11 @@ public interface TrashEntryService extends BaseService {
 		long groupId)
 		throws com.liferay.portal.security.auth.PrincipalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.trash.model.TrashEntry> getEntries(
+		long groupId, java.lang.String className)
+		throws com.liferay.portal.security.auth.PrincipalException;
+
 	/**
 	* Returns a range of all the trash entries matching the group ID.
 	*

--- a/portal-service/src/com/liferay/portlet/trash/service/TrashEntryServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/trash/service/TrashEntryServiceUtil.java
@@ -127,6 +127,12 @@ public class TrashEntryServiceUtil {
 		return getService().getEntries(groupId);
 	}
 
+	public static java.util.List<com.liferay.portlet.trash.model.TrashEntry> getEntries(
+		long groupId, java.lang.String className)
+		throws com.liferay.portal.security.auth.PrincipalException {
+		return getService().getEntries(groupId, className);
+	}
+
 	/**
 	* Returns a range of all the trash entries matching the group ID.
 	*

--- a/portal-service/src/com/liferay/portlet/trash/service/TrashEntryServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/trash/service/TrashEntryServiceWrapper.java
@@ -124,6 +124,13 @@ public class TrashEntryServiceWrapper implements TrashEntryService,
 		return _trashEntryService.getEntries(groupId);
 	}
 
+	@Override
+	public java.util.List<com.liferay.portlet.trash.model.TrashEntry> getEntries(
+		long groupId, java.lang.String className)
+		throws com.liferay.portal.security.auth.PrincipalException {
+		return _trashEntryService.getEntries(groupId, className);
+	}
+
 	/**
 	* Returns a range of all the trash entries matching the group ID.
 	*

--- a/portal-web/docroot/WEB-INF/remoting-servlet.xml
+++ b/portal-web/docroot/WEB-INF/remoting-servlet.xml
@@ -521,7 +521,7 @@
 		<property name="service" ref="com.liferay.portlet.flags.service.FlagsEntryService" />
 		<property name="serviceInterface" value="com.liferay.portlet.flags.service.FlagsEntryService" />
 	</bean>
-		<bean name="/com_liferay_portlet_messageboards_service_spring_MBBanService-hessian" class="org.springframework.remoting.caucho.HessianServiceExporter">
+	<bean name="/com_liferay_portlet_messageboards_service_spring_MBBanService-hessian" class="org.springframework.remoting.caucho.HessianServiceExporter">
 		<property name="service" ref="com.liferay.portlet.messageboards.service.MBBanService" />
 		<property name="serviceInterface" value="com.liferay.portlet.messageboards.service.MBBanService" />
 	</bean>


### PR DESCRIPTION
@adolfopa Esta es la pull de lo de llamar a los servicios locales/remotos, segun lo que toque, en las capabilities. Esta hecho todo, pero falla el test DLPortletDataHandlerTest.testDeleteAllFolders por un StackOverflowError en LiferayTrashCapability.

El error es porque cuando llamas a los servicios remotos de trash desde un trashandler, el servicio vuelve a llamar al handler y se enbucla. La solucion es usar el LocalRepository desde el trashhandler y nunca el remoto.

Si lo puedes acabar tu bien y si no ya lo hago yo a la vuelta, porque tampoco es urgente.