### PR TITLE
LPS-60404 We should better use mvcRenderCommandName to make sure that we are invoking the render logic.

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/portlet/action/EditFileEntryMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/portlet/action/EditFileEntryMVCActionCommand.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.servlet.ServletResponseConstants;
 import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.servlet.SessionMessages;
 import com.liferay.portal.kernel.upload.LiferayFileItemException;
 import com.liferay.portal.kernel.upload.UploadException;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
@@ -521,6 +522,15 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 				actionResponse.setRenderParameter("mvcPath", "/null.jsp");
 			}
 			else if (cmd.equals(Constants.PREVIEW)) {
+				SessionMessages.add(
+					actionRequest,
+					PortalUtil.getPortletId(actionRequest) +
+						SessionMessages.KEY_SUFFIX_FORCE_SEND_REDIRECT);
+
+				hideDefaultSuccessMessage(actionRequest);
+
+				actionResponse.setRenderParameter(
+					"mvcPath", "/document_library/edit_file_entry.jsp");
 			}
 			else if (!windowState.equals(LiferayWindowState.POP_UP)) {
 			}

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/portlet/action/EditFileEntryMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/portlet/action/EditFileEntryMVCActionCommand.java
@@ -530,7 +530,8 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 				hideDefaultSuccessMessage(actionRequest);
 
 				actionResponse.setRenderParameter(
-					"mvcPath", "/document_library/edit_file_entry.jsp");
+					"mvcRenderCommandName",
+					"/document_library/edit_file_entry");
 			}
 			else if (!windowState.equals(LiferayWindowState.POP_UP)) {
 			}


### PR DESCRIPTION
Buenas Adolfo,

He hecho un cambio a la lógica de Iván pero no me da tiempo a probarla. Yo creo que debería de funcionar seguro pero te lo envío por si acaso para que lo eches un vistazo y lo pruebes antes de enviarlo a Brian.

Si todo funciona bien también estaría guay darse un vistazo a todos los portlets que que estén invocando a actionResponse.setRenderParameter("mvcPath" y ver si no estaría mejor que invocasen a un renderCommandName.

Cualquier cosa me dices.