### PR TITLE
[See description] LPS-58547 Mentions not notifying

### DIFF
--- a/modules/apps/mentions/mentions-service/src/main/java/com/liferay/mentions/service/MentionsMessageServiceWrapper.java
+++ b/modules/apps/mentions/mentions-service/src/main/java/com/liferay/mentions/service/MentionsMessageServiceWrapper.java
@@ -23,6 +23,8 @@ import com.liferay.portal.kernel.module.configuration.ConfigurationFactory;
 import com.liferay.portal.kernel.parsers.bbcode.BBCodeTranslatorUtil;
 import com.liferay.portal.kernel.settings.CompanyServiceSettingsLocator;
 import com.liferay.portal.kernel.settings.LocalizedValuesMap;
+import com.liferay.portal.kernel.util.HtmlUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.service.ServiceContext;
@@ -114,9 +116,15 @@ public class MentionsMessageServiceWrapper
 				"contentURL", workflowContext.get("url"));
 		}
 
+		String title = message.getSubject();
+
+		if (message.isDiscussion()) {
+			title = StringUtil.shorten(HtmlUtil.extractText(content), 100);
+		}
+
 		_mentionsNotifier.notify(
-			message.getUserId(), message.getGroupId(), message.getSubject(),
-			content, message.getModelClassName(), message.getMessageId(),
+			message.getUserId(), message.getGroupId(), title, content,
+			message.getModelClassName(), message.getMessageId(),
 			subjectLocalizedValuesMap, bodyLocalizedValuesMap, serviceContext);
 
 		return message;

--- a/modules/apps/mentions/mentions-service/src/main/java/com/liferay/mentions/util/impl/DefaultMentionsNotifier.java
+++ b/modules/apps/mentions/mentions-service/src/main/java/com/liferay/mentions/util/impl/DefaultMentionsNotifier.java
@@ -184,7 +184,7 @@ public class DefaultMentionsNotifier implements MentionsNotifier {
 	}
 
 	private static final Pattern _pattern = Pattern.compile(
-		"(?:\\s|^|\\]|>)(@([^(?:@|>|\\[|\\s|,|.|<)]+))",
+		"(?:\\s|^|\\]|>)(&#64;([^(?:&#64;|>|\\[|\\s|,|.|<)]+))",
 		Pattern.CASE_INSENSITIVE);
 
 	private MentionsUserFinder _mentionsUserFinder;

--- a/modules/apps/mentions/mentions-service/src/main/java/com/liferay/mentions/util/impl/DefaultMentionsNotifier.java
+++ b/modules/apps/mentions/mentions-service/src/main/java/com/liferay/mentions/util/impl/DefaultMentionsNotifier.java
@@ -184,7 +184,7 @@ public class DefaultMentionsNotifier implements MentionsNotifier {
 	}
 
 	private static final Pattern _pattern = Pattern.compile(
-		"(?:\\s|^|\\]|>)(&#64;([^(?:&#64;|>|\\[|\\s|,|.|<)]+))",
+		"(?:\\s|^|\\]|>)([@|&#64;]([^(?:@|&#64;|>|\\[|\\s|,|.|<)]+))",
 		Pattern.CASE_INSENSITIVE);
 
 	private MentionsUserFinder _mentionsUserFinder;

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -8421,7 +8421,7 @@
     #     allowed-content : element (; element)*
     #         element : element-name | element-name[attribute (, atribute)*]
     #
-    discussion.comments.allowed.content=a[href];em;p;strong;u
+    discussion.comments.allowed.content=a[href];em;p;span[class];strong;u
     #discussion.comments.allowed.content=a[href,title];em;p;strong;u
 
     #


### PR DESCRIPTION
Buenas Adolfo, 

Te envío esta pull que es la que arregla lo de que no envíe notificaciones en los comentario.

El problema de raiz es que hay un sanitizer para asegurar qeu los comentarios sólo aceptan un marcado específico y ese sanitizer está escapando el texto por motivos de seguridad (además de elimianr el marcado de tags que no está soportado). Entonces, cuando el usuario escribe "Hola @test1" al escaparse resulta en algo tal que "Hola &#64;test1" por lo que hay que actualizar la expresión regular para que soporte este caso.

La expresión tiene que aceptar los dos, tanto la @ como el caracter HTML porque en blogs y message boards necesitamos la @ pero con comentarios el carácter html.

En el primer commit he incluido una etiqueta span que se estaba cargando y que necesitamos.
En el segundo commit cambio la @ por el caracter html y funciona guay. Sin embargo, también necesitamos la @ así que la he intentando poner en el úlitmo commit con un OR pero sin exito porque peta, y mis conocimientos de regex es bastante bajo, así que espero que puedas arreglarlo :)

Habría que probarlo en Comentarios, Message Boards y Blogs. En las pruebas hay que mencionar a otro usuario (si te mencionas a ti mismo no funciona) y hay que ver que la notificación llega correctamente en los tres casos y que el texto que aparece en la notificación es el bueno (que es lo que arreglo en el tercer commit) así como que el enlace apunta al sitio correcto.

Cualquier cosa me envías un mail o x slack me escribes aunque no esté conectado porque me conectaré a ratos.

Gracias!