### PR TITLE
[TECHNICAL-SUPPORT] LPS-68710

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/util/KBArticleURLHelper.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/util/KBArticleURLHelper.java
@@ -27,6 +27,8 @@ import javax.portlet.PortletURL;
 import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
 
+import javax.servlet.http.HttpServletRequest;
+
 /**
  * @author Adolfo Pérez
  */
@@ -59,8 +61,12 @@ public class KBArticleURLHelper {
 		if (portletId.startsWith(KBPortletKeys.KNOWLEDGE_BASE_ADMIN) ||
 			portletId.startsWith(KBPortletKeys.KNOWLEDGE_BASE_SEARCH)) {
 
+			HttpServletRequest httpServletRequest =
+				PortalUtil.getHttpServletRequest(_renderRequest);
+
 			portletURL.setParameter(
-				"redirect", PortalUtil.getCurrentURL(_renderRequest));
+				"redirect",
+				PortalUtil.getCurrentCompleteURL(httpServletRequest));
 		}
 
 		if (Validator.isNull(kbArticle.getUrlTitle()) ||

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/BaseKBPortlet.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/BaseKBPortlet.java
@@ -211,6 +211,43 @@ public abstract class BaseKBPortlet extends MVCPortlet {
 		writeJSON(actionRequest, actionResponse, jsonObject);
 	}
 
+	@Override
+	public String getRedirect(
+		ActionRequest actionRequest, ActionResponse actionResponse) {
+
+		String originalUrl = super.getRedirect(actionRequest, actionResponse);
+		String namespace = actionResponse.getNamespace();
+
+		String redirectParamName = namespace + "redirect";
+
+		// LPS-68710 Prevent the redirect parameter from getting too long
+		// (invalid) by using the embedded redirect URL within the redirect
+		// parameter, if it exists.
+
+		String redirectUrl = HttpUtil.getParameter(
+			originalUrl, redirectParamName, false);
+
+		if ((redirectUrl == null) || redirectUrl.isEmpty()) {
+			return originalUrl;
+		}
+
+		redirectUrl = HttpUtil.decodeURL(redirectUrl);
+
+		String prevRedirectUrl = HttpUtil.getParameter(
+			redirectUrl, redirectParamName, false);
+
+		if ((prevRedirectUrl == null) || prevRedirectUrl.isEmpty()) {
+			return originalUrl;
+		}
+
+		prevRedirectUrl = HttpUtil.decodeURL(prevRedirectUrl);
+
+		String newUrl = HttpUtil.setParameter(
+			originalUrl, redirectParamName, prevRedirectUrl);
+
+		return newUrl;
+	}
+
 	public void moveKBObject(
 			ActionRequest actionRequest, ActionResponse actionResponse)
 		throws Exception {

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/BaseKBPortlet.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/BaseKBPortlet.java
@@ -218,34 +218,28 @@ public abstract class BaseKBPortlet extends MVCPortlet {
 		String originalUrl = super.getRedirect(actionRequest, actionResponse);
 		String namespace = actionResponse.getNamespace();
 
-		String redirectParamName = namespace + "redirect";
+		String redirectParameter = namespace + "redirect";
 
-		// LPS-68710 Prevent the redirect parameter from getting too long
-		// (invalid) by using the embedded redirect URL within the redirect
-		// parameter, if it exists.
+		String redirect = HttpUtil.getParameter(
+			originalUrl, redirectParameter, false);
 
-		String redirectUrl = HttpUtil.getParameter(
-			originalUrl, redirectParamName, false);
-
-		if ((redirectUrl == null) || redirectUrl.isEmpty()) {
+		if (Validator.isNull(redirect)) {
 			return originalUrl;
 		}
 
-		redirectUrl = HttpUtil.decodeURL(redirectUrl);
+		redirect = HttpUtil.decodeURL(redirect);
 
-		String prevRedirectUrl = HttpUtil.getParameter(
-			redirectUrl, redirectParamName, false);
+		String oldRedirect = HttpUtil.getParameter(
+			redirect, redirectParameter, false);
 
-		if ((prevRedirectUrl == null) || prevRedirectUrl.isEmpty()) {
+		if (Validator.isNull(oldRedirect)) {
 			return originalUrl;
 		}
 
-		prevRedirectUrl = HttpUtil.decodeURL(prevRedirectUrl);
+		oldRedirect = HttpUtil.decodeURL(oldRedirect);
 
-		String newUrl = HttpUtil.setParameter(
-			originalUrl, redirectParamName, prevRedirectUrl);
-
-		return newUrl;
+		return HttpUtil.setParameter(
+			originalUrl, redirectParameter, oldRedirect);
 	}
 
 	public void moveKBObject(


### PR DESCRIPTION
From @SGM3 

>My analysis of the issue shows that there were roughly two problem areas.

>The first was the child KB article seemed to place a (relative path) URL as the redirect which affected the back button functionality and what page is loaded on submit. This is dependent on the page used to access the child KB. Setting a full path URL seems to all unify the behavior and correct the functionality for the most part. Back button functionality was still broken, but you were still able to submit suggestions, until the URL became too long. This was covered in the first commit

>The second issue is what the I had mentioned last. The portlet was appending the current URL (with the current redirect parameter) to the new URL redirect parameter. The back button relied on the embedded redirect parameter it seemed and the URL itself was getting too long. This was covered in the second commit.