### PR TITLE
LPS-70167 Knowledge Base - Import fails with KBArticleURLTitleException when only the latest version is exported/imported

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/exportimport/data/handler/KBArticleStagedModelDataHandler.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/exportimport/data/handler/KBArticleStagedModelDataHandler.java
@@ -281,6 +281,22 @@ public class KBArticleStagedModelDataHandler
 					resourcePrimaryKey, portletDataContext.getScopeGroupId());
 
 				if (existingKBArticle == null) {
+					Map<Long, Long> kbFolderIds =
+						(Map<Long, Long>)portletDataContext.
+							getNewPrimaryKeysMap(KBFolder.class);
+
+					long kbFolderId = MapUtil.getLong(
+						kbFolderIds, kbArticle.getKbFolderId(),
+						kbArticle.getKbFolderId());
+
+					existingKBArticle =
+						_kbArticleLocalService.fetchLatestKBArticleByUrlTitle(
+							portletDataContext.getScopeGroupId(), kbFolderId,
+							kbArticle.getUrlTitle(),
+							WorkflowConstants.STATUS_ANY);
+				}
+
+				if (existingKBArticle == null) {
 					importedKBArticle = _kbArticleLocalService.addKBArticle(
 						userId, kbArticle.getParentResourceClassNameId(),
 						parentResourcePrimKey, kbArticle.getTitle(),


### PR DESCRIPTION
Hi Adolfo,

the reproduction steps are a bit fishy, this issue is about importing **only** a new version of an already existing article.

In this case, the import process doesn't realize that the new article version belongs to a previously imported version.

It's working fine when all of the article versions are exported/imported, because e.g. when version 1 is imported, it populates the **kbArticleResourcePrimKeys** map, therefore when version 2 is imported, the proper **resourcePrimaryKey** is found.
It is also working when we publish from the last publish date, as in that case, the previous version will be exported/imported as well, because it was modified (the main field was set to false.)

So the problem is, **what we should do when only a new article version is imported?**

Right now, it is not straightforward to have this use case, but once we will have the missing *_ExportImportPortletPreferencesProcessor_ for the Article and the Display portlets, we will face this problem all the time, as only the latest approved version will be exported/imported.

I think the best solution would be to introduce a new kbArticleResource entity, like we already have journalArticleResource, which is responsible to solve this problem, and connect the different versions.

However, as it would require quite big changes, I looked for some alternatives.
I realized that the /groupId, parentKBFolderId, urlTitle/ trio is unique, therefore we can use it to fetch the already existing article.
If the article belongs to a folder, the folder will be always imported first, so we can use the _kbFolderIds_ map safely.

Sorry for the long description, could you please review the changes?

cc @sorin-pop

Thanks,
Tamás