### PR TITLE
LPS-68974 Implement PortletDataHandler&ExportImportPortletPreferencesProcessor for KB Display and KB Article portlets

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/build.gradle
+++ b/modules/apps/knowledge-base/knowledge-base-web/build.gradle
@@ -3,6 +3,8 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.application.list.api", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.document.library.api", version: "3.0.0"
 	provided group: "com.liferay", name: "com.liferay.expando.taglib", version: "1.0.0"
+	provided group: "com.liferay", name: "com.liferay.exportimport.api", version: "2.0.0"
+	provided group: "com.liferay", name: "com.liferay.exportimport.service", version: "3.0.0"
 	provided group: "com.liferay", name: "com.liferay.frontend.taglib", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.knowledge.base.api", version: "4.6.0"
 	provided group: "com.liferay", name: "com.liferay.knowledge.base.service", version: "1.1.0"

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/lar/KBArticleExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/lar/KBArticleExportImportPortletPreferencesProcessor.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.knowledge.base.web.internal.lar;
+
+import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.exportimport.kernel.lar.PortletDataException;
+import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
+import com.liferay.exportimport.portlet.preferences.processor.Capability;
+import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
+import com.liferay.exportimport.portlet.preferences.processor.capability.ReferencedStagedModelImporterCapability;
+import com.liferay.knowledge.base.constants.KBArticleConstants;
+import com.liferay.knowledge.base.constants.KBPortletKeys;
+import com.liferay.knowledge.base.model.KBArticle;
+import com.liferay.knowledge.base.service.KBArticleLocalService;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.portlet.PortletPreferences;
+import javax.portlet.ReadOnlyException;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Sorin Pop
+ */
+@Component(
+	immediate = true,
+	property = {"javax.portlet.name=" + KBPortletKeys.KNOWLEDGE_BASE_ARTICLE},
+	service = ExportImportPortletPreferencesProcessor.class
+)
+public class KBArticleExportImportPortletPreferencesProcessor
+	implements ExportImportPortletPreferencesProcessor {
+
+	@Override
+	public List<Capability> getExportCapabilities() {
+		return null;
+	}
+
+	@Override
+	public List<Capability> getImportCapabilities() {
+		return ListUtil.toList(
+			new Capability[] {_referencedStagedModelImporterCapability});
+	}
+
+	@Override
+	public PortletPreferences processExportPortletPreferences(
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences)
+		throws PortletDataException {
+
+		long resourcePrimKey = GetterUtil.getLong(
+			portletPreferences.getValue("resourcePrimKey", StringPool.BLANK));
+
+		if (resourcePrimKey !=
+				KBArticleConstants.DEFAULT_PARENT_RESOURCE_PRIM_KEY) {
+
+			List<KBArticle> kbArticles =
+				_kbArticleLocalService.getKBArticleAndAllDescendantKBArticles(
+					resourcePrimKey, WorkflowConstants.STATUS_APPROVED, null);
+
+			for (KBArticle kbArticle : kbArticles) {
+				StagedModelDataHandlerUtil.exportReferenceStagedModel(
+					portletDataContext, portletDataContext.getPortletId(),
+					kbArticle);
+			}
+		}
+
+		return portletPreferences;
+	}
+
+	@Override
+	public PortletPreferences processImportPortletPreferences(
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences)
+		throws PortletDataException {
+
+		long resourcePrimKey = GetterUtil.getLong(
+			portletPreferences.getValue("resourcePrimKey", StringPool.BLANK));
+
+		Map<Long, Long> kbArticleResourcePrimKeys =
+			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
+				KBArticle.class);
+
+		resourcePrimKey = MapUtil.getLong(
+			kbArticleResourcePrimKeys, resourcePrimKey, resourcePrimKey);
+
+		try {
+			portletPreferences.setValue(
+				"resourcePrimKey", String.valueOf(resourcePrimKey));
+		}
+		catch (ReadOnlyException roe) {
+			StringBundler sb = new StringBundler(8);
+
+			sb.append("Unable to save converted portlet preference ");
+			sb.append("resourcePrimKey=");
+			sb.append(resourcePrimKey);
+			sb.append(" (the root article)  ");
+			sb.append("while importing KB Article portlet. ");
+			sb.append("(portletId=");
+			sb.append(portletDataContext.getPortletId());
+			sb.append(")");
+
+			throw new PortletDataException(sb.toString(), roe);
+		}
+
+		return portletPreferences;
+	}
+
+	@Reference(unbind = "-")
+	protected void seKBArticleLocalService(
+		KBArticleLocalService kbArticleLocalService) {
+
+		_kbArticleLocalService = kbArticleLocalService;
+	}
+
+	@Reference(unbind = "-")
+	protected void setReferencedStagedModelImporterCapability(
+		ReferencedStagedModelImporterCapability
+			referencedStagedModelImporterCapability) {
+
+		_referencedStagedModelImporterCapability =
+			referencedStagedModelImporterCapability;
+	}
+
+	private KBArticleLocalService _kbArticleLocalService;
+	private ReferencedStagedModelImporterCapability
+		_referencedStagedModelImporterCapability;
+
+}

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/lar/KBArticlePortletDataHandler.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/lar/KBArticlePortletDataHandler.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.knowledge.base.web.internal.lar;
+
+import com.liferay.exportimport.kernel.lar.BasePortletDataHandler;
+import com.liferay.exportimport.kernel.lar.DataLevel;
+import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.exportimport.kernel.lar.PortletDataHandler;
+import com.liferay.exportimport.kernel.lar.PortletDataHandlerControl;
+import com.liferay.knowledge.base.constants.KBPortletKeys;
+import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
+import com.liferay.portal.kernel.util.StringPool;
+
+import javax.portlet.PortletPreferences;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Sorin Pop
+ * @author Tamas Molnar
+ */
+@Component(
+	property = {"javax.portlet.name=" + KBPortletKeys.KNOWLEDGE_BASE_ARTICLE},
+	service = PortletDataHandler.class
+)
+public class KBArticlePortletDataHandler extends BasePortletDataHandler {
+
+	public static final String SCHEMA_VERSION = "1.0.0";
+
+	@Override
+	public String getSchemaVersion() {
+		return SCHEMA_VERSION;
+	}
+
+	@Activate
+	protected void activate() {
+		setDataLevel(DataLevel.PORTLET_INSTANCE);
+		setDataPortletPreferences("resourcePrimKey");
+		setExportControls(new PortletDataHandlerControl[0]);
+	}
+
+	@Override
+	protected PortletPreferences doDeleteData(
+			PortletDataContext portletDataContext, String portletId,
+			PortletPreferences portletPreferences)
+		throws Exception {
+
+		portletPreferences.setValue("resourcePrimKey", StringPool.BLANK);
+
+		return portletPreferences;
+	}
+
+	@Reference(target = ModuleServiceLifecycle.PORTAL_INITIALIZED, unbind = "-")
+	protected void setModuleServiceLifecycle(
+		ModuleServiceLifecycle moduleServiceLifecycle) {
+	}
+
+}

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/lar/KBDisplayExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/lar/KBDisplayExportImportPortletPreferencesProcessor.java
@@ -1,0 +1,235 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.knowledge.base.web.internal.lar;
+
+import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.exportimport.kernel.lar.PortletDataException;
+import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
+import com.liferay.exportimport.portlet.preferences.processor.Capability;
+import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
+import com.liferay.exportimport.portlet.preferences.processor.capability.ReferencedStagedModelImporterCapability;
+import com.liferay.knowledge.base.constants.KBArticleConstants;
+import com.liferay.knowledge.base.constants.KBFolderConstants;
+import com.liferay.knowledge.base.constants.KBPortletKeys;
+import com.liferay.knowledge.base.model.KBArticle;
+import com.liferay.knowledge.base.model.KBFolder;
+import com.liferay.knowledge.base.service.KBArticleLocalService;
+import com.liferay.knowledge.base.service.KBFolderLocalService;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.portlet.PortletPreferences;
+import javax.portlet.ReadOnlyException;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Sorin Pop
+ */
+@Component(
+	immediate = true,
+	property = {"javax.portlet.name=" + KBPortletKeys.KNOWLEDGE_BASE_DISPLAY},
+	service = ExportImportPortletPreferencesProcessor.class
+)
+public class KBDisplayExportImportPortletPreferencesProcessor
+	implements ExportImportPortletPreferencesProcessor {
+
+	@Override
+	public List<Capability> getExportCapabilities() {
+		return null;
+	}
+
+	@Override
+	public List<Capability> getImportCapabilities() {
+		return ListUtil.toList(
+			new Capability[] {_referencedStagedModelImporterCapability});
+	}
+
+	@Override
+	public PortletPreferences processExportPortletPreferences(
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences)
+		throws PortletDataException {
+
+		long resourcePrimKey = GetterUtil.getLong(
+			portletPreferences.getValue("resourcePrimKey", StringPool.BLANK));
+
+		long resourceClassNameId = GetterUtil.getLong(
+			portletPreferences.getValue(
+				"resourceClassNameId", StringPool.BLANK));
+
+		String resourceClassName = PortalUtil.getClassName(resourceClassNameId);
+
+		try {
+			portletPreferences.setValue(
+				"resourceClassNameId", resourceClassName);
+		}
+		catch (ReadOnlyException roe) {
+			StringBundler sb = new StringBundler(9);
+
+			sb.append("Unable to save converted portlet preference ");
+			sb.append("resourceClassNameId (from ");
+			sb.append(resourceClassNameId);
+			sb.append(" to ");
+			sb.append(resourceClassName);
+			sb.append(") while exporting KB Display portlet. ");
+			sb.append("(portletId=");
+			sb.append(portletDataContext.getPortletId());
+			sb.append(")");
+
+			throw new PortletDataException(sb.toString(), roe);
+		}
+
+		if (resourceClassName.equals(KBArticleConstants.getClassName())) {
+			if (resourcePrimKey !=
+					KBArticleConstants.DEFAULT_PARENT_RESOURCE_PRIM_KEY) {
+
+				List<KBArticle> kbArticles =
+					_kbArticleLocalService.
+						getKBArticleAndAllDescendantKBArticles(
+							resourcePrimKey, WorkflowConstants.STATUS_APPROVED,
+							null);
+
+				for (KBArticle kbArticle : kbArticles) {
+					StagedModelDataHandlerUtil.exportReferenceStagedModel(
+						portletDataContext, portletDataContext.getPortletId(),
+						kbArticle);
+				}
+			}
+		}
+		else if (resourceClassName.equals(KBFolderConstants.getClassName())) {
+			if (resourcePrimKey != KBFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+				KBFolder rootFolder = _kbFolderLocalService.fetchKBFolder(
+					resourcePrimKey);
+
+				StagedModelDataHandlerUtil.exportReferenceStagedModel(
+					portletDataContext, portletDataContext.getPortletId(),
+					rootFolder);
+			}
+		}
+
+		return portletPreferences;
+	}
+
+	@Override
+	public PortletPreferences processImportPortletPreferences(
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences)
+		throws PortletDataException {
+
+		String resourceClassName = GetterUtil.getString(
+			portletPreferences.getValue(
+				"resourceClassNameId", StringPool.BLANK));
+
+		try {
+			portletPreferences.setValue(
+				"resourceClassNameId",
+				String.valueOf(PortalUtil.getClassNameId(resourceClassName)));
+		}
+		catch (ReadOnlyException roe) {
+			StringBundler sb = new StringBundler(9);
+
+			sb.append("Unable to save reconverted portlet preference ");
+			sb.append("resourceClassNameId (from ");
+			sb.append(resourceClassName);
+			sb.append(" to ");
+			sb.append(PortalUtil.getClassNameId(resourceClassName));
+			sb.append(") while importing KB Display portlet. ");
+			sb.append("(portletId=");
+			sb.append(portletDataContext.getPortletId());
+			sb.append(")");
+
+			throw new PortletDataException(sb.toString(), roe);
+		}
+
+		long resourcePrimKey = GetterUtil.getLong(
+			portletPreferences.getValue("resourcePrimKey", StringPool.BLANK));
+
+		Map<Long, Long> resourcePrimKeys = new HashMap<>();
+
+		if (resourceClassName.equals(KBArticleConstants.getClassName())) {
+			resourcePrimKeys =
+				(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
+					KBArticle.class);
+		}
+		else if (resourceClassName.equals(KBFolderConstants.getClassName())) {
+			resourcePrimKeys =
+				(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
+					KBFolder.class);
+		}
+
+		resourcePrimKey = MapUtil.getLong(
+			resourcePrimKeys, resourcePrimKey, resourcePrimKey);
+
+		try {
+			portletPreferences.setValue(
+				"resourcePrimKey", String.valueOf(resourcePrimKey));
+		}
+		catch (ReadOnlyException roe) {
+			StringBundler sb = new StringBundler(7);
+
+			sb.append("Unable to save converted portlet preference ");
+			sb.append("resourcePrimKey=");
+			sb.append(resourcePrimKey);
+			sb.append(" while importing KB Display portlet. ");
+			sb.append("(portletId=");
+			sb.append(portletDataContext.getPortletId());
+			sb.append(")");
+
+			throw new PortletDataException(sb.toString(), roe);
+		}
+
+		return portletPreferences;
+	}
+
+	@Reference(unbind = "-")
+	protected void seKBArticleLocalService(
+		KBArticleLocalService kbArticleLocalService) {
+
+		_kbArticleLocalService = kbArticleLocalService;
+	}
+
+	@Reference(unbind = "-")
+	protected void seKBFolderLocalService(
+		KBFolderLocalService kbFolderLocalService) {
+
+		_kbFolderLocalService = kbFolderLocalService;
+	}
+
+	@Reference(unbind = "-")
+	protected void setReferencedStagedModelImporterCapability(
+		ReferencedStagedModelImporterCapability
+			referencedStagedModelImporterCapability) {
+
+		_referencedStagedModelImporterCapability =
+			referencedStagedModelImporterCapability;
+	}
+
+	private KBArticleLocalService _kbArticleLocalService;
+	private KBFolderLocalService _kbFolderLocalService;
+	private ReferencedStagedModelImporterCapability
+		_referencedStagedModelImporterCapability;
+
+}

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/lar/KBDisplayPortletDataHandler.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/lar/KBDisplayPortletDataHandler.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.knowledge.base.web.internal.lar;
+
+import com.liferay.exportimport.kernel.lar.BasePortletDataHandler;
+import com.liferay.exportimport.kernel.lar.DataLevel;
+import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.exportimport.kernel.lar.PortletDataHandler;
+import com.liferay.exportimport.kernel.lar.PortletDataHandlerControl;
+import com.liferay.knowledge.base.constants.KBPortletKeys;
+import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
+import com.liferay.portal.kernel.util.StringPool;
+
+import javax.portlet.PortletPreferences;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Sorin Pop
+ * @author Tamas Molnar
+ */
+@Component(
+	property = {"javax.portlet.name=" + KBPortletKeys.KNOWLEDGE_BASE_DISPLAY},
+	service = PortletDataHandler.class
+)
+public class KBDisplayPortletDataHandler extends BasePortletDataHandler {
+
+	public static final String SCHEMA_VERSION = "1.0.0";
+
+	@Override
+	public String getSchemaVersion() {
+		return SCHEMA_VERSION;
+	}
+
+	@Activate
+	protected void activate() {
+		setDataLevel(DataLevel.PORTLET_INSTANCE);
+		setDataPortletPreferences("resourceClassNameId", "resourcePrimKey");
+		setExportControls(new PortletDataHandlerControl[0]);
+	}
+
+	@Override
+	protected PortletPreferences doDeleteData(
+			PortletDataContext portletDataContext, String portletId,
+			PortletPreferences portletPreferences)
+		throws Exception {
+
+		portletPreferences.setValue("resourceClassNameId", StringPool.BLANK);
+		portletPreferences.setValue("resourcePrimKey", StringPool.BLANK);
+
+		return portletPreferences;
+	}
+
+	@Reference(target = ModuleServiceLifecycle.PORTAL_INITIALIZED, unbind = "-")
+	protected void setModuleServiceLifecycle(
+		ModuleServiceLifecycle moduleServiceLifecycle) {
+	}
+
+}


### PR DESCRIPTION
Hi Adolfo,

Could you please review these implementations?

Notes:

1. In processExportPortletPreferences() we used getKBArticleAndAllDescendantKBArticles() in order to fetch the articles to be exported by the portlet. As we see, this method only fetches the main version of every KB article - and this seems consistent to what the WC Display portlet is doing, which is exporting the last approved version of the displayed article. However, please let us know if this is not proper.

2. Regarding what the KB Display portlet should export if it is set to point to a KB Folder, we eventually decided to only export that folder, without its contents and subfolders, because:
- potentially there could be many many subfolders and articles (and sub-articles) under a folder, which would result in the export of a KB Display portlet to run for a long time and export a lot of entities with it, which ultimately doesn't really seem to be what we want to happen when we export a KB Display portlet.
- we noticed that this issue is similarly handled when exporting a DL portlets

Cc: @moltam89

Thanks.