### PR TITLE
LPS-67246 Autogenerated

### DIFF
--- a/modules/apps/collaboration/subscription/subscription-api/src/main/java/com/liferay/subscription/service/SubscriptionLocalService.java
+++ b/modules/apps/collaboration/subscription/subscription-api/src/main/java/com/liferay/subscription/service/SubscriptionLocalService.java
@@ -383,6 +383,8 @@ public interface SubscriptionLocalService extends BaseLocalService,
 	public long dynamicQueryCount(DynamicQuery dynamicQuery,
 		Projection projection);
 
+	public void deleteGroupSubscriptions(long groupId);
+
 	/**
 	* Deletes the user's subscription to the entity. A social activity with the
 	* unsubscribe action is created.

--- a/modules/apps/collaboration/subscription/subscription-api/src/main/java/com/liferay/subscription/service/SubscriptionLocalServiceUtil.java
+++ b/modules/apps/collaboration/subscription/subscription-api/src/main/java/com/liferay/subscription/service/SubscriptionLocalServiceUtil.java
@@ -431,6 +431,10 @@ public class SubscriptionLocalServiceUtil {
 		return getService().dynamicQueryCount(dynamicQuery, projection);
 	}
 
+	public static void deleteGroupSubscriptions(long groupId) {
+		getService().deleteGroupSubscriptions(groupId);
+	}
+
 	/**
 	* Deletes the user's subscription to the entity. A social activity with the
 	* unsubscribe action is created.

--- a/modules/apps/collaboration/subscription/subscription-api/src/main/java/com/liferay/subscription/service/SubscriptionLocalServiceWrapper.java
+++ b/modules/apps/collaboration/subscription/subscription-api/src/main/java/com/liferay/subscription/service/SubscriptionLocalServiceWrapper.java
@@ -457,6 +457,11 @@ public class SubscriptionLocalServiceWrapper implements SubscriptionLocalService
 			projection);
 	}
 
+	@Override
+	public void deleteGroupSubscriptions(long groupId) {
+		_subscriptionLocalService.deleteGroupSubscriptions(groupId);
+	}
+
 	/**
 	* Deletes the user's subscription to the entity. A social activity with the
 	* unsubscribe action is created.

--- a/modules/apps/collaboration/subscription/subscription-api/src/main/java/com/liferay/subscription/service/persistence/SubscriptionPersistence.java
+++ b/modules/apps/collaboration/subscription/subscription-api/src/main/java/com/liferay/subscription/service/persistence/SubscriptionPersistence.java
@@ -42,6 +42,137 @@ public interface SubscriptionPersistence extends BasePersistence<Subscription> {
 	 */
 
 	/**
+	* Returns all the subscriptions where groupId = &#63;.
+	*
+	* @param groupId the group ID
+	* @return the matching subscriptions
+	*/
+	public java.util.List<Subscription> findByG(long groupId);
+
+	/**
+	* Returns a range of all the subscriptions where groupId = &#63;.
+	*
+	* <p>
+	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link SubscriptionModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	* </p>
+	*
+	* @param groupId the group ID
+	* @param start the lower bound of the range of subscriptions
+	* @param end the upper bound of the range of subscriptions (not inclusive)
+	* @return the range of matching subscriptions
+	*/
+	public java.util.List<Subscription> findByG(long groupId, int start, int end);
+
+	/**
+	* Returns an ordered range of all the subscriptions where groupId = &#63;.
+	*
+	* <p>
+	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link SubscriptionModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	* </p>
+	*
+	* @param groupId the group ID
+	* @param start the lower bound of the range of subscriptions
+	* @param end the upper bound of the range of subscriptions (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return the ordered range of matching subscriptions
+	*/
+	public java.util.List<Subscription> findByG(long groupId, int start,
+		int end,
+		com.liferay.portal.kernel.util.OrderByComparator<Subscription> orderByComparator);
+
+	/**
+	* Returns an ordered range of all the subscriptions where groupId = &#63;.
+	*
+	* <p>
+	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link SubscriptionModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	* </p>
+	*
+	* @param groupId the group ID
+	* @param start the lower bound of the range of subscriptions
+	* @param end the upper bound of the range of subscriptions (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @param retrieveFromCache whether to retrieve from the finder cache
+	* @return the ordered range of matching subscriptions
+	*/
+	public java.util.List<Subscription> findByG(long groupId, int start,
+		int end,
+		com.liferay.portal.kernel.util.OrderByComparator<Subscription> orderByComparator,
+		boolean retrieveFromCache);
+
+	/**
+	* Returns the first subscription in the ordered set where groupId = &#63;.
+	*
+	* @param groupId the group ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the first matching subscription
+	* @throws NoSuchSubscriptionException if a matching subscription could not be found
+	*/
+	public Subscription findByG_First(long groupId,
+		com.liferay.portal.kernel.util.OrderByComparator<Subscription> orderByComparator)
+		throws NoSuchSubscriptionException;
+
+	/**
+	* Returns the first subscription in the ordered set where groupId = &#63;.
+	*
+	* @param groupId the group ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the first matching subscription, or <code>null</code> if a matching subscription could not be found
+	*/
+	public Subscription fetchByG_First(long groupId,
+		com.liferay.portal.kernel.util.OrderByComparator<Subscription> orderByComparator);
+
+	/**
+	* Returns the last subscription in the ordered set where groupId = &#63;.
+	*
+	* @param groupId the group ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the last matching subscription
+	* @throws NoSuchSubscriptionException if a matching subscription could not be found
+	*/
+	public Subscription findByG_Last(long groupId,
+		com.liferay.portal.kernel.util.OrderByComparator<Subscription> orderByComparator)
+		throws NoSuchSubscriptionException;
+
+	/**
+	* Returns the last subscription in the ordered set where groupId = &#63;.
+	*
+	* @param groupId the group ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the last matching subscription, or <code>null</code> if a matching subscription could not be found
+	*/
+	public Subscription fetchByG_Last(long groupId,
+		com.liferay.portal.kernel.util.OrderByComparator<Subscription> orderByComparator);
+
+	/**
+	* Returns the subscriptions before and after the current subscription in the ordered set where groupId = &#63;.
+	*
+	* @param subscriptionId the primary key of the current subscription
+	* @param groupId the group ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the previous, current, and next subscription
+	* @throws NoSuchSubscriptionException if a subscription with the primary key could not be found
+	*/
+	public Subscription[] findByG_PrevAndNext(long subscriptionId,
+		long groupId,
+		com.liferay.portal.kernel.util.OrderByComparator<Subscription> orderByComparator)
+		throws NoSuchSubscriptionException;
+
+	/**
+	* Removes all the subscriptions where groupId = &#63; from the database.
+	*
+	* @param groupId the group ID
+	*/
+	public void removeByG(long groupId);
+
+	/**
+	* Returns the number of subscriptions where groupId = &#63;.
+	*
+	* @param groupId the group ID
+	* @return the number of matching subscriptions
+	*/
+	public int countByG(long groupId);
+
+	/**
 	* Returns all the subscriptions where userId = &#63;.
 	*
 	* @param userId the user ID

--- a/modules/apps/collaboration/subscription/subscription-api/src/main/java/com/liferay/subscription/service/persistence/SubscriptionUtil.java
+++ b/modules/apps/collaboration/subscription/subscription-api/src/main/java/com/liferay/subscription/service/persistence/SubscriptionUtil.java
@@ -112,6 +112,160 @@ public class SubscriptionUtil {
 	}
 
 	/**
+	* Returns all the subscriptions where groupId = &#63;.
+	*
+	* @param groupId the group ID
+	* @return the matching subscriptions
+	*/
+	public static List<Subscription> findByG(long groupId) {
+		return getPersistence().findByG(groupId);
+	}
+
+	/**
+	* Returns a range of all the subscriptions where groupId = &#63;.
+	*
+	* <p>
+	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link SubscriptionModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	* </p>
+	*
+	* @param groupId the group ID
+	* @param start the lower bound of the range of subscriptions
+	* @param end the upper bound of the range of subscriptions (not inclusive)
+	* @return the range of matching subscriptions
+	*/
+	public static List<Subscription> findByG(long groupId, int start, int end) {
+		return getPersistence().findByG(groupId, start, end);
+	}
+
+	/**
+	* Returns an ordered range of all the subscriptions where groupId = &#63;.
+	*
+	* <p>
+	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link SubscriptionModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	* </p>
+	*
+	* @param groupId the group ID
+	* @param start the lower bound of the range of subscriptions
+	* @param end the upper bound of the range of subscriptions (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return the ordered range of matching subscriptions
+	*/
+	public static List<Subscription> findByG(long groupId, int start, int end,
+		OrderByComparator<Subscription> orderByComparator) {
+		return getPersistence().findByG(groupId, start, end, orderByComparator);
+	}
+
+	/**
+	* Returns an ordered range of all the subscriptions where groupId = &#63;.
+	*
+	* <p>
+	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link SubscriptionModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	* </p>
+	*
+	* @param groupId the group ID
+	* @param start the lower bound of the range of subscriptions
+	* @param end the upper bound of the range of subscriptions (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @param retrieveFromCache whether to retrieve from the finder cache
+	* @return the ordered range of matching subscriptions
+	*/
+	public static List<Subscription> findByG(long groupId, int start, int end,
+		OrderByComparator<Subscription> orderByComparator,
+		boolean retrieveFromCache) {
+		return getPersistence()
+				   .findByG(groupId, start, end, orderByComparator,
+			retrieveFromCache);
+	}
+
+	/**
+	* Returns the first subscription in the ordered set where groupId = &#63;.
+	*
+	* @param groupId the group ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the first matching subscription
+	* @throws NoSuchSubscriptionException if a matching subscription could not be found
+	*/
+	public static Subscription findByG_First(long groupId,
+		OrderByComparator<Subscription> orderByComparator)
+		throws com.liferay.subscription.exception.NoSuchSubscriptionException {
+		return getPersistence().findByG_First(groupId, orderByComparator);
+	}
+
+	/**
+	* Returns the first subscription in the ordered set where groupId = &#63;.
+	*
+	* @param groupId the group ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the first matching subscription, or <code>null</code> if a matching subscription could not be found
+	*/
+	public static Subscription fetchByG_First(long groupId,
+		OrderByComparator<Subscription> orderByComparator) {
+		return getPersistence().fetchByG_First(groupId, orderByComparator);
+	}
+
+	/**
+	* Returns the last subscription in the ordered set where groupId = &#63;.
+	*
+	* @param groupId the group ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the last matching subscription
+	* @throws NoSuchSubscriptionException if a matching subscription could not be found
+	*/
+	public static Subscription findByG_Last(long groupId,
+		OrderByComparator<Subscription> orderByComparator)
+		throws com.liferay.subscription.exception.NoSuchSubscriptionException {
+		return getPersistence().findByG_Last(groupId, orderByComparator);
+	}
+
+	/**
+	* Returns the last subscription in the ordered set where groupId = &#63;.
+	*
+	* @param groupId the group ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the last matching subscription, or <code>null</code> if a matching subscription could not be found
+	*/
+	public static Subscription fetchByG_Last(long groupId,
+		OrderByComparator<Subscription> orderByComparator) {
+		return getPersistence().fetchByG_Last(groupId, orderByComparator);
+	}
+
+	/**
+	* Returns the subscriptions before and after the current subscription in the ordered set where groupId = &#63;.
+	*
+	* @param subscriptionId the primary key of the current subscription
+	* @param groupId the group ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the previous, current, and next subscription
+	* @throws NoSuchSubscriptionException if a subscription with the primary key could not be found
+	*/
+	public static Subscription[] findByG_PrevAndNext(long subscriptionId,
+		long groupId, OrderByComparator<Subscription> orderByComparator)
+		throws com.liferay.subscription.exception.NoSuchSubscriptionException {
+		return getPersistence()
+				   .findByG_PrevAndNext(subscriptionId, groupId,
+			orderByComparator);
+	}
+
+	/**
+	* Removes all the subscriptions where groupId = &#63; from the database.
+	*
+	* @param groupId the group ID
+	*/
+	public static void removeByG(long groupId) {
+		getPersistence().removeByG(groupId);
+	}
+
+	/**
+	* Returns the number of subscriptions where groupId = &#63;.
+	*
+	* @param groupId the group ID
+	* @return the number of matching subscriptions
+	*/
+	public static int countByG(long groupId) {
+		return getPersistence().countByG(groupId);
+	}
+
+	/**
 	* Returns all the subscriptions where userId = &#63;.
 	*
 	* @param userId the user ID

--- a/modules/apps/collaboration/subscription/subscription-service/service.xml
+++ b/modules/apps/collaboration/subscription/subscription-service/service.xml
@@ -29,6 +29,9 @@
 
 		<!-- Finder methods -->
 
+		<finder name="G" return-type="Collection">
+			<finder-column name="groupId" />
+		</finder>
 		<finder name="UserId" return-type="Collection">
 			<finder-column name="userId" />
 		</finder>

--- a/modules/apps/collaboration/subscription/subscription-service/src/main/java/com/liferay/subscription/internal/model/listener/GroupModelListener.java
+++ b/modules/apps/collaboration/subscription/subscription-service/src/main/java/com/liferay/subscription/internal/model/listener/GroupModelListener.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.subscription.internal.model.listener;
+
+import com.liferay.portal.kernel.exception.ModelListenerException;
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.subscription.service.SubscriptionLocalService;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Adolfo Pérez
+ */
+@Component(immediate = true, service = ModelListener.class)
+public class GroupModelListener extends BaseModelListener<Group> {
+
+	@Override
+	public void onBeforeRemove(Group group) throws ModelListenerException {
+		_subscriptionLocalService.deleteGroupSubscriptions(group.getGroupId());
+	}
+
+	@Reference
+	private SubscriptionLocalService _subscriptionLocalService;
+
+}

--- a/modules/apps/collaboration/subscription/subscription-service/src/main/java/com/liferay/subscription/service/impl/SubscriptionLocalServiceImpl.java
+++ b/modules/apps/collaboration/subscription/subscription-service/src/main/java/com/liferay/subscription/service/impl/SubscriptionLocalServiceImpl.java
@@ -159,6 +159,11 @@ public class SubscriptionLocalServiceImpl
 		return subscription;
 	}
 
+	@Override
+	public void deleteGroupSubscriptions(long groupId) {
+		subscriptionPersistence.removeByG(groupId);
+	}
+
 	/**
 	 * Deletes the subscription with the primary key. A social activity with the
 	 * unsubscribe action is created.

--- a/modules/apps/collaboration/subscription/subscription-service/src/main/java/com/liferay/subscription/service/persistence/impl/SubscriptionPersistenceImpl.java
+++ b/modules/apps/collaboration/subscription/subscription-service/src/main/java/com/liferay/subscription/service/persistence/impl/SubscriptionPersistenceImpl.java
@@ -90,6 +90,505 @@ public class SubscriptionPersistenceImpl extends BasePersistenceImpl<Subscriptio
 	public static final FinderPath FINDER_PATH_COUNT_ALL = new FinderPath(SubscriptionModelImpl.ENTITY_CACHE_ENABLED,
 			SubscriptionModelImpl.FINDER_CACHE_ENABLED, Long.class,
 			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countAll", new String[0]);
+	public static final FinderPath FINDER_PATH_WITH_PAGINATION_FIND_BY_G = new FinderPath(SubscriptionModelImpl.ENTITY_CACHE_ENABLED,
+			SubscriptionModelImpl.FINDER_CACHE_ENABLED, SubscriptionImpl.class,
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG",
+			new String[] {
+				Long.class.getName(),
+				
+			Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			});
+	public static final FinderPath FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G = new FinderPath(SubscriptionModelImpl.ENTITY_CACHE_ENABLED,
+			SubscriptionModelImpl.FINDER_CACHE_ENABLED, SubscriptionImpl.class,
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG",
+			new String[] { Long.class.getName() },
+			SubscriptionModelImpl.GROUPID_COLUMN_BITMASK);
+	public static final FinderPath FINDER_PATH_COUNT_BY_G = new FinderPath(SubscriptionModelImpl.ENTITY_CACHE_ENABLED,
+			SubscriptionModelImpl.FINDER_CACHE_ENABLED, Long.class,
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG",
+			new String[] { Long.class.getName() });
+
+	/**
+	 * Returns all the subscriptions where groupId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @return the matching subscriptions
+	 */
+	@Override
+	public List<Subscription> findByG(long groupId) {
+		return findByG(groupId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the subscriptions where groupId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link SubscriptionModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param start the lower bound of the range of subscriptions
+	 * @param end the upper bound of the range of subscriptions (not inclusive)
+	 * @return the range of matching subscriptions
+	 */
+	@Override
+	public List<Subscription> findByG(long groupId, int start, int end) {
+		return findByG(groupId, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the subscriptions where groupId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link SubscriptionModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param start the lower bound of the range of subscriptions
+	 * @param end the upper bound of the range of subscriptions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching subscriptions
+	 */
+	@Override
+	public List<Subscription> findByG(long groupId, int start, int end,
+		OrderByComparator<Subscription> orderByComparator) {
+		return findByG(groupId, start, end, orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the subscriptions where groupId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link SubscriptionModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param start the lower bound of the range of subscriptions
+	 * @param end the upper bound of the range of subscriptions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param retrieveFromCache whether to retrieve from the finder cache
+	 * @return the ordered range of matching subscriptions
+	 */
+	@Override
+	public List<Subscription> findByG(long groupId, int start, int end,
+		OrderByComparator<Subscription> orderByComparator,
+		boolean retrieveFromCache) {
+		boolean pagination = true;
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+				(orderByComparator == null)) {
+			pagination = false;
+			finderPath = FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G;
+			finderArgs = new Object[] { groupId };
+		}
+		else {
+			finderPath = FINDER_PATH_WITH_PAGINATION_FIND_BY_G;
+			finderArgs = new Object[] { groupId, start, end, orderByComparator };
+		}
+
+		List<Subscription> list = null;
+
+		if (retrieveFromCache) {
+			list = (List<Subscription>)finderCache.getResult(finderPath,
+					finderArgs, this);
+
+			if ((list != null) && !list.isEmpty()) {
+				for (Subscription subscription : list) {
+					if ((groupId != subscription.getGroupId())) {
+						list = null;
+
+						break;
+					}
+				}
+			}
+		}
+
+		if (list == null) {
+			StringBundler query = null;
+
+			if (orderByComparator != null) {
+				query = new StringBundler(3 +
+						(orderByComparator.getOrderByFields().length * 2));
+			}
+			else {
+				query = new StringBundler(3);
+			}
+
+			query.append(_SQL_SELECT_SUBSCRIPTION_WHERE);
+
+			query.append(_FINDER_COLUMN_G_GROUPID_2);
+
+			if (orderByComparator != null) {
+				appendOrderByComparator(query, _ORDER_BY_ENTITY_ALIAS,
+					orderByComparator);
+			}
+			else
+			 if (pagination) {
+				query.append(SubscriptionModelImpl.ORDER_BY_JPQL);
+			}
+
+			String sql = query.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query q = session.createQuery(sql);
+
+				QueryPos qPos = QueryPos.getInstance(q);
+
+				qPos.add(groupId);
+
+				if (!pagination) {
+					list = (List<Subscription>)QueryUtil.list(q, getDialect(),
+							start, end, false);
+
+					Collections.sort(list);
+
+					list = Collections.unmodifiableList(list);
+				}
+				else {
+					list = (List<Subscription>)QueryUtil.list(q, getDialect(),
+							start, end);
+				}
+
+				cacheResult(list);
+
+				finderCache.putResult(finderPath, finderArgs, list);
+			}
+			catch (Exception e) {
+				finderCache.removeResult(finderPath, finderArgs);
+
+				throw processException(e);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return list;
+	}
+
+	/**
+	 * Returns the first subscription in the ordered set where groupId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching subscription
+	 * @throws NoSuchSubscriptionException if a matching subscription could not be found
+	 */
+	@Override
+	public Subscription findByG_First(long groupId,
+		OrderByComparator<Subscription> orderByComparator)
+		throws NoSuchSubscriptionException {
+		Subscription subscription = fetchByG_First(groupId, orderByComparator);
+
+		if (subscription != null) {
+			return subscription;
+		}
+
+		StringBundler msg = new StringBundler(4);
+
+		msg.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		msg.append("groupId=");
+		msg.append(groupId);
+
+		msg.append(StringPool.CLOSE_CURLY_BRACE);
+
+		throw new NoSuchSubscriptionException(msg.toString());
+	}
+
+	/**
+	 * Returns the first subscription in the ordered set where groupId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching subscription, or <code>null</code> if a matching subscription could not be found
+	 */
+	@Override
+	public Subscription fetchByG_First(long groupId,
+		OrderByComparator<Subscription> orderByComparator) {
+		List<Subscription> list = findByG(groupId, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last subscription in the ordered set where groupId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching subscription
+	 * @throws NoSuchSubscriptionException if a matching subscription could not be found
+	 */
+	@Override
+	public Subscription findByG_Last(long groupId,
+		OrderByComparator<Subscription> orderByComparator)
+		throws NoSuchSubscriptionException {
+		Subscription subscription = fetchByG_Last(groupId, orderByComparator);
+
+		if (subscription != null) {
+			return subscription;
+		}
+
+		StringBundler msg = new StringBundler(4);
+
+		msg.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		msg.append("groupId=");
+		msg.append(groupId);
+
+		msg.append(StringPool.CLOSE_CURLY_BRACE);
+
+		throw new NoSuchSubscriptionException(msg.toString());
+	}
+
+	/**
+	 * Returns the last subscription in the ordered set where groupId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching subscription, or <code>null</code> if a matching subscription could not be found
+	 */
+	@Override
+	public Subscription fetchByG_Last(long groupId,
+		OrderByComparator<Subscription> orderByComparator) {
+		int count = countByG(groupId);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<Subscription> list = findByG(groupId, count - 1, count,
+				orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the subscriptions before and after the current subscription in the ordered set where groupId = &#63;.
+	 *
+	 * @param subscriptionId the primary key of the current subscription
+	 * @param groupId the group ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next subscription
+	 * @throws NoSuchSubscriptionException if a subscription with the primary key could not be found
+	 */
+	@Override
+	public Subscription[] findByG_PrevAndNext(long subscriptionId,
+		long groupId, OrderByComparator<Subscription> orderByComparator)
+		throws NoSuchSubscriptionException {
+		Subscription subscription = findByPrimaryKey(subscriptionId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			Subscription[] array = new SubscriptionImpl[3];
+
+			array[0] = getByG_PrevAndNext(session, subscription, groupId,
+					orderByComparator, true);
+
+			array[1] = subscription;
+
+			array[2] = getByG_PrevAndNext(session, subscription, groupId,
+					orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception e) {
+			throw processException(e);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected Subscription getByG_PrevAndNext(Session session,
+		Subscription subscription, long groupId,
+		OrderByComparator<Subscription> orderByComparator, boolean previous) {
+		StringBundler query = null;
+
+		if (orderByComparator != null) {
+			query = new StringBundler(4 +
+					(orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			query = new StringBundler(3);
+		}
+
+		query.append(_SQL_SELECT_SUBSCRIPTION_WHERE);
+
+		query.append(_FINDER_COLUMN_G_GROUPID_2);
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields = orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				query.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				query.append(_ORDER_BY_ENTITY_ALIAS);
+				query.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						query.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(WHERE_GREATER_THAN);
+					}
+					else {
+						query.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			query.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				query.append(_ORDER_BY_ENTITY_ALIAS);
+				query.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						query.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(ORDER_BY_ASC);
+					}
+					else {
+						query.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			query.append(SubscriptionModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = query.toString();
+
+		Query q = session.createQuery(sql);
+
+		q.setFirstResult(0);
+		q.setMaxResults(2);
+
+		QueryPos qPos = QueryPos.getInstance(q);
+
+		qPos.add(groupId);
+
+		if (orderByComparator != null) {
+			Object[] values = orderByComparator.getOrderByConditionValues(subscription);
+
+			for (Object value : values) {
+				qPos.add(value);
+			}
+		}
+
+		List<Subscription> list = q.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the subscriptions where groupId = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 */
+	@Override
+	public void removeByG(long groupId) {
+		for (Subscription subscription : findByG(groupId, QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS, null)) {
+			remove(subscription);
+		}
+	}
+
+	/**
+	 * Returns the number of subscriptions where groupId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @return the number of matching subscriptions
+	 */
+	@Override
+	public int countByG(long groupId) {
+		FinderPath finderPath = FINDER_PATH_COUNT_BY_G;
+
+		Object[] finderArgs = new Object[] { groupId };
+
+		Long count = (Long)finderCache.getResult(finderPath, finderArgs, this);
+
+		if (count == null) {
+			StringBundler query = new StringBundler(2);
+
+			query.append(_SQL_COUNT_SUBSCRIPTION_WHERE);
+
+			query.append(_FINDER_COLUMN_G_GROUPID_2);
+
+			String sql = query.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query q = session.createQuery(sql);
+
+				QueryPos qPos = QueryPos.getInstance(q);
+
+				qPos.add(groupId);
+
+				count = (Long)q.uniqueResult();
+
+				finderCache.putResult(finderPath, finderArgs, count);
+			}
+			catch (Exception e) {
+				finderCache.removeResult(finderPath, finderArgs);
+
+				throw processException(e);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	private static final String _FINDER_COLUMN_G_GROUPID_2 = "subscription.groupId = ?";
 	public static final FinderPath FINDER_PATH_WITH_PAGINATION_FIND_BY_USERID = new FinderPath(SubscriptionModelImpl.ENTITY_CACHE_ENABLED,
 			SubscriptionModelImpl.FINDER_CACHE_ENABLED, SubscriptionImpl.class,
 			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserId",
@@ -3184,7 +3683,13 @@ public class SubscriptionPersistenceImpl extends BasePersistenceImpl<Subscriptio
 		}
 		else
 		 if (isNew) {
-			Object[] args = new Object[] { subscriptionModelImpl.getUserId() };
+			Object[] args = new Object[] { subscriptionModelImpl.getGroupId() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_G, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G,
+				args);
+
+			args = new Object[] { subscriptionModelImpl.getUserId() };
 
 			finderCache.removeResult(FINDER_PATH_COUNT_BY_USERID, args);
 			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_USERID,
@@ -3235,6 +3740,23 @@ public class SubscriptionPersistenceImpl extends BasePersistenceImpl<Subscriptio
 		}
 
 		else {
+			if ((subscriptionModelImpl.getColumnBitmask() &
+					FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G.getColumnBitmask()) != 0) {
+				Object[] args = new Object[] {
+						subscriptionModelImpl.getOriginalGroupId()
+					};
+
+				finderCache.removeResult(FINDER_PATH_COUNT_BY_G, args);
+				finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G,
+					args);
+
+				args = new Object[] { subscriptionModelImpl.getGroupId() };
+
+				finderCache.removeResult(FINDER_PATH_COUNT_BY_G, args);
+				finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G,
+					args);
+			}
+
 			if ((subscriptionModelImpl.getColumnBitmask() &
 					FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_USERID.getColumnBitmask()) != 0) {
 				Object[] args = new Object[] {

--- a/modules/apps/collaboration/subscription/subscription-test/src/testIntegration/java/com/liferay/subscription/service/persistence/test/SubscriptionPersistenceTest.java
+++ b/modules/apps/collaboration/subscription/subscription-test/src/testIntegration/java/com/liferay/subscription/service/persistence/test/SubscriptionPersistenceTest.java
@@ -174,6 +174,13 @@ public class SubscriptionPersistenceTest {
 	}
 
 	@Test
+	public void testCountByG() throws Exception {
+		_persistence.countByG(RandomTestUtil.nextLong());
+
+		_persistence.countByG(0L);
+	}
+
+	@Test
 	public void testCountByUserId() throws Exception {
 		_persistence.countByUserId(RandomTestUtil.nextLong());
 


### PR DESCRIPTION
La pull la veo guay. Estaria mejor aun si podemos meter un test para asegurar que no se rompa. Algo sencillo al estilo añado una subscripcion, borro el grupo y me aseguro de que la subscripción se ha borrado. Lo podemos meter en el módulo subscription-test.