### PR TITLE
[See description] LPS-71637 Limit the scope of the links in wiki to the contentEditor

### DIFF
--- a/modules/apps/collaboration/wiki/wiki-api/src/main/java/com/liferay/wiki/item/selector/constants/WikiItemSelectorViewConstants.java
+++ b/modules/apps/collaboration/wiki/wiki-api/src/main/java/com/liferay/wiki/item/selector/constants/WikiItemSelectorViewConstants.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.wiki.item.selector.constants;
+
+/**
+ * @author Roberto Díaz
+ */
+public class WikiItemSelectorViewConstants {
+
+	public static final String ITEM_SELECTOR_VIEW_KEY = "page-attachments";
+
+}

--- a/modules/apps/collaboration/wiki/wiki-api/src/main/java/com/liferay/wiki/item/selector/criterion/WikiAttachmentItemSelectorCriterion.java
+++ b/modules/apps/collaboration/wiki/wiki-api/src/main/java/com/liferay/wiki/item/selector/criterion/WikiAttachmentItemSelectorCriterion.java
@@ -27,8 +27,7 @@ public class WikiAttachmentItemSelectorCriterion
 	}
 
 	public WikiAttachmentItemSelectorCriterion(long wikiPageResourceId) {
-		new WikiAttachmentItemSelectorCriterion(
-			wikiPageResourceId, new String[0]);
+		this(wikiPageResourceId, new String[0]);
 	}
 
 	public WikiAttachmentItemSelectorCriterion(

--- a/modules/apps/collaboration/wiki/wiki-editor-configuration/src/main/java/com/liferay/wiki/editor/configuration/internal/WikiLinksAlloyEditorConfigContributor.java
+++ b/modules/apps/collaboration/wiki/wiki-editor-configuration/src/main/java/com/liferay/wiki/editor/configuration/internal/WikiLinksAlloyEditorConfigContributor.java
@@ -39,7 +39,7 @@ import org.osgi.service.component.annotations.Component;
 	},
 	service = EditorConfigContributor.class
 )
-public class WikiLinksEditorConfigContributor
+public class WikiLinksAlloyEditorConfigContributor
 	extends BaseEditorConfigContributor {
 
 	@Override

--- a/modules/apps/collaboration/wiki/wiki-editor-configuration/src/main/java/com/liferay/wiki/editor/configuration/internal/WikiLinksAlloyEditorConfigContributor.java
+++ b/modules/apps/collaboration/wiki/wiki-editor-configuration/src/main/java/com/liferay/wiki/editor/configuration/internal/WikiLinksAlloyEditorConfigContributor.java
@@ -32,7 +32,7 @@ import org.osgi.service.component.annotations.Component;
  */
 @Component(
 	property = {
-		"editor.name=alloyeditor_creole",
+		"editor.config.key=contentEditor", "editor.name=alloyeditor_creole",
 		"javax.portlet.name=" + WikiPortletKeys.WIKI,
 		"javax.portlet.name=" + WikiPortletKeys.WIKI_ADMIN,
 		"javax.portlet.name=" + WikiPortletKeys.WIKI_DISPLAY

--- a/modules/apps/collaboration/wiki/wiki-editor-configuration/src/main/java/com/liferay/wiki/editor/configuration/internal/WikiLinksCKEditorConfigContributor.java
+++ b/modules/apps/collaboration/wiki/wiki-editor-configuration/src/main/java/com/liferay/wiki/editor/configuration/internal/WikiLinksCKEditorConfigContributor.java
@@ -43,7 +43,7 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"editor.name=ckeditor_creole",
+		"editor.config.key=contentEditor", "editor.name=ckeditor_creole",
 		"javax.portlet.name=" + WikiPortletKeys.WIKI,
 		"javax.portlet.name=" + WikiPortletKeys.WIKI_ADMIN,
 		"javax.portlet.name=" + WikiPortletKeys.WIKI_DISPLAY

--- a/modules/apps/collaboration/wiki/wiki-editor-configuration/src/main/java/com/liferay/wiki/editor/configuration/internal/WikiLinksCKEditorConfigContributor.java
+++ b/modules/apps/collaboration/wiki/wiki-editor-configuration/src/main/java/com/liferay/wiki/editor/configuration/internal/WikiLinksCKEditorConfigContributor.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.wiki.editor.configuration.internal;
+
+import com.liferay.item.selector.ItemSelector;
+import com.liferay.item.selector.ItemSelectorCriterion;
+import com.liferay.item.selector.ItemSelectorReturnType;
+import com.liferay.item.selector.ItemSelectorViewReturnTypeProvider;
+import com.liferay.item.selector.criteria.URLItemSelectorReturnType;
+import com.liferay.portal.kernel.editor.configuration.BaseEditorConfigContributor;
+import com.liferay.portal.kernel.editor.configuration.EditorConfigContributor;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.wiki.constants.WikiPortletKeys;
+import com.liferay.wiki.item.selector.constants.WikiItemSelectorViewConstants;
+import com.liferay.wiki.item.selector.criterion.WikiAttachmentItemSelectorCriterion;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.portlet.PortletURL;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Roberto Díaz
+ */
+@Component(
+	property = {
+		"editor.name=ckeditor_creole",
+		"javax.portlet.name=" + WikiPortletKeys.WIKI,
+		"javax.portlet.name=" + WikiPortletKeys.WIKI_ADMIN,
+		"javax.portlet.name=" + WikiPortletKeys.WIKI_DISPLAY
+	},
+	service = EditorConfigContributor.class
+)
+public class WikiLinksCKEditorConfigContributor
+	extends BaseEditorConfigContributor {
+
+	@Override
+	public void populateConfigJSONObject(
+		JSONObject jsonObject, Map<String, Object> inputEditorTaglibAttributes,
+		ThemeDisplay themeDisplay,
+		RequestBackedPortletURLFactory requestBackedPortletURLFactory) {
+
+		Map<String, String> fileBrowserParamsMap =
+			(Map<String, String>)inputEditorTaglibAttributes.get(
+				"liferay-ui:input-editor:fileBrowserParams");
+
+		if (fileBrowserParamsMap != null) {
+			long wikiPageResourcePrimKey = GetterUtil.getLong(
+				fileBrowserParamsMap.get("wikiPageResourcePrimKey"));
+
+			if (wikiPageResourcePrimKey != 0) {
+				String filebrowserBrowseUrl = jsonObject.getString(
+					"filebrowserBrowseUrl");
+
+				String itemSelectedEventName =
+					_itemSelector.getItemSelectedEventName(
+						filebrowserBrowseUrl);
+
+				List<ItemSelectorCriterion> itemSelectorCriteria =
+					_itemSelector.getItemSelectorCriteria(filebrowserBrowseUrl);
+
+				itemSelectorCriteria.add(
+					getWikiAttachmentItemSelectorCriterion(
+						wikiPageResourcePrimKey));
+
+				PortletURL itemSelectorURL = _itemSelector.getItemSelectorURL(
+					requestBackedPortletURLFactory, itemSelectedEventName,
+					itemSelectorCriteria.toArray(
+						new ItemSelectorCriterion[
+							itemSelectorCriteria.size()]));
+
+				jsonObject.put(
+					"filebrowserBrowseUrl", itemSelectorURL.toString());
+			}
+		}
+	}
+
+	protected WikiAttachmentItemSelectorCriterion
+		getWikiAttachmentItemSelectorCriterion(long wikiPageResourcePrimKey) {
+
+		WikiAttachmentItemSelectorCriterion itemSelectorCriterion =
+			new WikiAttachmentItemSelectorCriterion(wikiPageResourcePrimKey);
+
+		List<ItemSelectorReturnType> desiredItemSelectorReturnTypes =
+			new ArrayList<>();
+
+		desiredItemSelectorReturnTypes.add(new URLItemSelectorReturnType());
+
+		itemSelectorCriterion.setDesiredItemSelectorReturnTypes(
+			desiredItemSelectorReturnTypes);
+
+		return itemSelectorCriterion;
+	}
+
+	@Reference
+	private ItemSelector _itemSelector;
+
+	@Reference(
+		target = "(item.selector.view.key=" + WikiItemSelectorViewConstants.ITEM_SELECTOR_VIEW_KEY + ")"
+	)
+	private ItemSelectorViewReturnTypeProvider
+		_itemSelectorViewReturnTypeProvider;
+
+}

--- a/modules/apps/collaboration/wiki/wiki-editor-link-browse-web/bnd.bnd
+++ b/modules/apps/collaboration/wiki/wiki-editor-link-browse-web/bnd.bnd
@@ -1,0 +1,5 @@
+Bundle-Name: Liferay Wiki Editor Link Browse Web
+Bundle-SymbolicName: com.liferay.wiki.editor.link.browse.web
+Bundle-Version: 1.0.0
+Liferay-Releng-Module-Group-Description:
+Liferay-Releng-Module-Group-Title:

--- a/modules/apps/collaboration/wiki/wiki-editor-link-browse-web/build.gradle
+++ b/modules/apps/collaboration/wiki/wiki-editor-link-browse-web/build.gradle
@@ -1,0 +1,9 @@
+dependencies {
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	provided group: "javax.portlet", name: "portlet-api", version: "2.0"
+	provided group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
+	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	provided project(":apps:collaboration:item-selector:item-selector-api")
+	provided project(":apps:collaboration:item-selector:item-selector-criteria-api")
+	provided project(":apps:collaboration:wiki:wiki-api")
+}

--- a/modules/apps/collaboration/wiki/wiki-editor-link-browse-web/src/main/java/com/liferay/wiki/editor/link/browse/web/internal/editor/configuration/WikiContentAlloyEditorLinkBrowseConfigContributor.java
+++ b/modules/apps/collaboration/wiki/wiki-editor-link-browse-web/src/main/java/com/liferay/wiki/editor/link/browse/web/internal/editor/configuration/WikiContentAlloyEditorLinkBrowseConfigContributor.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.wiki.editor.link.browse.web.internal.editor.configuration;
+
+import com.liferay.item.selector.ItemSelector;
+import com.liferay.item.selector.ItemSelectorCriterion;
+import com.liferay.item.selector.ItemSelectorReturnType;
+import com.liferay.item.selector.criteria.URLItemSelectorReturnType;
+import com.liferay.portal.kernel.editor.configuration.BaseEditorConfigContributor;
+import com.liferay.portal.kernel.editor.configuration.EditorConfigContributor;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.wiki.constants.WikiPortletKeys;
+import com.liferay.wiki.item.selector.criterion.WikiAttachmentItemSelectorCriterion;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.portlet.PortletURL;
+
+import javax.servlet.ServletContext;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Roberto Díaz
+ */
+@Component(
+	property = {
+		"editor.config.key=contentEditor", "editor.name=alloyeditor",
+		"editor.name=alloyeditor_creole",
+		"javax.portlet.name=" + WikiPortletKeys.WIKI,
+		"javax.portlet.name=" + WikiPortletKeys.WIKI_ADMIN,
+		"javax.portlet.name=" + WikiPortletKeys.WIKI_DISPLAY,
+		"service.ranking:Integer=1000"
+	},
+	service = EditorConfigContributor.class
+)
+public class WikiContentAlloyEditorLinkBrowseConfigContributor
+	extends BaseEditorConfigContributor {
+
+	@Override
+	public void populateConfigJSONObject(
+		JSONObject jsonObject, Map<String, Object> inputEditorTaglibAttributes,
+		ThemeDisplay themeDisplay,
+		RequestBackedPortletURLFactory requestBackedPortletURLFactory) {
+
+		Map<String, String> fileBrowserParamsMap =
+			(Map<String, String>)inputEditorTaglibAttributes.get(
+				"liferay-ui:input-editor:fileBrowserParams");
+
+		if (fileBrowserParamsMap != null) {
+			long wikiPageResourcePrimKey = GetterUtil.getLong(
+				fileBrowserParamsMap.get("wikiPageResourcePrimKey"));
+
+			if (wikiPageResourcePrimKey != 0) {
+				String documentBrowseLinkUrl = jsonObject.getString(
+					"documentBrowseLinkUrl");
+
+				List<ItemSelectorCriterion> itemSelectorCriteria =
+					_itemSelector.getItemSelectorCriteria(
+						documentBrowseLinkUrl);
+
+				String itemSelectedEventName =
+					_itemSelector.getItemSelectedEventName(
+						documentBrowseLinkUrl);
+
+				itemSelectorCriteria.add(
+					getWikiAttachmentItemSelectorCriterion(
+						wikiPageResourcePrimKey));
+
+				PortletURL itemSelectorURL = _itemSelector.getItemSelectorURL(
+					requestBackedPortletURLFactory, itemSelectedEventName,
+					itemSelectorCriteria.toArray(
+						new ItemSelectorCriterion[
+							itemSelectorCriteria.size()]));
+
+				jsonObject.put(
+					"documentBrowseLinkUrl", itemSelectorURL.toString());
+			}
+		}
+	}
+
+	protected WikiAttachmentItemSelectorCriterion
+		getWikiAttachmentItemSelectorCriterion(long wikiPageResourcePrimKey) {
+
+		WikiAttachmentItemSelectorCriterion itemSelectorCriterion =
+			new WikiAttachmentItemSelectorCriterion(wikiPageResourcePrimKey);
+
+		List<ItemSelectorReturnType> desiredItemSelectorReturnTypes =
+			new ArrayList<>();
+
+		desiredItemSelectorReturnTypes.add(new URLItemSelectorReturnType());
+
+		itemSelectorCriterion.setDesiredItemSelectorReturnTypes(
+			desiredItemSelectorReturnTypes);
+
+		return itemSelectorCriterion;
+	}
+
+	@Reference
+	private ItemSelector _itemSelector;
+
+	@Reference(
+		target = "(osgi.web.symbolicname=com.liferay.frontend.editor.alloyeditor.link.browse.web)"
+	)
+	private ServletContext _servletContext;
+
+}

--- a/modules/apps/collaboration/wiki/wiki-editor-link-browse-web/src/main/java/com/liferay/wiki/editor/link/browse/web/internal/item/selector/provider/WikiAttachmentsItemSelectorViewReturnTypeProvider.java
+++ b/modules/apps/collaboration/wiki/wiki-editor-link-browse-web/src/main/java/com/liferay/wiki/editor/link/browse/web/internal/item/selector/provider/WikiAttachmentsItemSelectorViewReturnTypeProvider.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.wiki.editor.link.browse.web.internal.item.selector.provider;
+
+import com.liferay.item.selector.ItemSelectorReturnType;
+import com.liferay.item.selector.ItemSelectorView;
+import com.liferay.item.selector.ItemSelectorViewReturnTypeProvider;
+import com.liferay.item.selector.criteria.URLItemSelectorReturnType;
+import com.liferay.wiki.item.selector.constants.WikiItemSelectorViewConstants;
+
+import java.util.List;
+
+import javax.servlet.ServletContext;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Roberto Díaz
+ */
+@Component(
+	property = {
+		"item.selector.view.key=" + WikiItemSelectorViewConstants.ITEM_SELECTOR_VIEW_KEY
+	}
+)
+public class WikiAttachmentsItemSelectorViewReturnTypeProvider
+	implements ItemSelectorViewReturnTypeProvider {
+
+	@Override
+	public List<ItemSelectorReturnType>
+		populateSupportedItemSelectorReturnTypes(
+			List<ItemSelectorReturnType> supportedItemSelectorReturnTypes) {
+
+		supportedItemSelectorReturnTypes.add(new URLItemSelectorReturnType());
+
+		return supportedItemSelectorReturnTypes;
+	}
+
+	@Reference(
+		target = "(item.selector.view.key=" + WikiItemSelectorViewConstants.ITEM_SELECTOR_VIEW_KEY + ")"
+	)
+	private ItemSelectorView _itemSelectorView;
+
+	@Reference(
+		target = "(osgi.web.symbolicname=com.liferay.frontend.editor.alloyeditor.link.browse.web)"
+	)
+	private ServletContext _servletContext;
+
+}

--- a/modules/apps/collaboration/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/item/selector/view/WikiAttachmentItemSelectorView.java
+++ b/modules/apps/collaboration/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/item/selector/view/WikiAttachmentItemSelectorView.java
@@ -21,6 +21,7 @@ import com.liferay.item.selector.criteria.FileEntryItemSelectorReturnType;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.wiki.item.selector.constants.WikiItemSelectorViewConstants;
 import com.liferay.wiki.item.selector.criterion.WikiAttachmentItemSelectorCriterion;
 import com.liferay.wiki.web.internal.item.selector.view.display.context.WikiAttachmentItemSelectorViewDisplayContext;
 
@@ -44,7 +45,11 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Iván Zaera
  */
-@Component
+@Component(
+	property = {
+		"item.selector.view.key=" + WikiItemSelectorViewConstants.ITEM_SELECTOR_VIEW_KEY
+	}
+)
 public class WikiAttachmentItemSelectorView
 	implements ItemSelectorView<WikiAttachmentItemSelectorCriterion> {
 


### PR DESCRIPTION
Adolfo, tenemos algunas dudas de dónde deberían ir ciertas cosas: 
- _WikiContentAlloyEditorLinkBrowseConfigContributor_. y _WikiLinksCKEditorConfigContributor_ tienen lógica común que quizás se podría sacar a un Base, pero al estar en paquetes diferentes, ¿este Base dónde debería estar? 
- El Provider en realidad no debería depender del módulo de "frontend.editor.alloyeditor.link.browse.web". Porque entonces, si no tienes ese módulo desplegado, no sale la pestaña del Item Selector aunque tengas CKEditor en Wiki. 

Cualquier duda, háblalo con @robertoDiaz 