### PR TITLE
LPS-41934 Image button should open DM and URL tabs in Item Selector

### DIFF
--- a/modules/apps/foundation/frontend-editor/frontend-editor-tinymce-web/build.gradle
+++ b/modules/apps/foundation/frontend-editor/frontend-editor-tinymce-web/build.gradle
@@ -56,6 +56,8 @@ clean {
 
 dependencies {
 	provided group: "com.liferay", name: "com.liferay.frontend.taglib", version: "2.0.0"
+	provided group: "com.liferay", name: "com.liferay.item.selector.api", version: "2.3.0"
+	provided group: "com.liferay", name: "com.liferay.item.selector.criteria.api", version: "2.1.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	provided group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "2.0.0"
 	provided group: "javax.portlet", name: "portlet-api", version: "2.0"

--- a/modules/apps/foundation/frontend-editor/frontend-editor-tinymce-web/src/main/java/com/liferay/frontend/editor/tinymce/web/internal/editor/configuration/BaseTinyMCEEditorConfigConfigurator.java
+++ b/modules/apps/foundation/frontend-editor/frontend-editor-tinymce-web/src/main/java/com/liferay/frontend/editor/tinymce/web/internal/editor/configuration/BaseTinyMCEEditorConfigConfigurator.java
@@ -19,6 +19,6 @@ package com.liferay.frontend.editor.tinymce.web.internal.editor.configuration;
  * @deprecated As of 1.0.0, replaced by {@link BaseTinyMCEEditorConfigContributor}
  */
 @Deprecated
-public class BaseTinyMCEEditorConfigConfigurator
+public abstract class BaseTinyMCEEditorConfigConfigurator
 	extends BaseTinyMCEEditorConfigContributor {
 }

--- a/modules/apps/foundation/frontend-editor/frontend-editor-tinymce-web/src/main/java/com/liferay/frontend/editor/tinymce/web/internal/editor/configuration/BaseTinyMCEEditorConfigContributor.java
+++ b/modules/apps/foundation/frontend-editor/frontend-editor-tinymce-web/src/main/java/com/liferay/frontend/editor/tinymce/web/internal/editor/configuration/BaseTinyMCEEditorConfigContributor.java
@@ -14,6 +14,9 @@
 
 package com.liferay.frontend.editor.tinymce.web.internal.editor.configuration;
 
+import com.liferay.item.selector.ItemSelector;
+import com.liferay.item.selector.ItemSelectorCriterion;
+import com.liferay.item.selector.criteria.image.criterion.ImageItemSelectorCriterion;
 import com.liferay.portal.kernel.editor.configuration.BaseEditorConfigContributor;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
@@ -27,13 +30,16 @@ import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+
+import javax.portlet.PortletURL;
 
 /**
  * @author Ambrin Chaudhary
  */
-public class BaseTinyMCEEditorConfigContributor
+public abstract class BaseTinyMCEEditorConfigContributor
 	extends BaseEditorConfigContributor {
 
 	@Override
@@ -60,6 +66,27 @@ public class BaseTinyMCEEditorConfigContributor
 
 		jsonObject.put("convert_urls", Boolean.FALSE);
 		jsonObject.put("extended_valid_elements", _EXTENDED_VALID_ELEMENTS);
+
+		String filebrowserImageBrowseUrl = jsonObject.getString(
+			"filebrowserImageBrowseUrl");
+
+		String itemSelectedEventName =
+			getItemSelector().getItemSelectedEventName(
+				filebrowserImageBrowseUrl);
+
+		List<ItemSelectorCriterion> itemSelectorCriteria =
+			getItemSelector().getItemSelectorCriteria(
+				filebrowserImageBrowseUrl);
+
+		itemSelectorCriteria.add(new ImageItemSelectorCriterion());
+
+		PortletURL itemSelectorURL = getItemSelector().getItemSelectorURL(
+			requestBackedPortletURLFactory, itemSelectedEventName,
+			itemSelectorCriteria.toArray(
+				new ItemSelectorCriterion[itemSelectorCriteria.size()]));
+
+		jsonObject.put("filebrowserImageBrowseUrl", itemSelectorURL.toString());
+
 		jsonObject.put("invalid_elements", "script");
 
 		String contentsLanguageId = (String)inputEditorTaglibAttributes.get(
@@ -87,6 +114,8 @@ public class BaseTinyMCEEditorConfigContributor
 				"preview print");
 		jsonObject.put("toolbar_items_size", "small");
 	}
+
+	protected abstract ItemSelector getItemSelector();
 
 	protected String getTinyMCELanguage(String contentsLanguageId) {
 		Locale contentsLocale = LocaleUtil.fromLanguageId(contentsLanguageId);

--- a/modules/apps/foundation/frontend-editor/frontend-editor-tinymce-web/src/main/java/com/liferay/frontend/editor/tinymce/web/internal/editor/configuration/TinyMCEEditorConfigContributor.java
+++ b/modules/apps/foundation/frontend-editor/frontend-editor-tinymce-web/src/main/java/com/liferay/frontend/editor/tinymce/web/internal/editor/configuration/TinyMCEEditorConfigContributor.java
@@ -14,6 +14,7 @@
 
 package com.liferay.frontend.editor.tinymce.web.internal.editor.configuration;
 
+import com.liferay.item.selector.ItemSelector;
 import com.liferay.portal.kernel.editor.configuration.EditorConfigContributor;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -63,6 +64,11 @@ public class TinyMCEEditorConfigContributor
 		jsonObject.put(
 			"toolbar",
 			getToolbarJSONArray(inputEditorTaglibAttributes, themeDisplay));
+	}
+
+	@Override
+	protected ItemSelector getItemSelector() {
+		return _itemSelector;
 	}
 
 	protected JSONArray getPluginsJSONArray(
@@ -313,6 +319,9 @@ public class TinyMCEEditorConfigContributor
 
 	@Reference
 	private BrowserSniffer _browserSniffer;
+
+	@Reference
+	private ItemSelector _itemSelector;
 
 	private volatile ResourceBundleLoader _resourceBundleLoader;
 

--- a/modules/apps/foundation/frontend-editor/frontend-editor-tinymce-web/src/main/java/com/liferay/frontend/editor/tinymce/web/internal/editor/configuration/TinyMCESimpleEditorConfigContributor.java
+++ b/modules/apps/foundation/frontend-editor/frontend-editor-tinymce-web/src/main/java/com/liferay/frontend/editor/tinymce/web/internal/editor/configuration/TinyMCESimpleEditorConfigContributor.java
@@ -14,6 +14,7 @@
 
 package com.liferay.frontend.editor.tinymce.web.internal.editor.configuration;
 
+import com.liferay.item.selector.ItemSelector;
 import com.liferay.portal.kernel.editor.configuration.EditorConfigContributor;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
@@ -22,6 +23,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Ambrin Chaudhary
@@ -63,5 +65,13 @@ public class TinyMCESimpleEditorConfigContributor
 
 		jsonObject.put("toolbar", toolbar);
 	}
+
+	@Override
+	protected ItemSelector getItemSelector() {
+		return _itemSelector;
+	}
+
+	@Reference
+	private ItemSelector _itemSelector;
 
 }

--- a/modules/apps/foundation/frontend-editor/frontend-editor-tinymce-web/src/main/resources/META-INF/resources/tinymce.jsp
+++ b/modules/apps/foundation/frontend-editor/frontend-editor-tinymce-web/src/main/resources/META-INF/resources/tinymce.jsp
@@ -92,6 +92,12 @@ name = HtmlUtil.escapeJS(name);
 %>
 
 <aui:script use="aui-node-base">
+	var browseUrls = {
+		'file': 'filebrowserBrowseUrl',
+		'image': 'filebrowserImageBrowseUrl',
+		'media': 'filebrowserVideoBrowseUrl'
+	};
+
 	var getInitialContent = function() {
 		var data;
 
@@ -150,7 +156,43 @@ name = HtmlUtil.escapeJS(name);
 			}
 		},
 
-		fileBrowserCallback: function(field_name, url, type) {
+		filePickerCallback: function(callback, value, meta) {
+			var url = tinymce.activeEditor.settings[browseUrls[meta.filetype]];
+
+			if (url) {
+				var openItemSelectorDialog = function(itemSelectorDialog) {
+					itemSelectorDialog.set('eventName', '<%= name %>selectItem');
+					itemSelectorDialog.set('url', url);
+					itemSelectorDialog.set('zIndex', tinymce.activeEditor.windowManager.windows[0].zIndex + 10);
+
+					itemSelectorDialog.once(
+						'selectedItemChange',
+						function(event) {
+							callback(event.newVal ? event.newVal.value : value);
+						}
+					);
+
+					itemSelectorDialog.open();
+				};
+
+				var itemSelectorDialog = window['<%= name %>']._itemSelectorDialog;
+
+				if (itemSelectorDialog) {
+					openItemSelectorDialog(itemSelectorDialog);
+				}
+				else {
+					AUI().use(
+						'liferay-item-selector-dialog',
+						function(A) {
+							var itemSelectorDialog = new A.LiferayItemSelectorDialog();
+
+							window['<%= name %>']._itemSelectorDialog = itemSelectorDialog;
+
+							openItemSelectorDialog(itemSelectorDialog);
+						}
+					);
+				}
+			}
 		},
 
 		focus: function() {
@@ -202,7 +244,7 @@ name = HtmlUtil.escapeJS(name);
 			var editorConfig = <%= (editorConfigJSONObject != null) ? editorConfigJSONObject.toString() : "{}" %>;
 
 			var defaultConfig = {
-				file_browser_callback: window['<%= name %>'].fileBrowserCallback,
+				file_picker_callback: window['<%= name %>'].filePickerCallback,
 				init_instance_callback: window['<%= name %>'].initInstanceCallback
 			};
 


### PR DESCRIPTION
Hey @adolfopa, 
right now the "image" button in the TinyMCE Editor is opening only de "URL" tab. Although I added the `ImageItemSelectorCriterion` in the itemSelectorURL, it is not adding the "Documents and Media" tab. 
Could you please debug and check what may be happening? 
Many thanks! 