### PR TITLE
LPS-73230 Folder Facet portlet displays ID number for Bookmark folders

### DIFF
--- a/modules/apps/collaboration/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/search/BookmarksFolderIndexer.java
+++ b/modules/apps/collaboration/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/search/BookmarksFolderIndexer.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.BaseIndexer;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.FolderIndexer;
 import com.liferay.portal.kernel.search.IndexWriterHelper;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.SearchContext;
@@ -48,7 +49,8 @@ import org.osgi.service.component.annotations.Reference;
  * @author Eduardo Garcia
  */
 @Component(immediate = true, service = Indexer.class)
-public class BookmarksFolderIndexer extends BaseIndexer<BookmarksFolder> {
+public class BookmarksFolderIndexer 
+	extends BaseIndexer<BookmarksFolder> implements FolderIndexer{
 
 	public static final String CLASS_NAME = BookmarksFolder.class.getName();
 
@@ -63,6 +65,11 @@ public class BookmarksFolderIndexer extends BaseIndexer<BookmarksFolder> {
 	@Override
 	public String getClassName() {
 		return CLASS_NAME;
+	}
+	
+	@Override
+	public String[] getFolderClassNames() {
+		return new String[] {CLASS_NAME};
 	}
 
 	@Override


### PR DESCRIPTION
BookmarksFolderIndexer was not implementing FolderIndexer like other indexers JournalFolderIndexer
That’s why it’s folder title couldn’t be formed in facet. Fixed the issue to displaye corresponding name instead of portlet ID

Test environment :
Liferay version - Liferay 7 (Master)
Server - Tomcat 8
Database - MySQL 5.6
Browser - Chrome, FF, IE