### PR TITLE
LPS-75192 use default locale when no metadata is found

### DIFF
--- a/modules/apps/collaboration/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/util/DLFileEntryTypeUtil.java
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/util/DLFileEntryTypeUtil.java
@@ -46,9 +46,13 @@ public class DLFileEntryTypeUtil {
 
 		for (DDMStructure ddmStructure : dlFileEntryType.getDDMStructures()) {
 			DLFileEntryMetadata dlFileEntryMetadata =
-				DLFileEntryMetadataLocalServiceUtil.getFileEntryMetadata(
+				DLFileEntryMetadataLocalServiceUtil.fetchFileEntryMetadata(
 					ddmStructure.getStructureId(),
 					fileVersion.getFileVersionId());
+
+			if (dlFileEntryMetadata == null) {
+				continue;
+			}
 
 			DDMFormValues ddmFormValues =
 				dlEditFileEntryDisplayContext.getDDMFormValues(


### PR DESCRIPTION
Hi @adolfopa 

Your fix to https://issues.liferay.com/browse/LPS-72132 causes a regression bug that crashes DM portlet when trying to change document type in editing an existing document, because the combination of the new document type and file version has no metadata in DB, as a result, trying to rechieve such metadata to render edit page is invalid.

The reason to use default locale rather than using previous set locale is:
 I gave it a test and it turned out whenever someone changes document type, all previous content is discarded, so it does not neccessary to retain the locale information.

Edit:
Previously I was using try catch to handle control flow, which was rejected by CI, according to comment in LPS-36174, I changed to use fetch method and check its condition.