### PR TITLE
LPS-76152 Replace cross join with inner join

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_3/UpgradeMessageBoards.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_3/UpgradeMessageBoards.java
@@ -45,9 +45,9 @@ public class UpgradeMessageBoards extends UpgradeProcess {
 
 			sb.append("insert into ");
 			sb.append(tempTableName);
-			sb.append(" select MBMessage.threadId from MBThread, MBMessage ");
-			sb.append("where MBThread.threadId = MBMessage.threadId and ");
-			sb.append("MBThread.categoryId = ");
+			sb.append(" select MBMessage.threadId from MBMessage inner join ");
+			sb.append("MBThread on MBMessage.threadId = MBThread.threadId ");
+			sb.append("where MBThread.categoryId = ");
 			sb.append(MBCategoryConstants.DISCUSSION_CATEGORY_ID);
 			sb.append(" group by MBMessage.threadId having ");
 			sb.append("count(MBMessage.messageId) = 1");


### PR DESCRIPTION
While the comma syntax usually results in an inner join because of the where clause, I don't think it's guaranteed, and we have a client where the upgrade hangs at this step for them, even though it proceeds normally in our own testing.