### PR TITLE
LPS-80700 SQLServerException thrown when adding a KB article inside a KB folder, with MS SQL Server

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/resources/META-INF/custom-sql/default.xml
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/resources/META-INF/custom-sql/default.xml
@@ -3,7 +3,7 @@
 <custom-sql>
 	<sql id="com.liferay.knowledge.base.service.persistence.KBArticleFinder.countByUrlTitle">
 		SELECT
-			count(*)
+			COUNT(*) AS COUNT_VALUE
 		FROM
 			KBArticle
 		INNER JOIN


### PR DESCRIPTION
Hey @robertoDiaz 

Could you please check this pull request?

The `com.liferay.knowledge.base.service.persistence.KBArticleFinder.countByUrlTitle` query in _modules/apps/knowledge-base/knowledge-base-service/src/main/resources/META-INF/custom-sql/default.xml_  contains the clause count(*) which will lead the line

```
...
query.addScalar(COUNT_COLUMN_NAME, Type.LONG);
...
```

in `KBArticleFinderImpl` to fail.

Thank you,
István