### PR TITLE
[TECHNICAL-SUPPORT] LPS-84704

### DIFF
--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/content/content.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/content/content.jsp
@@ -98,16 +98,18 @@ PanelCategoryHelper panelCategoryHelper = (PanelCategoryHelper)request.getAttrib
 											portletId = panelCategoryHelper.getFirstPortletId(PanelCategoryKeys.SITE_ADMINISTRATION_CONTENT, permissionChecker, scopeGroup);
 										}
 
-										portletURL = PortalUtil.getControlPanelPortletURL(request, scopeGroup, portletId, 0, 0, PortletRequest.RENDER_PHASE);
+										if (Validator.isNotNull(portletId)) {
+											portletURL = PortalUtil.getControlPanelPortletURL(request, scopeGroup, portletId, 0, 0, PortletRequest.RENDER_PHASE);
 									%>
 
-										<li class="<%= (curScopeGroup.getGroupId() == scopeGroup.getGroupId()) ? "active" : StringPool.BLANK %>">
-											<a class="truncate-text" href="<%= portletURL.toString() %>">
-												<liferay-ui:message key="<%= HtmlUtil.escape(curScopeLayout.getName(locale)) %>" />
-											</a>
-										</li>
+											<li class="<%= (curScopeGroup.getGroupId() == scopeGroup.getGroupId()) ? "active" : StringPool.BLANK %>">
+												<a class="truncate-text" href="<%= portletURL.toString() %>">
+													<liferay-ui:message key="<%= HtmlUtil.escape(curScopeLayout.getName(locale)) %>" />
+												</a>
+											</li>
 
 									<%
+										}
 									}
 									%>
 


### PR DESCRIPTION
/cc @joshuacords 

Notes from Josh:

> https://issues.liferay.com/browse/LPS-84704
> https://issues.liferay.com/browse/LPP-31278
> 
> I haven't found a way to test this on master because Asset Tags now have their own separate Categorization and deploying the test module from LPP-31278 onto master results in a missing dependency. However, examining the code, that because master's code is identical the same errors are possible and need to be addressed.
> 
> Problem: portletId can be returned null if the panelCategoryHelper only has non-scopeable panels to choose from. This results in a NPE. Furthermore, I do not think Scopes without available panels should be displayed at all.
> 
> Solution: Check that portletId is not null before adding each non-default scope.