### PR TITLE
LPS-85217

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/asset/categories/validator/ExternalRepositoryAssetEntryValidatorExclusionRule.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/asset/categories/validator/ExternalRepositoryAssetEntryValidatorExclusionRule.java
@@ -16,7 +16,12 @@ package com.liferay.document.library.internal.asset.categories.validator;
 
 import com.liferay.asset.kernel.validator.AssetEntryValidatorExclusionRule;
 import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFileVersion;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.document.library.kernel.service.DLFileVersionLocalService;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -43,6 +48,20 @@ public class ExternalRepositoryAssetEntryValidatorExclusionRule
 		DLFileEntry dlFileEntry = _dlFileEntryLocalService.fetchDLFileEntry(
 			classPK);
 
+		if (dlFileEntry == null) {
+			try {
+				DLFileVersion dlFileVersion =
+					_dlFileVersionLocalService.fetchDLFileVersion(classPK);
+
+				dlFileEntry = dlFileVersion.getFileEntry();
+			}
+			catch (PortalException pe) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(pe, pe);
+				}
+			}
+		}
+
 		if ((dlFileEntry == null) ||
 			(dlFileEntry.getRepositoryId() != groupId)) {
 
@@ -52,7 +71,13 @@ public class ExternalRepositoryAssetEntryValidatorExclusionRule
 		return false;
 	}
 
+	private static final Log _log = LogFactoryUtil.getLog(
+		ExternalRepositoryAssetEntryValidatorExclusionRule.class);
+
 	@Reference(unbind = "-")
 	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+	@Reference(unbind = "-")
+	private DLFileVersionLocalService _dlFileVersionLocalService;
 
 }


### PR DESCRIPTION
From @wanderlast:

> This issue deals with validation of documents that are a part of the workflow. Specifically, what happens is that the validation step is skipped for documents that are being submitted as drafts (so they are part of an approval workflow).
> 
> In DLAppHelperLocalServiceImpl, where we update our asset entries, if we're adding a draft (see: "if (addDraftAssetEntry)") -- we use the following code for updating our entry:
> 
> ```
> assetEntry = assetEntryLocalService.updateEntry(
> 				userId, fileEntry.getGroupId(), fileEntry.getCreateDate(),
> 				fileEntry.getModifiedDate(),
> 				DLFileEntryConstants.getClassName(),
> 				fileVersion.getFileVersionId(), fileEntry.getUuid(),
> 				fileEntryTypeId, assetCategoryIds, assetTagNames, true, false,
> 				null, null, null, null, fileEntry.getMimeType(),
> 				fileEntry.getTitle(), fileEntry.getDescription(), null, null,
> 				null, 0, 0, null);
> ```
> Specifically, we send fileVersion.getFileVersionId() as our ClassPK.
> 
> When we later try to retrieve a fileEntry using this in ExternalRepositoryAssetEntryValidatorExclusionRule's isValidationExcluded() method:
> 
> ```
> 		DLFileEntry dlFileEntry = _dlFileEntryLocalService.fetchDLFileEntry(
> 			classPK);
> ```
> 
> null is returned which then promptly returns that the fileEntry is excluded from validation.
> 
> This is, of course, incorrect behavior. The fix checks if dlFileEntry returned null and then attempts to use the classPK to retrieve a fileVersion and subsequently a fileEntry from that fileVersion. If this is still null, we know that the null was correct.
> 
> Please let me know if you have any questions or suggestions about the fix. Thanks!

From @chriskian:

> I already asked Lianne if removing `DLFileEntry dlFileEntry = _dlFileEntryLocalService.fetchDLFileEntry(classPK);` would still resolve the issue, but with only one check since `DLFileVersion dlFileVersion = _dlFileVersionLocalService.fetchDLFileVersion(classPK); ` is there.  She told me the first check is needed for "normal" workflow documents, and her added code is for draft workflow docs, so they are both needed.  Otherwise, "normal" workflow docs throw errors when trying to retrieve by fileVersion.
> 
> I also asked about all of the extra arguments, but they were added before her changes, and for seemingly no reason.  Neither of us is sure why.  See [LPS-70393](https://issues.liferay.com/browse/LPS-70393).