### PR TITLE
LPS-86348 If the templateHandler depends on running classNameUpgrade in the Blogs Service we just need to ensure that step run, otherwise we would prevent the rollback of micro changes in the schema version

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/template/BlogsPortletDisplayTemplateHandler.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/template/BlogsPortletDisplayTemplateHandler.java
@@ -152,7 +152,7 @@ public class BlogsPortletDisplayTemplateHandler
 	private Portal _portal;
 
 	@Reference(
-		target = "(&(release.bundle.symbolic.name=com.liferay.blogs.service)(release.schema.version=1.1.2))"
+		target = "(&(release.bundle.symbolic.name=com.liferay.blogs.service)(release.schema.version>=1.0.0))"
 	)
 	private Release _release;
 


### PR DESCRIPTION
Hi @adolfopa,

I realized that you added back the dependency with the blogs service module here:
https://github.com/liferay/liferay-portal/commit/52ab594efa16e41693a6d15dbd34ea4a99d478c7#diff-6f59d89fe8e7d7f305e5ea36589b89e9

I think I made a mistake removing it (because I thought that we already depended on the blogs services) but we should depend on the proper schema version to allow rollback of micro changes.

We talk in person this Monday if you prefer it.

Thanks.

cc @jcampoy