### PR TITLE
LPS-86356 Create upgrade process to create potentially missing Adaptive Media configuration added by LPS-82009

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-document-library-thumbnails/src/main/java/com/liferay/adaptive/media/document/library/thumbnails/internal/upgrade/AMDocumentLibraryThumbnailsUpgrade.java
+++ b/modules/apps/adaptive-media/adaptive-media-document-library-thumbnails/src/main/java/com/liferay/adaptive/media/document/library/thumbnails/internal/upgrade/AMDocumentLibraryThumbnailsUpgrade.java
@@ -15,7 +15,9 @@
 package com.liferay.adaptive.media.document.library.thumbnails.internal.upgrade;
 
 import com.liferay.adaptive.media.document.library.thumbnails.internal.upgrade.v1_0_0.UpgradeDocumentLibraryThumbnailsConfiguration;
+import com.liferay.adaptive.media.document.library.thumbnails.internal.upgrade.v1_0_1.UpgradeDocumentLibraryThumbnailsPreviewConfiguration;
 import com.liferay.adaptive.media.document.library.thumbnails.internal.util.AMCompanyThumbnailConfigurationInitializer;
+import com.liferay.adaptive.media.image.configuration.AMImageConfigurationHelper;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
@@ -36,11 +38,19 @@ public class AMDocumentLibraryThumbnailsUpgrade
 			new UpgradeDocumentLibraryThumbnailsConfiguration(
 				_amCompanyThumbnailConfigurationInitializer,
 				_companyLocalService));
+
+		registry.register(
+			"1.0.0", "1.0.1",
+			new UpgradeDocumentLibraryThumbnailsPreviewConfiguration(
+				_amImageConfigurationHelper, _companyLocalService));
 	}
 
 	@Reference(unbind = "-")
 	private AMCompanyThumbnailConfigurationInitializer
 		_amCompanyThumbnailConfigurationInitializer;
+
+	@Reference(unbind = "-")
+	private AMImageConfigurationHelper _amImageConfigurationHelper;
 
 	@Reference(unbind = "-")
 	private CompanyLocalService _companyLocalService;

--- a/modules/apps/adaptive-media/adaptive-media-document-library-thumbnails/src/main/java/com/liferay/adaptive/media/document/library/thumbnails/internal/upgrade/v1_0_1/UpgradeDocumentLibraryThumbnailsPreviewConfiguration.java
+++ b/modules/apps/adaptive-media/adaptive-media-document-library-thumbnails/src/main/java/com/liferay/adaptive/media/document/library/thumbnails/internal/upgrade/v1_0_1/UpgradeDocumentLibraryThumbnailsPreviewConfiguration.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.adaptive.media.document.library.thumbnails.internal.upgrade.v1_0_1;
+
+import com.liferay.adaptive.media.exception.AMImageConfigurationException;
+import com.liferay.adaptive.media.image.configuration.AMImageConfigurationEntry;
+import com.liferay.adaptive.media.image.configuration.AMImageConfigurationHelper;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.LoggingTimer;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.util.PrefsPropsUtil;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+/**
+ * @author Jonathan McCann
+ */
+public class UpgradeDocumentLibraryThumbnailsPreviewConfiguration
+	extends UpgradeProcess {
+
+	public UpgradeDocumentLibraryThumbnailsPreviewConfiguration(
+		AMImageConfigurationHelper amImageConfigurationHelper,
+		CompanyLocalService companyLocalService) {
+
+		_amImageConfigurationHelper = amImageConfigurationHelper;
+		_companyLocalService = companyLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		try (LoggingTimer loggingTimer = new LoggingTimer()) {
+			int dlFileEntryPreviewMaxHeight = PrefsPropsUtil.getInteger(
+				PropsKeys.DL_FILE_ENTRY_PREVIEW_DOCUMENT_MAX_HEIGHT);
+			int dlFileEntryPreviewMaxWidth = PrefsPropsUtil.getInteger(
+				PropsKeys.DL_FILE_ENTRY_PREVIEW_DOCUMENT_MAX_WIDTH);
+
+			if ((dlFileEntryPreviewMaxHeight <= 0) &&
+				(dlFileEntryPreviewMaxWidth <= 0)) {
+
+				return;
+			}
+
+			String name = String.format(
+				"%s %dx%d", "Preview", dlFileEntryPreviewMaxWidth,
+				dlFileEntryPreviewMaxHeight);
+
+			String normalizedName = _normalize(name);
+
+			Map<String, String> properties = new HashMap<>();
+
+			properties.put(
+				"max-height", String.valueOf(dlFileEntryPreviewMaxHeight));
+			properties.put(
+				"max-width", String.valueOf(dlFileEntryPreviewMaxWidth));
+
+			ActionableDynamicQuery actionableDynamicQuery =
+				_companyLocalService.getActionableDynamicQuery();
+
+			actionableDynamicQuery.setPerformActionMethod(
+				(Company company) -> {
+					try {
+						Collection<AMImageConfigurationEntry>
+							amImageConfigurationEntries =
+								_amImageConfigurationHelper.
+									getAMImageConfigurationEntries(
+										company.getCompanyId(),
+										amImageConfigurationEntry -> true);
+
+						if (_isDuplicate(
+								amImageConfigurationEntries, name,
+								normalizedName)) {
+
+							return;
+						}
+
+						_amImageConfigurationHelper.
+							addAMImageConfigurationEntry(
+								company.getCompanyId(), name,
+								"This image resolution was automatically " +
+									"added.",
+								normalizedName, properties);
+					}
+					catch (Exception e) {
+						_log.error(e, e);
+					}
+				});
+
+			actionableDynamicQuery.performActions();
+		}
+	}
+
+	private boolean _isDuplicate(
+			Collection<AMImageConfigurationEntry> amImageConfigurationEntries,
+			String name, String uuid)
+		throws AMImageConfigurationException {
+
+		Stream<AMImageConfigurationEntry> amImageConfigurationEntryStream =
+			amImageConfigurationEntries.stream();
+
+		Optional<AMImageConfigurationEntry>
+			duplicateNameAMImageConfigurationEntryOptional =
+				amImageConfigurationEntryStream.filter(
+					amImageConfigurationEntry ->
+						name.equals(amImageConfigurationEntry.getName()) ||
+						uuid.equals(amImageConfigurationEntry.getUUID())
+				).findFirst();
+
+		return duplicateNameAMImageConfigurationEntryOptional.isPresent();
+	}
+
+	private String _normalize(String str) {
+		Matcher matcher = _pattern.matcher(str);
+
+		return matcher.replaceAll(StringPool.DASH);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		UpgradeDocumentLibraryThumbnailsPreviewConfiguration.class);
+
+	private static final Pattern _pattern = Pattern.compile("[^\\w-]");
+
+	private final AMImageConfigurationHelper _amImageConfigurationHelper;
+	private final CompanyLocalService _companyLocalService;
+
+}


### PR DESCRIPTION
@sergiogonzalez 

This fix is to make sure the new "Preview" image resolution for Adaptive Media is created for clients who have run the portal before LPS-82009.

The fix itself isn't the prettiest, but there were a number of limitations I had to work around. If you have any other ideas on how to achieve the same result, please let me know.

The biggest issue is that some users will have the image resolution (if they started on fix pack DXP-1 or later) so we if try to call `initializeCompany` again it will throw exceptions since it is trying to add a duplicate image resolution.

This is why I went ahead and duplicated some of the code from AMImageConfigurationHelperImpl. Some things are exposed for consumption but other validation methods are not unfortunately. I also needed some of the code from `initializeCompany` so that is duplicated as well.

Please let me know if you have any thoughts or questions.