### PR TITLE
LPS-86575 Identical header titles will lead to identical links in table of contents

### DIFF
--- a/modules/apps/wiki/wiki-engine-creole/src/main/java/com/liferay/wiki/engine/creole/internal/antlrwiki/translator/XhtmlTranslator.java
+++ b/modules/apps/wiki/wiki-engine-creole/src/main/java/com/liferay/wiki/engine/creole/internal/antlrwiki/translator/XhtmlTranslator.java
@@ -141,6 +141,8 @@ public class XhtmlTranslator extends XhtmlTranslationVisitor {
 		TableOfContentsVisitor tableOfContentsVisitor =
 			new TableOfContentsVisitor();
 
+		_contentMap.clear();
+
 		TreeNode<HeadingNode> tableOfContents = tableOfContentsVisitor.compose(
 			_rootWikiPageNode);
 

--- a/modules/apps/wiki/wiki-engine-creole/src/main/java/com/liferay/wiki/engine/creole/internal/antlrwiki/translator/XhtmlTranslator.java
+++ b/modules/apps/wiki/wiki-engine-creole/src/main/java/com/liferay/wiki/engine/creole/internal/antlrwiki/translator/XhtmlTranslator.java
@@ -141,8 +141,6 @@ public class XhtmlTranslator extends XhtmlTranslationVisitor {
 		TableOfContentsVisitor tableOfContentsVisitor =
 			new TableOfContentsVisitor();
 
-		Map<String, Integer> contentMap = new HashMap<>();
-
 		TreeNode<HeadingNode> tableOfContents = tableOfContentsVisitor.compose(
 			_rootWikiPageNode);
 
@@ -162,7 +160,7 @@ public class XhtmlTranslator extends XhtmlTranslationVisitor {
 		append("<a class=\"toc-trigger\" href=\"javascript:;\">[-]</a></h4>");
 		append("<div class=\"toc-index\">");
 
-		appendTableOfContents(tableOfContents, contentMap, 1);
+		appendTableOfContents(tableOfContents, 1);
 
 		append("</div>");
 		append("</div>");
@@ -191,8 +189,7 @@ public class XhtmlTranslator extends XhtmlTranslationVisitor {
 	}
 
 	protected void appendTableOfContents(
-		TreeNode<HeadingNode> tableOfContents, Map<String, Integer> contentMap,
-		int depth) {
+		TreeNode<HeadingNode> tableOfContents, int depth) {
 
 		List<TreeNode<HeadingNode>> treeNodes = tableOfContents.getChildNodes();
 
@@ -226,21 +223,21 @@ public class XhtmlTranslator extends XhtmlTranslationVisitor {
 			}
 
 			append(StringPool.POUND);
-			append(getHeadingMarkup(_page.getTitle(), content, contentMap));
+			append(getHeadingMarkup(_page.getTitle(), content, _contentMap));
 			append("\">");
 			append(content);
 			append("</a>");
 
-			if (contentMap.containsKey(content)) {
-				int count = contentMap.get(content);
+			if (_contentMap.containsKey(content)) {
+				int count = _contentMap.get(content);
 
-				contentMap.put(content, count + 1);
+				_contentMap.put(content, count + 1);
 			}
 			else {
-				contentMap.put(content, 1);
+				_contentMap.put(content, 1);
 			}
 
-			appendTableOfContents(treeNode, contentMap, depth + 1);
+			appendTableOfContents(treeNode, depth + 1);
 
 			append("</li>");
 		}
@@ -291,21 +288,19 @@ public class XhtmlTranslator extends XhtmlTranslationVisitor {
 	protected String getHeadingMarkup(
 		String prefix, String text, Map<String, Integer> map) {
 
-		StringBundler sb = new StringBundler(6);
-
-		sb.append(_HEADING_ANCHOR_PREFIX);
-		sb.append(prefix);
-		sb.append(StringPool.DASH);
-		sb.append(text.trim());
-
-		if ((map != null) && map.containsKey(text)) {
-			int count = map.get(text);
-
-			sb.append(StringPool.DASH);
-			sb.append(count);
+		if ((map == null) || map.isEmpty() || !map.containsKey(text)) {
+			return StringUtil.replace(
+				StringBundler.concat(
+					_HEADING_ANCHOR_PREFIX, prefix, StringPool.DASH,
+					text.trim()),
+				CharPool.SPACE, CharPool.PLUS);
 		}
 
-		return StringUtil.replace(sb.toString(), CharPool.SPACE, CharPool.PLUS);
+		return StringUtil.replace(
+			StringBundler.concat(
+				_HEADING_ANCHOR_PREFIX, prefix, StringPool.DASH, text.trim(),
+				StringPool.DASH, map.get(text)),
+			CharPool.SPACE, CharPool.PLUS);
 	}
 
 	protected String getUnformattedHeadingText(HeadingNode headingNode) {
@@ -337,6 +332,7 @@ public class XhtmlTranslator extends XhtmlTranslationVisitor {
 		XhtmlTranslator.class);
 
 	private String _attachmentURLPrefix;
+	private final Map<String, Integer> _contentMap = new HashMap<>();
 	private PortletURL _editPageURL;
 	private final Map<String, Integer> _headingMap = new HashMap<>();
 	private WikiPage _page;


### PR DESCRIPTION
Hey @adolfopa,

Could you please review this pull request?

It is possible to create table of contents that have identical titles.
For example, there may be more than one heading named Heading1, which will lead to multiple entries in the table of contents with the title Heading1.

If this happens, all of the entries with the title Heading1 will link to the first Heading1 header in the Wiki page, although each Heading1 titled entry should point to it's respective heading.

I solved this issue by keeping track of ToC entries and headings each in their own Maps, and generate unique serial numbers for their occurrences if they happen to appear more then once in the Wiki page.

Thank you and best regards,
István