### PR TITLE
LPS-86807 Wiki attachment image with an ampersand in the file name does not appear on page

### DIFF
--- a/modules/apps/wiki/wiki-engine-creole/src/main/java/com/liferay/wiki/engine/creole/internal/antlrwiki/translator/XhtmlTranslator.java
+++ b/modules/apps/wiki/wiki-engine-creole/src/main/java/com/liferay/wiki/engine/creole/internal/antlrwiki/translator/XhtmlTranslator.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TreeNode;
+import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.wiki.engine.creole.internal.antlrwiki.translator.internal.UnformattedHeadingTextVisitor;
 import com.liferay.wiki.engine.creole.internal.antlrwiki.translator.internal.UnformattedLinksTextVisitor;
 import com.liferay.wiki.engine.creole.internal.parser.ast.CollectionNode;
@@ -101,11 +102,11 @@ public class XhtmlTranslator extends XhtmlTranslationVisitor {
 		append(" src=\"");
 
 		if (imageNode.isAbsoluteLink()) {
-			append(imageNode.getLink());
+			append(URLCodec.encodeURL(imageNode.getLink()));
 		}
 		else {
 			append(_attachmentURLPrefix);
-			append(imageNode.getLink());
+			append(URLCodec.encodeURL(imageNode.getLink()));
 		}
 
 		append("\" />");


### PR DESCRIPTION
Hey @robertoDiaz 

Could you please review this pull request?
Is is forwarded from https://github.com/IstvanD/liferay-portal/pull/75

The solution fixes only the issue with the published Wiki pages.
The broken image icon in the editor view will be dealt with in a separate LPS.

@amadeafejes 

Thank you and best regards,
István