### PR TITLE
LPS-88410 Cannot properly scroll from mobile device in Documents and Media portlet, List view, if logged in

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
@@ -86,7 +86,7 @@ if (portletTitleBasedNavigation && (folderId != DLFolderConstants.DEFAULT_PARENT
 					<%
 					boolean draggable = false;
 
-					if (DLFileEntryPermission.contains(permissionChecker, fileEntry, ActionKeys.DELETE) || DLFileEntryPermission.contains(permissionChecker, fileEntry, ActionKeys.UPDATE)) {
+					if (!BrowserSnifferUtil.isMobile(request) && (DLFileEntryPermission.contains(permissionChecker, fileEntry, ActionKeys.DELETE) || DLFileEntryPermission.contains(permissionChecker, fileEntry, ActionKeys.UPDATE))) {
 						draggable = true;
 
 						if (dlSearchContainer.getRowMover() == null) {
@@ -359,7 +359,7 @@ if (portletTitleBasedNavigation && (folderId != DLFolderConstants.DEFAULT_PARENT
 
 					boolean draggable = false;
 
-					if (DLFolderPermission.contains(permissionChecker, curFolder, ActionKeys.DELETE) || DLFolderPermission.contains(permissionChecker, curFolder, ActionKeys.UPDATE)) {
+					if (!BrowserSnifferUtil.isMobile(request) && (DLFolderPermission.contains(permissionChecker, curFolder, ActionKeys.DELETE) || DLFolderPermission.contains(permissionChecker, curFolder, ActionKeys.UPDATE))) {
 						draggable = true;
 
 						if (dlSearchContainer.getRowMover() == null) {


### PR DESCRIPTION
Hey @robertoDiaz 

Could you please review this pull request?

The root cause of the issue is that document and folders entries are configured to be draggable (movable from one folder to another) and this conflicts with the dragging functionality of touchscreen devices.

I disabled the rowMover on mobile (touchscreen) devices since dragging and dropping documents isn't possible on touchscreens in the first place.

Thank you and best regards,
István