### PR TITLE
[TECHNICAL-SUPPORT] LPS-88484

### DIFF
--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppHelperLocalService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppHelperLocalService.java
@@ -23,6 +23,7 @@ import com.liferay.document.library.kernel.model.DLFolder;
 
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.messaging.async.Async;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileShortcut;
 import com.liferay.portal.kernel.repository.model.FileVersion;
@@ -157,6 +158,10 @@ public interface DLAppHelperLocalService extends BaseLocalService {
 	*/
 	public Folder moveFolderToTrash(long userId, Folder folder)
 		throws PortalException;
+
+	@Async
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public void reindex(List<Long> dlFileEntryIds) throws PortalException;
 
 	public void restoreDependentsFromTrash(DLFolder dlFolder)
 		throws PortalException;

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppHelperLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppHelperLocalServiceUtil.java
@@ -214,6 +214,11 @@ public class DLAppHelperLocalServiceUtil {
 		return getService().moveFolderToTrash(userId, folder);
 	}
 
+	public static void reindex(java.util.List<Long> dlFileEntryIds)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		getService().reindex(dlFileEntryIds);
+	}
+
 	public static void restoreDependentsFromTrash(
 		com.liferay.document.library.kernel.model.DLFolder dlFolder)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppHelperLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppHelperLocalServiceWrapper.java
@@ -229,6 +229,12 @@ public class DLAppHelperLocalServiceWrapper implements DLAppHelperLocalService,
 	}
 
 	@Override
+	public void reindex(java.util.List<Long> dlFileEntryIds)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		_dlAppHelperLocalService.reindex(dlFileEntryIds);
+	}
+
+	@Override
 	public void restoreDependentsFromTrash(
 		com.liferay.document.library.kernel.model.DLFolder dlFolder)
 		throws com.liferay.portal.kernel.exception.PortalException {


### PR DESCRIPTION
@adolfopa 

Please let me know your thoughts on these changes. I thought about making a call to the `ExecutorService` or `BackgroundTask` but thought that using `@Async` was the cleanest solution.

Additionally, if the reindex was changed to something like `indexer.reindex(dlFileEntries)` it performs worse (in regards to releasing control back to the user) than the `IndexableActionableDynamicQuery` despite needing to be refetched.