### PR TITLE
[TECHNICAL-SUPPORT] LPS-88550

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_1/UpgradeDocumentLibrary.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_1/UpgradeDocumentLibrary.java
@@ -125,8 +125,8 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 			sb.append("select fileVersionId, DDMStructureId from ");
 			sb.append("DLFileEntryMetadata where fileVersionId in (select ");
 			sb.append("fileVersionId from DLFileEntryMetadata group by ");
-			sb.append("fileVersionId having count(*) = 2) and DDMStructureId ");
-			sb.append("= ?");
+			sb.append("fileVersionId having count(*) >= 2) and ");
+			sb.append("DDMStructureId = ?");
 
 			try (PreparedStatement ps1 = connection.prepareStatement(
 					sb.toString());


### PR DESCRIPTION
@adolfopa 

Some notes on how it is possible to get into this situation:

1. Before LPS-30576 was introduced, there would be DLFileEntryMetadata entries for every DLFileEntry for each Portal Instance (ie 3 portal instances leads to 3 distinct entries within DLFileEntryMetadata)

2. In 6.2 a new DDMStructure was created for TIKARAWMETADATA (as evidenced by LPS-65441). If a user edits a DLFileEntry after this is introduced then a new DLFileEntryMetadata entry is created pointing to the new DDMStructure.

3. In 7.0 this issue was partially resolved by LPS-69329. It assumed that only duplicates would be encountered. However, this did not take into account #1 where multiple portal instances could errantly create duplicate DLFileEntryMetadata entries.

The solution proposed here is instead of searching for exactly 2 duplicated entries we should search for 2 or greater entries.

Please let me know if you have any questions or concerns.