### PR TITLE
[TECHNICAL-SUPPORT] LPS-88490

### DIFF
--- a/modules/apps/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/internal/exportimport/data/handler/BookmarksEntryStagedModelDataHandler.java
+++ b/modules/apps/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/internal/exportimport/data/handler/BookmarksEntryStagedModelDataHandler.java
@@ -17,12 +17,14 @@ package com.liferay.bookmarks.internal.exportimport.data.handler;
 import com.liferay.bookmarks.model.BookmarksEntry;
 import com.liferay.bookmarks.model.BookmarksFolder;
 import com.liferay.bookmarks.model.BookmarksFolderConstants;
+import com.liferay.bookmarks.service.BookmarksEntryLocalService;
 import com.liferay.exportimport.data.handler.base.BaseStagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.ExportImportPathUtil;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.exportimport.staged.model.repository.StagedModelRepository;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.xml.Element;
 
@@ -117,10 +119,15 @@ public class BookmarksEntryStagedModelDataHandler
 				portletDataContext, importedEntry);
 		}
 		else {
-			importedEntry.setEntryId(existingEntry.getEntryId());
+			long userId = portletDataContext.getUserId(entry.getUserUuid());
 
-			importedEntry = _stagedModelRepository.updateStagedModel(
-				portletDataContext, importedEntry);
+			ServiceContext serviceContext =
+				portletDataContext.createServiceContext(entry);
+
+			importedEntry = _bookmarksEntryLocalService.updateEntry(
+				userId, existingEntry.getEntryId(), entry.getGroupId(),
+				entry.getFolderId(), entry.getName(), entry.getUrl(),
+				entry.getDescription(), serviceContext);
 		}
 
 		portletDataContext.importClassedModel(entry, importedEntry);
@@ -140,6 +147,9 @@ public class BookmarksEntryStagedModelDataHandler
 
 		_stagedModelRepository = stagedModelRepository;
 	}
+
+	@Reference
+	private BookmarksEntryLocalService _bookmarksEntryLocalService;
 
 	private StagedModelRepository<BookmarksEntry> _stagedModelRepository;
 


### PR DESCRIPTION
/cc @joshuacords 

Notes from Josh:
> https://issues.liferay.com/browse/LPS-88490
> https://issues.liferay.com/browse/LPP-32496
> 
> **Problem**: Overwriting the EntryId before the updateStagedModel() makes the serviceContext will cause the [assetCategory](https://github.com/joshuacords/liferay-portal/blob/0397da87d4353a608b65e82ad2527873ea5df9c5/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextImpl.java#L737-L744) and assetTag maps to try looking up by the wrong BookmarkEntry id. 
> 
> **Solution**: Instead, initialize the serviceContext beforehand just like [Blogs](https://github.com/joshuacords/liferay-portal/blob/4e348adc47223835111669ab0db240032313c12a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/exportimport/data/handler/BlogsEntryStagedModelDataHandler.java#L263-L268) does.
> 
> I did check all the other StagedModelDataHandlers where duplicates of the original code existed: AssetDisplayPageEntry, AssetListEntry, AssetListEntryAssetEntryRel, BookmarkFolders, DDLRecordSet, DDMFormInstance, FragmentEntry, FragmentCollection, FragmentEntryLink, LayoutPageTemplateCollection, LayoutPageTemplateStructure, LayoutPageTemplateEntry, SiteNavigationMenu, SiteNavigationMenuItem - but none of these appear to be using Categories and Tags so no changes are necessary.