### PR TITLE
[TECHNICAL-SUPPORT] LPS-76639

### DIFF
--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/persistence/MBThreadFinder.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/persistence/MBThreadFinder.java
@@ -45,6 +45,10 @@ public interface MBThreadFinder {
 		boolean anonymous,
 		com.liferay.portal.kernel.dao.orm.QueryDefinition<com.liferay.message.boards.model.MBThread> queryDefinition);
 
+	public int countByG_U_LPD_A(long groupId, long userId,
+		java.util.Date lastPostDate, boolean includeAnonymous,
+		com.liferay.portal.kernel.dao.orm.QueryDefinition<com.liferay.message.boards.model.MBThread> queryDefinition);
+
 	public int countByS_G_U_C(long groupId, long userId, long[] categoryIds,
 		com.liferay.portal.kernel.dao.orm.QueryDefinition<com.liferay.message.boards.model.MBThread> queryDefinition);
 
@@ -96,6 +100,11 @@ public interface MBThreadFinder {
 
 	public java.util.List<com.liferay.message.boards.model.MBThread> findByG_U_C_A(
 		long groupId, long userId, long[] categoryIds, boolean anonymous,
+		com.liferay.portal.kernel.dao.orm.QueryDefinition<com.liferay.message.boards.model.MBThread> queryDefinition);
+
+	public java.util.List<com.liferay.message.boards.model.MBThread> findByG_U_LPD_A(
+		long groupId, long userId, java.util.Date lastPostDate,
+		boolean includeAnonymous,
 		com.liferay.portal.kernel.dao.orm.QueryDefinition<com.liferay.message.boards.model.MBThread> queryDefinition);
 
 	public java.util.List<com.liferay.message.boards.model.MBThread> findByS_G_U_C(

--- a/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/service/persistence/packageinfo
+++ b/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBThreadServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBThreadServiceImpl.java
@@ -84,8 +84,13 @@ public class MBThreadServiceImpl extends MBThreadServiceBaseImpl {
 			QueryDefinition<MBThread> queryDefinition = new QueryDefinition<>(
 				status, start, end, null);
 
-			return mbThreadFinder.findByG_U_LPD(
-				groupId, userId, modifiedDate, queryDefinition);
+			if (includeAnonymous) {
+				return mbThreadFinder.findByG_U_LPD(
+					groupId, userId, modifiedDate, queryDefinition);
+			}
+
+			return mbThreadFinder.findByG_U_LPD_A(
+				groupId, userId, modifiedDate, false, queryDefinition);
 		}
 
 		long[] categoryIds = mbCategoryService.getCategoryIds(
@@ -212,8 +217,13 @@ public class MBThreadServiceImpl extends MBThreadServiceBaseImpl {
 			QueryDefinition<MBThread> queryDefinition = new QueryDefinition<>(
 				status);
 
-			return mbThreadFinder.countByG_U_LPD(
-				groupId, userId, modifiedDate, queryDefinition);
+			if (includeAnonymous) {
+				return mbThreadFinder.countByG_U_LPD(
+					groupId, userId, modifiedDate, queryDefinition);
+			}
+
+			return mbThreadFinder.countByG_U_LPD_A(
+				groupId, userId, modifiedDate, false, queryDefinition);
 		}
 
 		long[] categoryIds = mbCategoryService.getCategoryIds(

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/persistence/impl/MBThreadFinderImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/persistence/impl/MBThreadFinderImpl.java
@@ -215,56 +215,8 @@ public class MBThreadFinderImpl
 		long groupId, long userId, Date lastPostDate,
 		QueryDefinition<MBThread> queryDefinition) {
 
-		Session session = null;
-
-		try {
-			session = openSession();
-
-			String sql = _customSQL.get(getClass(), COUNT_BY_G_U_LPD);
-
-			if (userId <= 0) {
-				sql = StringUtil.replace(
-					sql, _INNER_JOIN_SQL, StringPool.BLANK);
-				sql = StringUtil.replace(sql, _USER_ID_SQL, StringPool.BLANK);
-			}
-
-			sql = updateSQL(sql, queryDefinition);
-
-			SQLQuery q = session.createSynchronizedSQLQuery(sql);
-
-			q.addScalar(COUNT_COLUMN_NAME, Type.LONG);
-
-			QueryPos qPos = QueryPos.getInstance(q);
-
-			qPos.add(groupId);
-			qPos.add(lastPostDate);
-
-			if (userId > 0) {
-				qPos.add(userId);
-			}
-
-			if (queryDefinition.getStatus() != WorkflowConstants.STATUS_ANY) {
-				qPos.add(queryDefinition.getStatus());
-			}
-
-			Iterator<Long> itr = q.iterate();
-
-			if (itr.hasNext()) {
-				Long count = itr.next();
-
-				if (count != null) {
-					return count.intValue();
-				}
-			}
-
-			return 0;
-		}
-		catch (Exception e) {
-			throw new SystemException(e);
-		}
-		finally {
-			closeSession(session);
-		}
+		return countByG_U_LPD_A(
+			groupId, userId, lastPostDate, true, queryDefinition);
 	}
 
 	@Override
@@ -357,6 +309,71 @@ public class MBThreadFinderImpl
 			qPos.add(groupId);
 			qPos.add(userId);
 			qPos.add(anonymous);
+
+			if (queryDefinition.getStatus() != WorkflowConstants.STATUS_ANY) {
+				qPos.add(queryDefinition.getStatus());
+			}
+
+			Iterator<Long> itr = q.iterate();
+
+			if (itr.hasNext()) {
+				Long count = itr.next();
+
+				if (count != null) {
+					return count.intValue();
+				}
+			}
+
+			return 0;
+		}
+		catch (Exception e) {
+			throw new SystemException(e);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	@Override
+	public int countByG_U_LPD_A(
+		long groupId, long userId, Date lastPostDate, boolean includeAnonymous,
+		QueryDefinition<MBThread> queryDefinition) {
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			String sql = _customSQL.get(getClass(), COUNT_BY_G_U_LPD);
+
+			if (userId <= 0) {
+				if (includeAnonymous) {
+					sql = StringUtil.replace(
+						sql, _INNER_JOIN_SQL, StringPool.BLANK);
+				}
+
+				sql = StringUtil.replace(sql, _USER_ID_SQL, StringPool.BLANK);
+			}
+
+			sql = updateSQL(sql, queryDefinition);
+
+			if (!includeAnonymous) {
+				sql = _customSQL.appendCriteria(
+					sql, "AND (MBMessage.anonymous = [$FALSE$])");
+			}
+
+			SQLQuery q = session.createSynchronizedSQLQuery(sql);
+
+			q.addScalar(COUNT_COLUMN_NAME, Type.LONG);
+
+			QueryPos qPos = QueryPos.getInstance(q);
+
+			qPos.add(groupId);
+			qPos.add(lastPostDate);
+
+			if (userId > 0) {
+				qPos.add(userId);
+			}
 
 			if (queryDefinition.getStatus() != WorkflowConstants.STATUS_ANY) {
 				qPos.add(queryDefinition.getStatus());
@@ -654,48 +671,8 @@ public class MBThreadFinderImpl
 		long groupId, long userId, Date lastPostDate,
 		QueryDefinition<MBThread> queryDefinition) {
 
-		Session session = null;
-
-		try {
-			session = openSession();
-
-			String sql = _customSQL.get(getClass(), FIND_BY_G_U_LPD);
-
-			if (userId <= 0) {
-				sql = StringUtil.replace(
-					sql, _INNER_JOIN_SQL, StringPool.BLANK);
-				sql = StringUtil.replace(sql, _USER_ID_SQL, StringPool.BLANK);
-			}
-
-			sql = updateSQL(sql, queryDefinition);
-
-			SQLQuery q = session.createSynchronizedSQLQuery(sql);
-
-			q.addEntity("MBThread", MBThreadImpl.class);
-
-			QueryPos qPos = QueryPos.getInstance(q);
-
-			qPos.add(groupId);
-			qPos.add(lastPostDate);
-
-			if (userId > 0) {
-				qPos.add(userId);
-			}
-
-			if (queryDefinition.getStatus() != WorkflowConstants.STATUS_ANY) {
-				qPos.add(queryDefinition.getStatus());
-			}
-
-			return (List<MBThread>)QueryUtil.list(
-				q, getDialect(), queryDefinition.getStart(),
-				queryDefinition.getEnd());
-		}
-		catch (Exception e) {
-			throw new SystemException(e);
-		}
-		finally {
-			closeSession(session);
-		}
+		return findByG_U_LPD_A(
+			groupId, userId, lastPostDate, true, queryDefinition);
 	}
 
 	@Override
@@ -812,6 +789,63 @@ public class MBThreadFinderImpl
 			qPos.add(groupId);
 			qPos.add(userId);
 			qPos.add(anonymous);
+
+			if (queryDefinition.getStatus() != WorkflowConstants.STATUS_ANY) {
+				qPos.add(queryDefinition.getStatus());
+			}
+
+			return (List<MBThread>)QueryUtil.list(
+				q, getDialect(), queryDefinition.getStart(),
+				queryDefinition.getEnd());
+		}
+		catch (Exception e) {
+			throw new SystemException(e);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	@Override
+	public List<MBThread> findByG_U_LPD_A(
+		long groupId, long userId, Date lastPostDate, boolean includeAnonymous,
+		QueryDefinition<MBThread> queryDefinition) {
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			String sql = _customSQL.get(getClass(), FIND_BY_G_U_LPD);
+
+			if (userId <= 0) {
+				if (includeAnonymous) {
+					sql = StringUtil.replace(
+						sql, _INNER_JOIN_SQL, StringPool.BLANK);
+				}
+
+				sql = StringUtil.replace(sql, _USER_ID_SQL, StringPool.BLANK);
+			}
+
+			sql = updateSQL(sql, queryDefinition);
+
+			if (!includeAnonymous) {
+				sql = _customSQL.appendCriteria(
+					sql, "AND (MBMessage.anonymous = [$FALSE$])");
+			}
+
+			SQLQuery q = session.createSynchronizedSQLQuery(sql);
+
+			q.addEntity("MBThread", MBThreadImpl.class);
+
+			QueryPos qPos = QueryPos.getInstance(q);
+
+			qPos.add(groupId);
+			qPos.add(lastPostDate);
+
+			if (userId > 0) {
+				qPos.add(userId);
+			}
 
 			if (queryDefinition.getStatus() != WorkflowConstants.STATUS_ANY) {
 				qPos.add(queryDefinition.getStatus());

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/persistence/impl/MBThreadFinderImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/persistence/impl/MBThreadFinderImpl.java
@@ -347,17 +347,15 @@ public class MBThreadFinderImpl
 			String sql = _customSQL.get(getClass(), COUNT_BY_G_U_LPD);
 
 			if (userId <= 0) {
-				if (includeAnonymous) {
-					sql = StringUtil.replace(
-						sql, _INNER_JOIN_SQL, StringPool.BLANK);
-				}
+				sql = StringUtil.replace(
+					sql, _INNER_JOIN_SQL, StringPool.BLANK);
 
 				sql = StringUtil.replace(sql, _USER_ID_SQL, StringPool.BLANK);
 			}
 
 			sql = updateSQL(sql, queryDefinition);
 
-			if (!includeAnonymous) {
+			if (!includeAnonymous && (userId > 0)) {
 				sql = _customSQL.appendCriteria(
 					sql, "AND (MBMessage.anonymous = [$FALSE$])");
 			}
@@ -819,17 +817,15 @@ public class MBThreadFinderImpl
 			String sql = _customSQL.get(getClass(), FIND_BY_G_U_LPD);
 
 			if (userId <= 0) {
-				if (includeAnonymous) {
-					sql = StringUtil.replace(
-						sql, _INNER_JOIN_SQL, StringPool.BLANK);
-				}
+				sql = StringUtil.replace(
+					sql, _INNER_JOIN_SQL, StringPool.BLANK);
 
 				sql = StringUtil.replace(sql, _USER_ID_SQL, StringPool.BLANK);
 			}
 
 			sql = updateSQL(sql, queryDefinition);
 
-			if (!includeAnonymous) {
+			if (!includeAnonymous && (userId > 0)) {
 				sql = _customSQL.appendCriteria(
 					sql, "AND (MBMessage.anonymous = [$FALSE$])");
 			}


### PR DESCRIPTION
The first two commits are the same as your original fix but it had the following issues:

1. Decreased the performance of viewing the "Recent Posts" tab
2. Anonymous posts were never displayed in the "Recent Posts" tab

https://github.com/adolfopa/liferay-portal/commit/43f4bbb6829a6e9a8e0971bd875535a45bd5cf91 addresses these issues by filtering out anonymous posts only if there is a `userId` passed in. The `userId` is passed when clicking on the "Recent Posts" link next to a user's name. When clicking on the tab itself, `0` is passed for the `userId`. Additionally, if a user clicks on their own "Recent Posts" link then the anonymous posts will appear because `includeAnonymous` will be `true` so the additional `false` logic will not be triggered.

I do not know what performance tests were run to find the regression described in https://github.com/brianchandotcom/liferay-portal/pull/57388 but I'm hoping that by only performing the `join` when there is a `userId` will be enough.

If you know how to run those performance tests or know of a different way to fetch back the information we need in order to filter out the anonymous posts please let me know.