### PR TITLE
[TS] LPS-88004 Staging should not restrict deleting or editing comments on Live site when required permissions are granted

### DIFF
--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/security/permission/resource/definition/BlogsEntryModelResourcePermissionDefinition.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/security/permission/resource/definition/BlogsEntryModelResourcePermissionDefinition.java
@@ -20,6 +20,8 @@ import com.liferay.blogs.model.BlogsEntry;
 import com.liferay.blogs.service.BlogsEntryLocalService;
 import com.liferay.exportimport.kernel.staging.permission.StagingPermission;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermissionLogic;
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
@@ -68,9 +70,27 @@ public class BlogsEntryModelResourcePermissionDefinition
 			modelResourcePermissionLogicConsumer) {
 
 		modelResourcePermissionLogicConsumer.accept(
-			new StagedModelPermissionLogic<>(
+			new StagedModelPermissionLogic<BlogsEntry>(
 				_stagingPermission, BlogsPortletKeys.BLOGS,
-				BlogsEntry::getEntryId));
+				BlogsEntry::getEntryId) {
+
+				@Override
+				public Boolean contains(
+					PermissionChecker permissionChecker, String name,
+					BlogsEntry blogsEntry, String actionId) {
+
+					if (actionId.equals(ActionKeys.UPDATE_DISCUSSION) ||
+						actionId.equals(ActionKeys.DELETE_DISCUSSION)) {
+
+						return null;
+					}
+
+					return super.contains(
+						permissionChecker, name, blogsEntry, actionId);
+				}
+
+			});
+
 		modelResourcePermissionLogicConsumer.accept(
 			new WorkflowedModelPermissionLogic<>(
 				_workflowPermission, modelResourcePermission,

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/security/permission/resource/DLFileEntryModelResourcePermissionRegistrar.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/security/permission/resource/DLFileEntryModelResourcePermissionRegistrar.java
@@ -72,9 +72,30 @@ public class DLFileEntryModelResourcePermissionRegistrar {
 				_portletResourcePermission,
 				(modelResourcePermission, consumer) -> {
 					consumer.accept(
-						new StagedModelPermissionLogic<>(
+						new StagedModelPermissionLogic<DLFileEntry>(
 							_stagingPermission, DLPortletKeys.DOCUMENT_LIBRARY,
-							DLFileEntry::getFileEntryId));
+							DLFileEntry::getFileEntryId) {
+
+							@Override
+							public Boolean contains(
+								PermissionChecker permissionChecker,
+								String name, DLFileEntry dlFileEntry,
+								String actionId) {
+
+								if (actionId.equals(
+										ActionKeys.UPDATE_DISCUSSION) ||
+									actionId.equals(
+										ActionKeys.DELETE_DISCUSSION)) {
+
+									return null;
+								}
+
+								return super.contains(
+									permissionChecker, name, dlFileEntry,
+									actionId);
+							}
+
+						});
 					consumer.accept(
 						new DLFileEntryWorkflowedModelPermissionLogic(
 							modelResourcePermission));

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/security/permission/resource/JournalArticleModelResourcePermissionRegistrar.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/security/permission/resource/JournalArticleModelResourcePermissionRegistrar.java
@@ -80,9 +80,30 @@ public class JournalArticleModelResourcePermissionRegistrar {
 				_portletResourcePermission,
 				(modelResourcePermission, consumer) -> {
 					consumer.accept(
-						new StagedModelPermissionLogic<>(
+						new StagedModelPermissionLogic<JournalArticle>(
 							_stagingPermission, JournalPortletKeys.JOURNAL,
-							JournalArticle::getResourcePrimKey));
+							JournalArticle::getResourcePrimKey) {
+
+							@Override
+							public Boolean contains(
+								PermissionChecker permissionChecker,
+								String name, JournalArticle journalArticle,
+								String actionId) {
+
+								if (actionId.equals(
+										ActionKeys.UPDATE_DISCUSSION) ||
+									actionId.equals(
+										ActionKeys.DELETE_DISCUSSION)) {
+
+									return null;
+								}
+
+								return super.contains(
+									permissionChecker, name, journalArticle,
+									actionId);
+							}
+
+						});
 					consumer.accept(
 						new WorkflowedModelPermissionLogic<>(
 							_workflowPermission, modelResourcePermission,

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/security/permission/resource/WikiPageModelResourcePermissionRegistrar.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/security/permission/resource/WikiPageModelResourcePermissionRegistrar.java
@@ -74,9 +74,30 @@ public class WikiPageModelResourcePermissionRegistrar {
 				_portletResourcePermission,
 				(modelResourcePermission, consumer) -> {
 					consumer.accept(
-						new StagedModelPermissionLogic<>(
+						new StagedModelPermissionLogic<WikiPage>(
 							_stagingPermission, WikiPortletKeys.WIKI,
-							WikiPage::getResourcePrimKey));
+							WikiPage::getResourcePrimKey) {
+
+							@Override
+							public Boolean contains(
+								PermissionChecker permissionChecker,
+								String name, WikiPage wikiPage,
+								String actionId) {
+
+								if (actionId.equals(
+										ActionKeys.UPDATE_DISCUSSION) ||
+									actionId.equals(
+										ActionKeys.DELETE_DISCUSSION)) {
+
+									return null;
+								}
+
+								return super.contains(
+									permissionChecker, name, wikiPage,
+									actionId);
+							}
+
+						});
 					consumer.accept(
 						new WorkflowedModelPermissionLogic<>(
 							_workflowPermission, modelResourcePermission,

--- a/portal-impl/src/com/liferay/portal/service/permission/LayoutPermissionImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/permission/LayoutPermissionImpl.java
@@ -552,12 +552,16 @@ public class LayoutPermissionImpl
 		Group group = layout.getGroup();
 
 		if (group.hasLocalOrRemoteStagingGroup()) {
-			Boolean hasPermission = StagingPermissionUtil.hasPermission(
-				permissionChecker, group, Layout.class.getName(),
-				layout.getGroupId(), null, actionId);
+			if (!actionId.equals(ActionKeys.DELETE_DISCUSSION) &&
+				!actionId.equals(ActionKeys.UPDATE_DISCUSSION)) {
 
-			if (hasPermission != null) {
-				return hasPermission.booleanValue();
+				Boolean hasPermission = StagingPermissionUtil.hasPermission(
+					permissionChecker, group, Layout.class.getName(),
+					layout.getGroupId(), null, actionId);
+
+				if (hasPermission != null) {
+					return hasPermission.booleanValue();
+				}
 			}
 		}
 		else if (!checkViewableGroup && group.isUserGroup() &&


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-88004

Hey Adolfo,

Vendel checked all entities (including the private modules) supporting discussion (based on their `resource-actions` xml and found these "affected":
* BlogsEntry
* DLFileEntry
* JournalArticle
* Layout
* WikiPage

Not affected:
* CalendarBooking uses a different approach for checking comment permissions in staging. It is working correctly already.
* TaskEntry is not staged at all, so there's no need to control permissions from staging perspective.

Author: @vendeltoreki
Reviewers: @danielkocsis, @lipusz
Staging review: :heavy_check_mark: 
Security review: :heavy_check_mark: 

@ealonso: fyi since it changes `JournalArticleModelResourcePermissionRegistrar`. Just in case you want to take a look at.

Thanks,
Tibor