### PR TITLE
[TECHNICAL-SUPPORT] lps-89281

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/webdav/DLWebDAVStorageImpl.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/webdav/DLWebDAVStorageImpl.java
@@ -53,10 +53,13 @@ import com.liferay.portal.kernel.lock.Lock;
 import com.liferay.portal.kernel.lock.NoSuchLockException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.RoleConstants;
 import com.liferay.portal.kernel.repository.capabilities.TrashCapability;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
@@ -821,6 +824,10 @@ public class DLWebDAVStorageImpl extends BaseWebDAVStorageImpl {
 			long groupId = webDAVRequest.getGroupId();
 			long parentFolderId = getParentFolderId(
 				webDAVRequest.getCompanyId(), pathArray);
+
+			Role defaultGroupRole =
+				RoleLocalServiceUtil.getDefaultGroupRole(groupId);
+
 			String title = getTitle(pathArray);
 			String description = StringPool.BLANK;
 			String changeLog = StringPool.BLANK;
@@ -830,7 +837,12 @@ public class DLWebDAVStorageImpl extends BaseWebDAVStorageImpl {
 
 			serviceContext.setAddGroupPermissions(
 				isAddGroupPermissions(groupId));
-			serviceContext.setAddGuestPermissions(true);
+
+			if (defaultGroupRole.equals(RoleConstants.GUEST)) {
+				serviceContext.setAddGuestPermissions(true);
+			} else {
+				serviceContext.setAddGuestPermissions(false);
+			}
 
 			String extension = FileUtil.getExtension(title);
 


### PR DESCRIPTION
Relevant tickets:
https://issues.liferay.com/browse/LPS-89281

Hi Adolfo,

From as far back as git tracks, we've setAddGuestPermissions to true when uploading via WebDAV. However, when a site is private the documents still get the guest permissions added. Comparing this with the multiple files uploader, if a site is open, then we default the permissions to site member, rather than guest. I attempted to emulate this same check in this pull request.