### PR TITLE
[TECHNICAL-SUPPORT] LPS-89503

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_more_menu_items.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_more_menu_items.jsp
@@ -58,6 +58,10 @@ JournalViewMoreMenuItemsDisplayContext journalViewMoreMenuItemsDisplayContext = 
 	<liferay-ui:search-container
 		searchContainer="<%= journalViewMoreMenuItemsDisplayContext.getDDMStructuresSearchContainer() %>"
 	>
+		<liferay-ui:search-container-results
+			results="<%= ListUtil.subList(journalViewMoreMenuItemsDisplayContext.getDDMStructures(), searchContainer.getStart(), searchContainer.getEnd()) %>"
+		/>
+
 		<liferay-ui:search-container-row
 			className="com.liferay.dynamic.data.mapping.model.DDMStructure"
 			cssClass="selectable"


### PR DESCRIPTION
/cc @brianikim 

Notes from Brian:

> https://issues.liferay.com/browse/LPS-89503
> 
> The issue here is that the returned results in the web content menu pop-up frame that appears when you click to view more menu items is not respecting the pagination.
> 
> The reason for this issue is that the implementation that properly handles pagination results was not implemented for [view_more_menu_items.jsp](https://github.com/liferay/liferay-portal/blob/master/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_more_menu_items.jsp). The fix is to implement the requirement.
> 
> See attached video in the ticket for a more visual description of the behavior.
> 
> Please let me know if you have any questions. Thanks.
> 
> Sincerely,
> Brian Kim