### PR TITLE
LPS-89421 Resized image has poor quality

### DIFF
--- a/portal-impl/src/com/liferay/portal/image/ImageToolImpl.java
+++ b/portal-impl/src/com/liferay/portal/image/ImageToolImpl.java
@@ -803,6 +803,18 @@ public class ImageToolImpl implements ImageTool {
 
 			Graphics2D scaledGraphics2D = scaledBufferedImage.createGraphics();
 
+			scaledGraphics2D.setRenderingHint(
+				RenderingHints.KEY_ANTIALIASING,
+				RenderingHints.VALUE_ANTIALIAS_ON);
+
+			scaledGraphics2D.setRenderingHint(
+				RenderingHints.KEY_INTERPOLATION,
+				RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+
+			scaledGraphics2D.setRenderingHint(
+				RenderingHints.KEY_RENDERING,
+				RenderingHints.VALUE_RENDER_QUALITY);
+
 			scaledGraphics2D.drawImage(
 				originalBufferedImage, 0, 0, scaledWidth, scaledHeight, null);
 


### PR DESCRIPTION
Hey @robertoDiaz 

Could you please review this pull request?

By adding the proper rendering hints, the scaled image will have a much better quality.
I added the rendering hints to the branch that doesn't uses the progressive bi-linear scaling algorithm, since that method produces a decent quality scaling by default.

Thank you and best regards,
István