### PR TITLE
LPS-89573 Upgrade step AMCompanyThumbnailConfigurationInitializer fails if a default configuration is disabled

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-document-library-thumbnails/src/main/java/com/liferay/adaptive/media/document/library/thumbnails/internal/util/AMCompanyThumbnailConfigurationInitializer.java
+++ b/modules/apps/adaptive-media/adaptive-media-document-library-thumbnails/src/main/java/com/liferay/adaptive/media/document/library/thumbnails/internal/util/AMCompanyThumbnailConfigurationInitializer.java
@@ -144,7 +144,7 @@ public class AMCompanyThumbnailConfigurationInitializer {
 
 		Collection<AMImageConfigurationEntry> amImageConfigurationEntries =
 			_amImageConfigurationHelper.getAMImageConfigurationEntries(
-				companyId);
+				companyId, amImageConfigurationEntry -> true);
 
 		Stream<AMImageConfigurationEntry> amImageConfigurationEntryStream =
 			amImageConfigurationEntries.stream();


### PR DESCRIPTION
Hi @adolfopa. 

A customer found this issue in their upgrade from 7.0 to 7.1. It turned out to be a missing argument when refactoring between commits (019631d and ea90546). 

Please let me know if you have any questions. Thanks! 

(cc @achaparro)