### PR TITLE
LPS-90205

### DIFF
--- a/modules/apps/social/social-activities-web/src/main/java/com/liferay/social/activities/web/internal/util/SocialActivitiesQueryHelper.java
+++ b/modules/apps/social/social-activities-web/src/main/java/com/liferay/social/activities/web/internal/util/SocialActivitiesQueryHelper.java
@@ -42,6 +42,11 @@ public class SocialActivitiesQueryHelper {
 					group.getGroupId(), start, end);
 			}
 
+			if (layout.isPublicLayout()) {
+				return _socialActivitySetLocalService.getUserActivitySets(
+					group.getClassPK(), start, end);
+			}
+
 			return _socialActivitySetLocalService.getUserViewableActivitySets(
 				group.getClassPK(), start, end);
 		}
@@ -82,6 +87,11 @@ public class SocialActivitiesQueryHelper {
 			if (!group.isUser()) {
 				return _socialActivitySetLocalService.getGroupActivitySetsCount(
 					group.getGroupId());
+			}
+
+			if (layout.isPublicLayout()) {
+				return _socialActivitySetLocalService.getUserActivitySetsCount(
+					group.getClassPK());
 			}
 
 			return _socialActivitySetLocalService.


### PR DESCRIPTION
https://issues.liferay.com/browse/LPP-32948
https://issues.liferay.com/browse/LPS-90205

From @wanderlast:

This fix is relatively self-explanatory and is based off of the expected behavior outlined in [PTR-617](https://issues.liferay.com/browse/PTR-617) which is excerpted below:

> If placed in a private personal page, then "All" tab shows the activities of all users of any site that user can view (this includes the staff users add to their personal site). That is, current behavior must be kept. Please note there is a slight difference between this tab and "My Sites" tab, which does not include personal site
> If placed in a public personal page, then "All" tab shows the activities of that user specifically (this makes "all" tab, which is hidden in that view, to behave the same as "ME" tab)

getUserActivitySets() explicitly only gets sets associated with a specific userID and is used for a public personal page.
getUserViewableActivitySets() includes a SQL clause that also causes it to include any activities on a site that the user is a member of and is therefore what is used for a private personal page.

Please let me know if you have any questions. Thanks!

Passing SF test: https://github.com/ChrisKian/liferay-portal/pull/99#issuecomment-463727648
Passing Relevant tests: https://github.com/ChrisKian/liferay-portal/pull/99#issuecomment-463757830