### PR TITLE
[TECHNICAL-SUPPORT] LPS-91536

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_6/UpgradeAssetDisplayPageEntry.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_6/UpgradeAssetDisplayPageEntry.java
@@ -64,7 +64,7 @@ public class UpgradeAssetDisplayPageEntry extends UpgradeProcess {
 		sb.append("and AssetDisplayPageEntry.classNameId = ? and ");
 		sb.append("AssetDisplayPageEntry.classPK = ");
 		sb.append("JournalArticle.resourcePrimKey ) ");
-		sb.append("group by groupId, userId, resourcePrimKey");
+		sb.append("group by resourcePrimKey");
 
 		long journalArticleClassNameId = PortalUtil.getClassNameId(
 			JournalArticle.class);

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_6/UpgradeAssetDisplayPageEntry.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_6/UpgradeAssetDisplayPageEntry.java
@@ -54,7 +54,7 @@ public class UpgradeAssetDisplayPageEntry extends UpgradeProcess {
 	}
 
 	protected void updateAssetDisplayPageEntry() throws Exception {
-		StringBuilder sb = new StringBuilder(8);
+		StringBuilder sb = new StringBuilder(9);
 
 		sb.append("select groupId, userId, resourcePrimKey from ");
 		sb.append("JournalArticle where JournalArticle.layoutUuid is not null");
@@ -63,7 +63,8 @@ public class UpgradeAssetDisplayPageEntry extends UpgradeProcess {
 		sb.append("AssetDisplayPageEntry.groupId = JournalArticle.groupId ");
 		sb.append("and AssetDisplayPageEntry.classNameId = ? and ");
 		sb.append("AssetDisplayPageEntry.classPK = ");
-		sb.append("JournalArticle.resourcePrimKey )");
+		sb.append("JournalArticle.resourcePrimKey ) ");
+		sb.append("group by groupId, userId, resourcePrimKey");
 
 		long journalArticleClassNameId = PortalUtil.getClassNameId(
 			JournalArticle.class);


### PR DESCRIPTION
/cc @joshuacords 

Notes from Josh:

> https://issues.liferay.com/browse/LPS-91536
> https://issues.liferay.com/browse/LPP-33125
> 
> **Problem**: The upgrade process tries to add an AssetDisplayPageEntry for each journal article version, however only one AssetDisplayPageEntry should exist for all versions of a journal article. What happens is after the first version creates an AssetDisplayPageEntry, all remaining versions will throw benign errors during the upgrade process.
> 
> **Solution**: Since only one AssetDisplayPageEntry is necessary for each journal article set of versions, and there is no differentiation in the linkage between any of the version only retrieve one Journal Article per index.
> 
> Note: In master, this upgrade process will also throw errors because of https://issues.liferay.com/browse/LPS-91537. This fix will remove the duplicate index errors, but not the errors documented on that ticket. In 7.1.x, those other errors don't exist and so this fix will remove all errors. 