### PR TITLE
[TECHNICAL-SUPPORT] LPS-93499 NumberFormatException is thrown if fileEntryId is removed from an image tag

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-service/src/main/java/com/liferay/adaptive/media/image/internal/exportimport/content/processor/AMImageHTMLExportImportContentProcessor.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-service/src/main/java/com/liferay/adaptive/media/image/internal/exportimport/content/processor/AMImageHTMLExportImportContentProcessor.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.StagedModel;
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.util.Validator;
 
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -181,9 +182,14 @@ public class AMImageHTMLExportImportContentProcessor
 			"[" + AMImageHTMLConstants.ATTRIBUTE_NAME_FILE_ENTRY_ID + "]";
 
 		for (Element element : document.select(elementSelector)) {
-			long fileEntryId = Long.valueOf(
-				element.attr(
-					AMImageHTMLConstants.ATTRIBUTE_NAME_FILE_ENTRY_ID));
+			String fileEntryIdValue = element.attr(
+				AMImageHTMLConstants.ATTRIBUTE_NAME_FILE_ENTRY_ID);
+
+			if (!Validator.isNumber(fileEntryIdValue)) {
+				continue;
+			}
+
+			long fileEntryId = Long.valueOf(fileEntryIdValue);
 
 			try {
 				FileEntry fileEntry = _dlAppLocalService.getFileEntry(


### PR DESCRIPTION
Hi @adolfopa ,

The export now fails, when the HTML web content has an `<img>` tag with a `data-fileentryid=""` attribute. My change would ignore when `fileEntryId` has an invalid value, and change nothing in the tag. This way the export/import/publish will still be successful, not blocking any of these processes.

Please review my changes.

Thanks,
Vendel