### PR TITLE
LPS-72995 If the originalBufferedImage's type is 0 set the new one to be RGB

### DIFF
--- a/portal-impl/src/com/liferay/portal/image/ImageToolImpl.java
+++ b/portal-impl/src/com/liferay/portal/image/ImageToolImpl.java
@@ -792,8 +792,14 @@ public class ImageToolImpl implements ImageTool {
 
 		BufferedImage originalBufferedImage = getBufferedImage(renderedImage);
 
+		int type = originalBufferedImage.getType();
+
+		if (type == BufferedImage.TYPE_CUSTOM) {
+			type = BufferedImage.TYPE_INT_ARGB;
+		}
+
 		BufferedImage scaledBufferedImage = new BufferedImage(
-			scaledWidth, scaledHeight, originalBufferedImage.getType());
+			scaledWidth, scaledHeight, type);
 
 		int originalHeight = originalBufferedImage.getHeight();
 		int originalWidth = originalBufferedImage.getWidth();


### PR DESCRIPTION
Hi! This is a fix for [LPS-72995](https://issues.liferay.com/browse/LPS-72995)
Could you take a look into it please?
Thanks!