### PR TITLE
LPS-75754 Allow video tag in blogs

### DIFF
--- a/modules/apps/blogs/blogs-editor-configuration/src/main/java/com/liferay/blogs/editor/configuration/internal/BlogsContentEditorConfigContributor.java
+++ b/modules/apps/blogs/blogs-editor-configuration/src/main/java/com/liferay/blogs/editor/configuration/internal/BlogsContentEditorConfigContributor.java
@@ -65,7 +65,7 @@ public class BlogsContentEditorConfigContributor
 		ThemeDisplay themeDisplay,
 		RequestBackedPortletURLFactory requestBackedPortletURLFactory) {
 
-		StringBundler sb = new StringBundler(6);
+		StringBundler sb = new StringBundler(7);
 
 		sb.append("a[*](*); ");
 		sb.append(getAllowedContentText());
@@ -73,6 +73,7 @@ public class BlogsContentEditorConfigContributor
 		sb.append(getAllowedContentLists());
 		sb.append(" p {text-align}; ");
 		sb.append(getAllowedContentTable());
+		sb.append(" video[*](*);");
 
 		jsonObject.put("allowedContent", sb.toString());
 


### PR DESCRIPTION
Hello @adolfopa 👋 

I'm sending you a possible solution for [LPS-75754](https://issues.liferay.com/browse/LPS-75754), although the issue indicates that the problem it is related to AntiSamy I think that is not the case and it's a problem in the blogs editor.

When including the `<video>` tag at HTML view, is deleted when switching to preview mode; and it looks like it's something we should allow.
I have added in the configuration of the editor the necessary code to accept the tag.

See also: https://github.com/jbalsas/liferay-portal/pull/1793#issuecomment-498149118

Please, let me know if I'm missing something.
Thanks!