### PR TITLE
[TS] LPS-86455

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/repository/event/FileVersionPreviewEventListenerImpl.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/repository/event/FileVersionPreviewEventListenerImpl.java
@@ -23,6 +23,8 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.repository.event.FileVersionPreviewEventListener;
 import com.liferay.portal.kernel.repository.model.FileVersion;
 
+import java.util.List;
+
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -33,6 +35,33 @@ import org.osgi.service.component.annotations.Reference;
 @Component(immediate = true, service = FileVersionPreviewEventListener.class)
 public class FileVersionPreviewEventListenerImpl
 	implements FileVersionPreviewEventListener {
+
+	public void deleteDLFileVersionPreviews(long fileEntryId) {
+		List<DLFileVersionPreview> fileVersionPreviews =
+			_dlFileVersionPreviewLocalService.getFileEntryDLFileVersionPreviews(
+				fileEntryId);
+
+		for (DLFileVersionPreview dlFileVersionPreview : fileVersionPreviews) {
+			_dlFileVersionPreviewLocalService.
+				deleteDLFileEntryFileVersionPreviews(
+					dlFileVersionPreview.getDlFileVersionPreviewId());
+		}
+	}
+
+	@Override
+	public long getDLFileVersionPreviewId(
+		long fileEntryId, long fileVersionId, int fileVersionPreviewStatus) {
+
+		DLFileVersionPreview dlFileVersionPreview =
+			_dlFileVersionPreviewLocalService.fetchDLFileVersionPreview(
+				fileEntryId, fileVersionId, fileVersionPreviewStatus);
+
+		if (dlFileVersionPreview == null) {
+			return 0;
+		}
+
+		return dlFileVersionPreview.getDlFileVersionPreviewId();
+	}
 
 	@Override
 	public void onFailure(FileVersion fileVersion) {

--- a/portal-kernel/src/com/liferay/portal/kernel/repository/event/FileVersionPreviewEventListener.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/event/FileVersionPreviewEventListener.java
@@ -22,8 +22,40 @@ import com.liferay.portal.kernel.repository.model.FileVersion;
  */
 public interface FileVersionPreviewEventListener {
 
+	public void deleteDLFileVersionPreviews(long fileEntryId);
+
+	public long getDLFileVersionPreviewId(
+		long fileEntryId, long fileVersionId, int fileVersionPreviewStatus);
+
 	public void onFailure(FileVersion fileVersion);
 
 	public void onSuccess(FileVersion fileVersion);
+
+	public enum DLFileEntryPreviewType {
+
+		FAIL(0), NOT_GENERATED(1), SUCCESS(2);
+
+		public static DLFileEntryPreviewType fromInteger(int value) {
+			for (DLFileEntryPreviewType dlFileEntryPreviewType : values()) {
+				if (dlFileEntryPreviewType.toInteger() == value) {
+					return dlFileEntryPreviewType;
+				}
+			}
+
+			throw new IllegalArgumentException(
+				"No DLFileEntryPreviewType exists with value " + value);
+		}
+
+		public int toInteger() {
+			return _value;
+		}
+
+		private DLFileEntryPreviewType(int value) {
+			_value = value;
+		}
+
+		private final int _value;
+
+	}
 
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-86455

From @wanderlast:

> This is related to https://issues.liferay.com/browse/LPS-86455 which is a closed ticket. However, the ticket is essentially unbackportable to 71x/70x without significant changes due to various infrastructure differences between Master and 7.1.x. This commit forwardports API that was previously within LPS-86455 but that was later removed in Master due to it being unnecessary or due to an alternative approach being used. This API allows the fix to be viable in 7.1.x.
> 
> One example is of the enumeration which was added in 8d1091207a11e4e0ed1f8e1607610353627dd1e6, and then removed in 4b74a48d0407c7af7f68e95b7feebed36edc9a8d to be replaced by a Constants class. Since some of the infrastructure necessary for this fix is located in portal-impl in 7.1.x (specifically the getThumbnailSrc method that is found in DLImpl in 7.1.x, but found in a module in Master), the constants class cannot be properly called and the enum is therefore necessary.