### PR TITLE
LPS-96138

### DIFF
--- a/portal-impl/src/com/liferay/portal/sharepoint/SharepointServlet.java
+++ b/portal-impl/src/com/liferay/portal/sharepoint/SharepointServlet.java
@@ -51,10 +51,6 @@ public class SharepointServlet extends HttpServlet {
 
 		try {
 			String uri = httpServletRequest.getRequestURI();
-
-			if (uri.equals("/_vti_inf.html")) {
-				vtiInfHtml(httpServletResponse);
-			}
 		}
 		catch (Exception e) {
 			_log.error(e, e);
@@ -131,28 +127,6 @@ public class SharepointServlet extends HttpServlet {
 		catch (SharepointException se) {
 			_log.error(se, se);
 		}
-	}
-
-	protected void vtiInfHtml(HttpServletResponse httpServletResponse)
-		throws Exception {
-
-		StringBundler sb = new StringBundler(13);
-
-		sb.append("<!-- FrontPage Configuration Information");
-		sb.append(StringPool.NEW_LINE);
-		sb.append(" FPVersion=\"6.0.2.9999\"");
-		sb.append(StringPool.NEW_LINE);
-		sb.append("FPShtmlScriptUrl=\"_vti_bin/shtml.dll/_vti_rpc\"");
-		sb.append(StringPool.NEW_LINE);
-		sb.append("FPAuthorScriptUrl=\"_vti_bin/_vti_aut/author.dll\"");
-		sb.append(StringPool.NEW_LINE);
-		sb.append("FPAdminScriptUrl=\"_vti_bin/_vti_adm/admin.dll\"");
-		sb.append(StringPool.NEW_LINE);
-		sb.append("TPScriptUrl=\"_vti_bin/owssvr.dll\"");
-		sb.append(StringPool.NEW_LINE);
-		sb.append("-->");
-
-		ServletResponseUtil.write(httpServletResponse, sb.toString());
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/portal-impl/src/com/liferay/portal/sharepoint/SharepointServlet.java
+++ b/portal-impl/src/com/liferay/portal/sharepoint/SharepointServlet.java
@@ -15,12 +15,10 @@
 package com.liferay.portal.sharepoint;
 
 import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
-import com.liferay.portal.kernel.servlet.ServletResponseUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.webdav.WebDAVUtil;
 import com.liferay.portal.sharepoint.methods.Method;
@@ -47,13 +45,6 @@ public class SharepointServlet extends HttpServlet {
 					httpServletRequest.getHeader(HttpHeaders.USER_AGENT), " ",
 					httpServletRequest.getMethod(), " ",
 					httpServletRequest.getRequestURI()));
-		}
-
-		try {
-			String uri = httpServletRequest.getRequestURI();
-		}
-		catch (Exception e) {
-			_log.error(e, e);
 		}
 	}
 


### PR DESCRIPTION
@adolfopa 

We couldn't think of anything that relies on `/_vti_inf.html` but we're not sure. On the security side, the problem is `/_vti_inf.html` contains `FPShtmlScriptUrl`, `FPAuthorScriptUrl`, `FPAdminScriptUrl` and `TPScriptUrl` which the security vendor is saying should not be public. I don't think there's any real security issue here since we're not actually running FrontPage Server Extensions. But just to be safe, if this path isn't really being used, we can just remove it.

cc @sunnygao