### PR TITLE
LPS-97094 User's Personal Data is not fully anonymized in Related Assets

### DIFF
--- a/modules/apps/blogs/blogs-uad-test/src/testIntegration/java/com/liferay/blogs/uad/anonymizer/test/BlogsEntryUADAnonymizerTest.java
+++ b/modules/apps/blogs/blogs-uad-test/src/testIntegration/java/com/liferay/blogs/uad/anonymizer/test/BlogsEntryUADAnonymizerTest.java
@@ -24,7 +24,7 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.user.associated.data.anonymizer.UADAnonymizer;
-import com.liferay.user.associated.data.test.util.BaseUADAnonymizerTestCase;
+import com.liferay.user.associated.data.test.util.BaseHasAssetEntryUADAnonymizerTestCase;
 import com.liferay.user.associated.data.test.util.WhenHasStatusByUserIdField;
 
 import java.util.ArrayList;
@@ -39,7 +39,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class BlogsEntryUADAnonymizerTest
-	extends BaseUADAnonymizerTestCase<BlogsEntry>
+	extends BaseHasAssetEntryUADAnonymizerTestCase<BlogsEntry>
 	implements WhenHasStatusByUserIdField {
 
 	@ClassRule
@@ -100,7 +100,12 @@ public class BlogsEntryUADAnonymizerTest
 			(blogsEntry.getStatusByUserId() != user.getUserId()) &&
 			!statusByUserName.equals(user.getFullName())) {
 
-			return true;
+			if (isAssetEntryAutoAnonymized(
+					BlogsEntry.class.getName(), blogsEntry.getEntryId(),
+					user)) {
+
+				return true;
+			}
 		}
 
 		return false;

--- a/modules/apps/blogs/blogs-uad/src/main/java/com/liferay/blogs/uad/anonymizer/BlogsEntryUADAnonymizer.java
+++ b/modules/apps/blogs/blogs-uad/src/main/java/com/liferay/blogs/uad/anonymizer/BlogsEntryUADAnonymizer.java
@@ -14,13 +14,40 @@
 
 package com.liferay.blogs.uad.anonymizer;
 
+import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.asset.kernel.service.AssetEntryLocalService;
+import com.liferay.blogs.model.BlogsEntry;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.user.associated.data.anonymizer.UADAnonymizer;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Brian Wing Shun Chan
  */
 @Component(immediate = true, service = UADAnonymizer.class)
 public class BlogsEntryUADAnonymizer extends BaseBlogsEntryUADAnonymizer {
+	@Override
+	public void autoAnonymize(
+		BlogsEntry blogsEntry, long userId, User anonymousUser)
+		throws PortalException {
+
+		if (blogsEntry.getUserId() == userId) {
+			AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
+				BlogsEntry.class.getName(), blogsEntry.getEntryId());
+
+			assetEntry.setUserId(anonymousUser.getUserId());
+			assetEntry.setUserName(anonymousUser.getFullName());
+
+			_assetEntryLocalService.updateAssetEntry(assetEntry);
+		}
+
+		super.autoAnonymize(blogsEntry, userId, anonymousUser);
+	}
+
+	@Reference
+	private AssetEntryLocalService _assetEntryLocalService;
+
 }

--- a/modules/apps/blogs/blogs-uad/src/main/java/com/liferay/blogs/uad/anonymizer/BlogsEntryUADAnonymizer.java
+++ b/modules/apps/blogs/blogs-uad/src/main/java/com/liferay/blogs/uad/anonymizer/BlogsEntryUADAnonymizer.java
@@ -29,9 +29,10 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(immediate = true, service = UADAnonymizer.class)
 public class BlogsEntryUADAnonymizer extends BaseBlogsEntryUADAnonymizer {
+
 	@Override
 	public void autoAnonymize(
-		BlogsEntry blogsEntry, long userId, User anonymousUser)
+			BlogsEntry blogsEntry, long userId, User anonymousUser)
 		throws PortalException {
 
 		if (blogsEntry.getUserId() == userId) {

--- a/modules/apps/user-associated-data/user-associated-data-test-util/build.gradle
+++ b/modules/apps/user-associated-data/user-associated-data-test-util/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.test", version: "default"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.test.integration", version: "default"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:static:osgi:osgi-util")
 	compileOnly project(":apps:user-associated-data:user-associated-data-api")

--- a/modules/apps/user-associated-data/user-associated-data-test-util/src/main/java/com/liferay/user/associated/data/test/util/BaseHasAssetEntryUADAnonymizerTestCase.java
+++ b/modules/apps/user-associated-data/user-associated-data-test-util/src/main/java/com/liferay/user/associated/data/test/util/BaseHasAssetEntryUADAnonymizerTestCase.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.user.associated.data.test.util;
+
+import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.asset.kernel.service.AssetEntryLocalService;
+import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.test.rule.Inject;
+
+/**
+ * @author Samuel Trong Tran
+ */
+public abstract class BaseHasAssetEntryUADAnonymizerTestCase
+	<T extends BaseModel>
+		extends BaseUADAnonymizerTestCase<T> {
+
+	protected boolean isAssetEntryAutoAnonymized(
+			String className, long classPK, User user)
+		throws Exception {
+
+		AssetEntry assetEntry = assetEntryLocalService.getEntry(
+			className, classPK);
+
+		String userName = assetEntry.getUserName();
+
+		if ((assetEntry.getUserId() != user.getUserId()) &&
+			!userName.equals(user.getFullName())) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	@Inject
+	protected AssetEntryLocalService assetEntryLocalService;
+
+}


### PR DESCRIPTION
Hi Adolfo,

Can you take a look at this and see if the changes look good to you? When updating the user fields (userId and userName) of a blog entry, its related asset entry does not get updated. `BlogsEntryLocalService.updateAsset` doesn't update the user fields of the asset entries so we have to update it manually.

This also affects DM, Message Boards, and Wiki. If all looks good, we'll apply the changes to the other entites. Thanks\!