### PR TITLE
LPS-93907 commons-compress 1.18 depends on xz 1.8

### DIFF
--- a/lib/portal/dependencies.properties
+++ b/lib/portal/dependencies.properties
@@ -187,5 +187,5 @@ xmpcore=com.adobe.xmp:xmpcore:5.1.3
 xpp3=xpp3:xpp3_min:1.1.4c
 xstream=com.thoughtworks.xstream:xstream:1.4.11.1
 xuggle-xuggler-noarch=com.liferay:xuggle.xuggler.noarch:5.4
-xz=org.tukaani:xz:1.5
+xz=org.tukaani:xz:1.8
 yui-compressor=com.yahoo.platform.yui:yuicompressor:2.4.8

--- a/lib/versions-complete.xml
+++ b/lib/versions-complete.xml
@@ -7707,7 +7707,7 @@
 			</library>
 			<library>
 				<file-name>lib/portal/xz.jar</file-name>
-				<version>1.5</version>
+				<version>1.8</version>
 				<project-name>XZ</project-name>
 				<project-url>http://tukaani.org/xz/java.html</project-url>
 				<licenses>

--- a/lib/versions-ext.xml
+++ b/lib/versions-ext.xml
@@ -3372,7 +3372,7 @@
 			</library>
 			<library>
 				<file-name>lib/portal/xz.jar</file-name>
-				<version>1.5</version>
+				<version>1.8</version>
 				<project-name>XZ</project-name>
 				<project-url>http://tukaani.org/xz/java.html</project-url>
 				<licenses>

--- a/lib/versions.html
+++ b/lib/versions.html
@@ -3452,7 +3452,7 @@
 </td><td></td>
 </tr>
 <tr>
-<td nowrap>lib/portal/xz.jar</td><td nowrap>1.5</td><td nowrap><a href="http://tukaani.org/xz/java.html">XZ</a></td><td nowrap><a href="http://en.wikipedia.org/wiki/Public_domain">Public Domain</a>
+<td nowrap>lib/portal/xz.jar</td><td nowrap>1.8</td><td nowrap><a href="http://tukaani.org/xz/java.html">XZ</a></td><td nowrap><a href="http://en.wikipedia.org/wiki/Public_domain">Public Domain</a>
 <br>
 </td><td></td>
 </tr>


### PR DESCRIPTION
Hi @adolfopa 

Could you please review this pull request?
This third party jar upgraded fixes an issue with .7z file compression.

Thank you and best regards,
István