### PR TITLE
LPS-99922 Title needs to be escaped in templates as well.

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/com/liferay/blogs/web/template/dependencies/portlet_display_template_basic.ftl
+++ b/modules/apps/blogs/blogs-web/src/main/resources/com/liferay/blogs/web/template/dependencies/portlet_display_template_basic.ftl
@@ -15,7 +15,7 @@
 						</#if>
 
 						<h3 class="title">
-							<a class="title-link" href="${viewEntryPortletURL.toString()}">${blogsEntryUtil.getDisplayTitle(resourceBundle, curBlogEntry)}</a>
+							<a class="title-link" href="${viewEntryPortletURL.toString()}">${htmlUtil.escape(blogsEntryUtil.getDisplayTitle(resourceBundle, curBlogEntry))}</a>
 						</h3>
 					</div>
 

--- a/modules/apps/blogs/blogs-web/src/main/resources/com/liferay/blogs/web/template/dependencies/portlet_display_template_card.ftl
+++ b/modules/apps/blogs/blogs-web/src/main/resources/com/liferay/blogs/web/template/dependencies/portlet_display_template_card.ftl
@@ -32,7 +32,7 @@
 
 								<h3 class="title">
 									<a class="title-link" href="${viewEntryPortletURL.toString()}">
-									${blogsEntryUtil.getDisplayTitle(resourceBundle, curBlogEntry)}</a>
+									${htmlUtil.escape(blogsEntryUtil.getDisplayTitle(resourceBundle, curBlogEntry))}</a>
 								</h3>
 							</div>
 


### PR DESCRIPTION
/cc @brianikim,

Notes from Brian:
> https://issues.liferay.com/browse/LPS-99922
>
> Scripts can be executed using blogs title because we use freemarker display templates to show blog entries in the blog portlet.
> 
> The fix is straightforward. We just need to escape the blog entry titles for the templates used in blogs portlet.
> 
> Please let me know if you have any questions. Thanks.
> 
> Sincerely,
> Brian Kim