### PR TITLE
LPS-99515 In case hasOwnerPermission is null we shouldn't return false

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/security/permission/resource/DLFileEntryModelResourcePermissionRegistrar.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/security/permission/resource/DLFileEntryModelResourcePermissionRegistrar.java
@@ -231,8 +231,8 @@ public class DLFileEntryModelResourcePermissionRegistrar {
 						dlFileEntry.getFileEntryId(), dlFileEntry.getUserId(),
 						actionId);
 
-				if (!hasOwnerPermission) {
-					return false;
+				if (hasOwnerPermission) {
+					return true;
 				}
 			}
 


### PR DESCRIPTION
Hi @adolfopa ,

We slightly modified this logic when we moved from the old pattern (DLFileEntryPermission) to the new one (DLFileEntryModelResourcePermissionRegistrar). You can see it in [DLFileEntryPerimssion.java in 7.0.x branch](https://github.com/liferay/liferay-portal-ee/blob/7.0.x/portal-impl/src/com/liferay/portlet/documentlibrary/service/permission/DLFileEntryPermission.java#L137-L139). 

That change is causing LPS-99515 because if hasOwnerPermission is null, then we'll return false instead of null and then we are not executing the right logic in [DefaultModelResourcePermission](https://github.com/liferay/liferay-portal/blob/master/portal-kernel/src/com/liferay/portal/kernel/internal/security/permission/resource/DefaultModelResourcePermission.java#L141-L146).

Thanks.

Regards

/cc @robertoDiaz