### PR TITLE
LPS-100424 - References from deleted attachments cannot be removed in edit mode in Chrome

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/creole/creole_parser.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/creole/creole_parser.js
@@ -347,7 +347,7 @@
 						r[2] === undefined
 							? options && options.defaultImageText
 								? options.defaultImageText
-								: ''
+								: ' '
 							: r[2].replace(/~(.)/g, '$1');
 					node.appendChild(img);
 				}


### PR DESCRIPTION
Hi @robertoDiaz ,

Could you please review this pull request?

The problem was because the image alt field was left blank. 
If the path of the image points to a non-existent address, the empty alt field will cause an error.
https://issues.liferay.com/browse/LPS-100424

Thank you.

Regards,
Marci