### PR TITLE
LPS-100424 References from deleted attachments cannot be removed in edit mode in Chrome

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/creole/creole_parser.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/creole/creole_parser.js
@@ -343,12 +343,12 @@
 
 					var img = document.createElement('img');
 					img.src = imagePath;
-					img.alt =
-						r[2] === undefined
-							? options && options.defaultImageText
-								? options.defaultImageText
-								: ''
-							: r[2].replace(/~(.)/g, '$1');
+					if(r[2]) {
+						img.alt = r[2].replace(/~(.)/g, '$1');
+					}
+					else if(options && options.defaultImageText) {
+						img.alt = options.defaultImageText;
+					}
 					node.appendChild(img);
 				}
 			},


### PR DESCRIPTION
Hi @adolfopa 

I realized that my previous solution is incomplete and may cause unexpected behavior.
Could you please review this pull request?

Thank you and best regards,
Marcell