### PR TITLE
LPS-101518 removed unused dependency

### DIFF
--- a/modules/apps/document-library/document-library-api/build.gradle
+++ b/modules/apps/document-library/document-library-api/build.gradle
@@ -7,7 +7,6 @@ dependencies {
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:bulk:bulk-selection-api")
 	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
-	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":core:petra:petra-function")
 }


### PR DESCRIPTION
Hi @adolfopa ,
Found that the frontend dependency was removed in https://issues.liferay.com/browse/LPS-79686.
(https://github.com/liferay/liferay-portal/commit/476d8bafa19e46c84de7cf2b5cedaeea6eff7ee6)

Can you please review?
https://issues.liferay.com/browse/LPS-101518

Thanks,
Balázs