### PR TITLE
[TECHNICAL-SUPPORT] LPS-100082

### DIFF
--- a/modules/apps/application-list/application-list-api/src/main/java/com/liferay/application/list/BasePanelApp.java
+++ b/modules/apps/application-list/application-list-api/src/main/java/com/liferay/application/list/BasePanelApp.java
@@ -82,7 +82,7 @@ public abstract class BasePanelApp implements PanelApp {
 		return _userNotificationEventLocalService.
 			getUserNotificationEventsCount(
 				user.getUserId(), _portlet.getPortletId(),
-				UserNotificationDeliveryConstants.TYPE_WEBSITE, false);
+				UserNotificationDeliveryConstants.TYPE_WEBSITE, true, false);
 	}
 
 	@Override

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
@@ -1004,7 +1004,7 @@ public class JournalArticleStagedModelDataHandler
 				_importFriendlyURLEntries(
 					portletDataContext, article, importedArticle);
 
-				_sendStoredUserNotificationEvents(article);
+				_sendUndeliveredUserNotificationEvents(article);
 			}
 			finally {
 				ServiceContextThreadLocal.popServiceContext();
@@ -1425,7 +1425,9 @@ public class JournalArticleStagedModelDataHandler
 		}
 	}
 
-	private void _sendStoredUserNotificationEvents(JournalArticle article) {
+	private void _sendUndeliveredUserNotificationEvents(
+		JournalArticle article) {
+
 		ActionableDynamicQuery actionableDynamicQuery =
 			_userNotificationEventLocalService.getActionableDynamicQuery();
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
@@ -81,6 +81,7 @@ import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -1492,17 +1493,43 @@ public class JournalArticleStagedModelDataHandler
 					subscriptionSender.setFrom(fromAddress, fromName);
 
 					subscriptionSender.setHtmlFormat(true);
-					subscriptionSender.setLocalizedBodyMap(
+
+					Map<String, String> localizedJsonBodyMap =
 						(Map)JSONFactoryUtil.looseDeserialize(
 							jsonObject.get(
 								"localizedBodyMap"
-							).toString()));
+							).toString());
 
-					subscriptionSender.setLocalizedSubjectMap(
+					Map<Locale, String> localizedBodyMap = new HashMap<>();
+
+					for (Map.Entry<String, String> entry :
+							localizedJsonBodyMap.entrySet()) {
+
+						localizedBodyMap.put(
+							LocaleUtil.fromLanguageId(entry.getKey()),
+							entry.getValue());
+					}
+
+					subscriptionSender.setLocalizedBodyMap(localizedBodyMap);
+
+					Map<String, String> localizedJsonSubjectMap =
 						(Map)JSONFactoryUtil.looseDeserialize(
 							jsonObject.get(
 								"localizedSubjectMap"
-							).toString()));
+							).toString());
+
+					Map<Locale, String> localizedSubjectMap = new HashMap<>();
+
+					for (Map.Entry<String, String> entry :
+							localizedJsonSubjectMap.entrySet()) {
+
+						localizedSubjectMap.put(
+							LocaleUtil.fromLanguageId(entry.getKey()),
+							entry.getValue());
+					}
+
+					subscriptionSender.setLocalizedSubjectMap(
+						localizedSubjectMap);
 
 					subscriptionSender.setMailId(
 						"journal_article", article.getId());

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
@@ -41,6 +41,7 @@ import com.liferay.friendly.url.model.FriendlyURLEntry;
 import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
 import com.liferay.journal.configuration.JournalGroupServiceConfiguration;
 import com.liferay.journal.configuration.JournalServiceConfiguration;
+import com.liferay.journal.constants.JournalConstants;
 import com.liferay.journal.internal.exportimport.creation.strategy.JournalCreationStrategy;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.model.JournalArticleConstants;
@@ -74,6 +75,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.UserNotificationEventLocalService;
+import com.liferay.portal.kernel.settings.GroupServiceSettingsLocator;
 import com.liferay.portal.kernel.trash.TrashHandler;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.FileUtil;
@@ -1239,13 +1241,6 @@ public class JournalArticleStagedModelDataHandler
 	}
 
 	@Reference(unbind = "-")
-	protected void setJournalGroupServiceConfiguration(
-		JournalGroupServiceConfiguration journalGroupServiceConfiguration) {
-
-		_journalGroupServiceConfiguration = journalGroupServiceConfiguration;
-	}
-
-	@Reference(unbind = "-")
 	protected void setUserLocalService(UserLocalService userLocalService) {
 		_userLocalService = userLocalService;
 	}
@@ -1480,11 +1475,19 @@ public class JournalArticleStagedModelDataHandler
 						(key, value) -> subscriptionSender.setContextAttribute(
 							key, value.get("originalValue")));
 
+					JournalGroupServiceConfiguration
+						journalGroupServiceConfiguration =
+							_configurationProvider.getConfiguration(
+								JournalGroupServiceConfiguration.class,
+								new GroupServiceSettingsLocator(
+									article.getGroupId(),
+									JournalConstants.SERVICE_NAME));
+
 					String fromAddress =
-						_journalGroupServiceConfiguration.emailFromAddress();
+						journalGroupServiceConfiguration.emailFromAddress();
 
 					String fromName =
-						_journalGroupServiceConfiguration.emailFromName();
+						journalGroupServiceConfiguration.emailFromName();
 
 					subscriptionSender.setFrom(fromAddress, fromName);
 
@@ -1599,7 +1602,6 @@ public class JournalArticleStagedModelDataHandler
 	private JournalArticleResourceLocalService
 		_journalArticleResourceLocalService;
 	private JournalCreationStrategy _journalCreationStrategy;
-	private JournalGroupServiceConfiguration _journalGroupServiceConfiguration;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/base/JournalArticleLocalServiceBaseImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/base/JournalArticleLocalServiceBaseImpl.java
@@ -639,9 +639,6 @@ public abstract class JournalArticleLocalServiceBaseImpl
 		counterLocalService;
 
 	@Reference
-	protected com.liferay.exportimport.kernel.staging.Staging staging;
-
-	@Reference
 	protected com.liferay.portal.kernel.service.ClassNameLocalService
 		classNameLocalService;
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/base/JournalArticleLocalServiceBaseImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/base/JournalArticleLocalServiceBaseImpl.java
@@ -639,6 +639,9 @@ public abstract class JournalArticleLocalServiceBaseImpl
 		counterLocalService;
 
 	@Reference
+	protected com.liferay.exportimport.kernel.staging.Staging staging;
+
+	@Reference
 	protected com.liferay.portal.kernel.service.ClassNameLocalService
 		classNameLocalService;
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -8416,18 +8416,9 @@ public class JournalArticleLocalServiceImpl
 		subscriptionSender.addPersistedSubscribers(
 			JournalFolder.class.getName(), article.getGroupId());
 
-		long liveGroupId = 0;
+		Group group = groupLocalService.getGroup(article.getGroupId());
 
-		try {
-			Group group = serviceContext.getScopeGroup();
-
-			if (group.isStagingGroup()) {
-				liveGroupId = staging.getLiveGroupId(
-					serviceContext.getScopeGroupId());
-			}
-		}
-		catch (Exception e) {
-		}
+		long liveGroupId = group.getLiveGroupId();
 
 		if (liveGroupId > 0) {
 			subscriptionSender.addPersistedSubscribers(

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -6956,7 +6956,12 @@ public class JournalArticleLocalServiceImpl
 			action = "move_from_trash";
 		}
 
-		notifySubscribers(user.getUserId(), article, action, serviceContext);
+		Group group = groupLocalService.getGroup(article.getGroupId());
+
+		if (!group.isStaged() || group.isStagingGroup()) {
+			notifySubscribers(
+				user.getUserId(), article, action, serviceContext);
+		}
 
 		return article;
 	}

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -8411,6 +8411,24 @@ public class JournalArticleLocalServiceImpl
 		subscriptionSender.addPersistedSubscribers(
 			JournalFolder.class.getName(), article.getGroupId());
 
+		long liveGroupId = 0;
+
+		try {
+			Group group = serviceContext.getScopeGroup();
+
+			if (group.isStagingGroup()) {
+				liveGroupId = staging.getLiveGroupId(
+					serviceContext.getScopeGroupId());
+			}
+		}
+		catch (Exception e) {
+		}
+
+		if (liveGroupId > 0) {
+			subscriptionSender.addPersistedStagingSubscribers(
+				JournalFolder.class.getName(), liveGroupId);
+		}
+
 		if (folder != null) {
 			subscriptionSender.addPersistedSubscribers(
 				JournalFolder.class.getName(), folder.getFolderId());
@@ -8418,6 +8436,23 @@ public class JournalArticleLocalServiceImpl
 			for (Long ancestorFolderId : folder.getAncestorFolderIds()) {
 				subscriptionSender.addPersistedSubscribers(
 					JournalFolder.class.getName(), ancestorFolderId);
+			}
+
+			if (liveGroupId > 0) {
+				folder = journalFolderPersistence.fetchByUUID_G(
+					folder.getUuid(), liveGroupId);
+
+				if (folder != null) {
+					subscriptionSender.addPersistedStagingSubscribers(
+						JournalFolder.class.getName(), folder.getFolderId());
+
+					for (Long ancestorFolderId :
+							folder.getAncestorFolderIds()) {
+
+						subscriptionSender.addPersistedStagingSubscribers(
+							JournalFolder.class.getName(), ancestorFolderId);
+					}
+				}
 			}
 		}
 
@@ -8431,6 +8466,17 @@ public class JournalArticleLocalServiceImpl
 
 		subscriptionSender.addPersistedSubscribers(
 			JournalArticle.class.getName(), article.getResourcePrimKey());
+
+		if (liveGroupId > 0) {
+			article = journalArticlePersistence.fetchByUUID_G(
+				article.getUuid(), liveGroupId);
+
+			if (article != null) {
+				subscriptionSender.addPersistedStagingSubscribers(
+					JournalArticle.class.getName(),
+					article.getResourcePrimKey());
+			}
+		}
 
 		subscriptionSender.flushNotificationsAsync();
 	}

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -8430,8 +8430,8 @@ public class JournalArticleLocalServiceImpl
 		}
 
 		if (liveGroupId > 0) {
-			subscriptionSender.addPersistedStagingSubscribers(
-				JournalFolder.class.getName(), liveGroupId);
+			subscriptionSender.addPersistedSubscribers(
+				JournalFolder.class.getName(), liveGroupId, false);
 		}
 
 		if (folder != null) {
@@ -8448,14 +8448,16 @@ public class JournalArticleLocalServiceImpl
 					folder.getUuid(), liveGroupId);
 
 				if (folder != null) {
-					subscriptionSender.addPersistedStagingSubscribers(
-						JournalFolder.class.getName(), folder.getFolderId());
+					subscriptionSender.addPersistedSubscribers(
+						JournalFolder.class.getName(), folder.getFolderId(),
+						false);
 
 					for (Long ancestorFolderId :
 							folder.getAncestorFolderIds()) {
 
-						subscriptionSender.addPersistedStagingSubscribers(
-							JournalFolder.class.getName(), ancestorFolderId);
+						subscriptionSender.addPersistedSubscribers(
+							JournalFolder.class.getName(), ancestorFolderId,
+							false);
 					}
 				}
 			}
@@ -8477,9 +8479,9 @@ public class JournalArticleLocalServiceImpl
 				article.getUuid(), liveGroupId);
 
 			if (article != null) {
-				subscriptionSender.addPersistedStagingSubscribers(
+				subscriptionSender.addPersistedSubscribers(
 					JournalArticle.class.getName(),
-					article.getResourcePrimKey());
+					article.getResourcePrimKey(), false);
 			}
 		}
 

--- a/modules/apps/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/application/list/NotificationsPanelApp.java
+++ b/modules/apps/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/application/list/NotificationsPanelApp.java
@@ -47,9 +47,9 @@ public class NotificationsPanelApp extends BasePanelApp {
 		}
 
 		return _userNotificationEventLocalService.
-			getArchivedUserNotificationEventsCount(
+			getDeliveredArchivedUserNotificationEventsCount(
 				user.getUserId(),
-				UserNotificationDeliveryConstants.TYPE_WEBSITE, false);
+				UserNotificationDeliveryConstants.TYPE_WEBSITE, true, false);
 	}
 
 	@Override

--- a/modules/apps/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/poller/NotificationsPollerProcessor.java
+++ b/modules/apps/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/poller/NotificationsPollerProcessor.java
@@ -74,9 +74,10 @@ public class NotificationsPollerProcessor extends BasePollerProcessor {
 
 		int unreadUserNotificationsCount =
 			_userNotificationEventLocalService.
-				getArchivedUserNotificationEventsCount(
+				getDeliveredArchivedUserNotificationEventsCount(
 					pollerRequest.getUserId(),
-					UserNotificationDeliveryConstants.TYPE_WEBSITE, false);
+					UserNotificationDeliveryConstants.TYPE_WEBSITE, true,
+					false);
 
 		pollerResponse.setParameter(
 			"unreadUserNotificationsCount",

--- a/modules/apps/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/configuration/icon/MarkAllNotificationsAsReadPortletConfigurationIcon.java
+++ b/modules/apps/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/configuration/icon/MarkAllNotificationsAsReadPortletConfigurationIcon.java
@@ -86,8 +86,8 @@ public class MarkAllNotificationsAsReadPortletConfigurationIcon
 				_userNotificationEventLocalService.
 					getArchivedUserNotificationEventsCount(
 						themeDisplay.getUserId(),
-						UserNotificationDeliveryConstants.TYPE_WEBSITE, false,
-						false);
+						UserNotificationDeliveryConstants.TYPE_WEBSITE, true,
+						false, false);
 
 			if (unreadNotificationEventsCount > 0) {
 				return true;

--- a/modules/apps/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/product/navigation/personal/menu/NotificationsPersonalMenuEntry.java
+++ b/modules/apps/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/product/navigation/personal/menu/NotificationsPersonalMenuEntry.java
@@ -52,9 +52,10 @@ public class NotificationsPersonalMenuEntry extends BasePersonalMenuEntry {
 
 		int count =
 			_userNotificationEventLocalService.
-				getArchivedUserNotificationEventsCount(
+				getDeliveredArchivedUserNotificationEventsCount(
 					themeDisplay.getUserId(),
-					UserNotificationDeliveryConstants.TYPE_WEBSITE, false);
+					UserNotificationDeliveryConstants.TYPE_WEBSITE, true,
+					false);
 
 		if (count > 0) {
 			return "simple-circle";

--- a/modules/apps/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/util/NotificationsUtil.java
+++ b/modules/apps/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/util/NotificationsUtil.java
@@ -34,7 +34,7 @@ public class NotificationsUtil {
 		if (actionRequired) {
 			return UserNotificationEventLocalServiceUtil.
 				getArchivedUserNotificationEventsCount(
-					userId, _DELIVERY_TYPE, true, false);
+					userId, _DELIVERY_TYPE, true, true, false);
 		}
 
 		return UserNotificationEventLocalServiceUtil.
@@ -75,12 +75,13 @@ public class NotificationsUtil {
 			searchContainer.setTotal(
 				UserNotificationEventLocalServiceUtil.
 					getArchivedUserNotificationEventsCount(
-						userId, _DELIVERY_TYPE, actionRequired, archived));
+						userId, _DELIVERY_TYPE, true, actionRequired,
+						archived));
 
 			searchContainer.setResults(
 				UserNotificationEventLocalServiceUtil.
 					getArchivedUserNotificationEvents(
-						userId, _DELIVERY_TYPE, actionRequired, archived,
+						userId, _DELIVERY_TYPE, true, actionRequired, archived,
 						searchContainer.getStart(), searchContainer.getEnd(),
 						obc));
 		}

--- a/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/view.jsp
+++ b/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/view.jsp
@@ -61,7 +61,7 @@ navigationURL.setParameter(SearchContainer.DEFAULT_CUR_PARAM, "0");
 
 						navigationItem.setActive(actionRequired);
 						navigationItem.setHref(renderResponse.createRenderURL(), "actionRequired", StringPool.TRUE);
-						navigationItem.setLabel(LanguageUtil.format(request, "requests-list-x", String.valueOf(UserNotificationEventLocalServiceUtil.getArchivedUserNotificationEventsCount(themeDisplay.getUserId(), UserNotificationDeliveryConstants.TYPE_WEBSITE, true, false))));
+						navigationItem.setLabel(LanguageUtil.format(request, "requests-list-x", String.valueOf(UserNotificationEventLocalServiceUtil.getArchivedUserNotificationEventsCount(themeDisplay.getUserId(), UserNotificationDeliveryConstants.TYPE_WEBSITE, true, true, false))));
 					});
 			}
 		}

--- a/modules/apps/product-navigation/product-navigation-personal-menu-web/src/main/java/com/liferay/product/navigation/personal/menu/web/internal/control/menu/PersonalMenuProductNavigationControlMenuEntry.java
+++ b/modules/apps/product-navigation/product-navigation-personal-menu-web/src/main/java/com/liferay/product/navigation/personal/menu/web/internal/control/menu/PersonalMenuProductNavigationControlMenuEntry.java
@@ -75,9 +75,10 @@ public class PersonalMenuProductNavigationControlMenuEntry
 			httpServletRequest.setAttribute(
 				PersonalMenuWebKeys.NOTIFICATIONS_COUNT,
 				_userNotificationEventLocalService.
-					getArchivedUserNotificationEventsCount(
+					getUserNotificationEventsCount(
 						themeDisplay.getUserId(),
-						UserNotificationDeliveryConstants.TYPE_WEBSITE, false));
+						UserNotificationDeliveryConstants.TYPE_WEBSITE, true,
+						false));
 		}
 
 		return super.includeIcon(httpServletRequest, httpServletResponse);

--- a/modules/apps/product-navigation/product-navigation-user-personal-bar-web/src/main/java/com/liferay/product/navigation/user/personal/bar/web/internal/portlet/ProductNavigationUserPersonalBarPortlet.java
+++ b/modules/apps/product-navigation/product-navigation-user-personal-bar-web/src/main/java/com/liferay/product/navigation/user/personal/bar/web/internal/portlet/ProductNavigationUserPersonalBarPortlet.java
@@ -92,9 +92,9 @@ public class ProductNavigationUserPersonalBarPortlet extends MVCPortlet {
 		}
 
 		return _userNotificationEventLocalService.
-			getArchivedUserNotificationEventsCount(
+			getUserNotificationEventsCount(
 				themeDisplay.getUserId(),
-				UserNotificationDeliveryConstants.TYPE_WEBSITE, false);
+				UserNotificationDeliveryConstants.TYPE_WEBSITE, true, false);
 	}
 
 	@Reference(unbind = "-")

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserNotificationEventPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserNotificationEventPersistenceTest.java
@@ -361,6 +361,21 @@ public class UserNotificationEventPersistenceTest {
 	}
 
 	@Test
+	public void testCountByU_T_DT_D_A() throws Exception {
+		_persistence.countByU_T_DT_D_A(
+			RandomTestUtil.nextLong(), "", RandomTestUtil.nextInt(),
+			RandomTestUtil.randomBoolean(), RandomTestUtil.randomBoolean());
+
+		_persistence.countByU_T_DT_D_A(
+			0L, "null", 0, RandomTestUtil.randomBoolean(),
+			RandomTestUtil.randomBoolean());
+
+		_persistence.countByU_T_DT_D_A(
+			0L, (String)null, 0, RandomTestUtil.randomBoolean(),
+			RandomTestUtil.randomBoolean());
+	}
+
+	@Test
 	public void testCountByU_DT_D_AR_A() throws Exception {
 		_persistence.countByU_DT_D_AR_A(
 			RandomTestUtil.nextLong(), RandomTestUtil.nextInt(),

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserNotificationEventPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserNotificationEventPersistenceTest.java
@@ -274,6 +274,16 @@ public class UserNotificationEventPersistenceTest {
 	}
 
 	@Test
+	public void testCountByU_D_AR() throws Exception {
+		_persistence.countByU_D_AR(
+			RandomTestUtil.nextLong(), RandomTestUtil.randomBoolean(),
+			RandomTestUtil.randomBoolean());
+
+		_persistence.countByU_D_AR(
+			0L, RandomTestUtil.randomBoolean(), RandomTestUtil.randomBoolean());
+	}
+
+	@Test
 	public void testCountByU_D_A() throws Exception {
 		_persistence.countByU_D_A(
 			RandomTestUtil.nextLong(), RandomTestUtil.randomBoolean(),
@@ -284,12 +294,12 @@ public class UserNotificationEventPersistenceTest {
 	}
 
 	@Test
-	public void testCountByU_A_A() throws Exception {
-		_persistence.countByU_A_A(
+	public void testCountByU_AR_A() throws Exception {
+		_persistence.countByU_AR_A(
 			RandomTestUtil.nextLong(), RandomTestUtil.randomBoolean(),
 			RandomTestUtil.randomBoolean());
 
-		_persistence.countByU_A_A(
+		_persistence.countByU_AR_A(
 			0L, RandomTestUtil.randomBoolean(), RandomTestUtil.randomBoolean());
 	}
 
@@ -307,6 +317,17 @@ public class UserNotificationEventPersistenceTest {
 	}
 
 	@Test
+	public void testCountByU_DT_D_AR() throws Exception {
+		_persistence.countByU_DT_D_AR(
+			RandomTestUtil.nextLong(), RandomTestUtil.nextInt(),
+			RandomTestUtil.randomBoolean(), RandomTestUtil.randomBoolean());
+
+		_persistence.countByU_DT_D_AR(
+			0L, 0, RandomTestUtil.randomBoolean(),
+			RandomTestUtil.randomBoolean());
+	}
+
+	@Test
 	public void testCountByU_DT_D_A() throws Exception {
 		_persistence.countByU_DT_D_A(
 			RandomTestUtil.nextLong(), RandomTestUtil.nextInt(),
@@ -318,14 +339,37 @@ public class UserNotificationEventPersistenceTest {
 	}
 
 	@Test
-	public void testCountByU_DT_A_A() throws Exception {
-		_persistence.countByU_DT_A_A(
+	public void testCountByU_DT_AR_A() throws Exception {
+		_persistence.countByU_DT_AR_A(
 			RandomTestUtil.nextLong(), RandomTestUtil.nextInt(),
 			RandomTestUtil.randomBoolean(), RandomTestUtil.randomBoolean());
 
-		_persistence.countByU_DT_A_A(
+		_persistence.countByU_DT_AR_A(
 			0L, 0, RandomTestUtil.randomBoolean(),
 			RandomTestUtil.randomBoolean());
+	}
+
+	@Test
+	public void testCountByU_D_AR_A() throws Exception {
+		_persistence.countByU_D_AR_A(
+			RandomTestUtil.nextLong(), RandomTestUtil.randomBoolean(),
+			RandomTestUtil.randomBoolean(), RandomTestUtil.randomBoolean());
+
+		_persistence.countByU_D_AR_A(
+			0L, RandomTestUtil.randomBoolean(), RandomTestUtil.randomBoolean(),
+			RandomTestUtil.randomBoolean());
+	}
+
+	@Test
+	public void testCountByU_DT_D_AR_A() throws Exception {
+		_persistence.countByU_DT_D_AR_A(
+			RandomTestUtil.nextLong(), RandomTestUtil.nextInt(),
+			RandomTestUtil.randomBoolean(), RandomTestUtil.randomBoolean(),
+			RandomTestUtil.randomBoolean());
+
+		_persistence.countByU_DT_D_AR_A(
+			0L, 0, RandomTestUtil.randomBoolean(),
+			RandomTestUtil.randomBoolean(), RandomTestUtil.randomBoolean());
 	}
 
 	@Test

--- a/portal-impl/src/com/liferay/portal/service.xml
+++ b/portal-impl/src/com/liferay/portal/service.xml
@@ -3040,6 +3040,13 @@
 			<finder-column name="actionRequired" />
 			<finder-column name="archived" />
 		</finder>
+		<finder name="U_T_DT_D_A" return-type="Collection">
+			<finder-column name="userId" />
+			<finder-column name="type" />
+			<finder-column name="deliveryType" />
+			<finder-column name="delivered" />
+			<finder-column name="archived" />
+		</finder>
 		<finder name="U_DT_D_AR_A" return-type="Collection">
 			<finder-column name="userId" />
 			<finder-column name="deliveryType" />

--- a/portal-impl/src/com/liferay/portal/service.xml
+++ b/portal-impl/src/com/liferay/portal/service.xml
@@ -2995,12 +2995,17 @@
 			<finder-column name="deliveryType" />
 			<finder-column name="archived" />
 		</finder>
-		<finder name="U_D_A" return-type="Collection">
+		<finder name="U_D_AR" return-type="Collection">
 			<finder-column name="userId" />
 			<finder-column name="delivered" />
 			<finder-column name="actionRequired" />
 		</finder>
-		<finder name="U_A_A" return-type="Collection">
+		<finder name="U_D_A" return-type="Collection">
+			<finder-column name="userId" />
+			<finder-column name="delivered" />
+			<finder-column name="archived" />
+		</finder>
+		<finder name="U_AR_A" return-type="Collection">
 			<finder-column name="userId" />
 			<finder-column name="actionRequired" />
 			<finder-column name="archived" />
@@ -3011,15 +3016,34 @@
 			<finder-column name="deliveryType" />
 			<finder-column name="delivered" />
 		</finder>
-		<finder name="U_DT_D_A" return-type="Collection">
+		<finder name="U_DT_D_AR" return-type="Collection">
 			<finder-column name="userId" />
 			<finder-column name="deliveryType" />
 			<finder-column name="delivered" />
 			<finder-column name="actionRequired" />
 		</finder>
-		<finder name="U_DT_A_A" return-type="Collection">
+		<finder name="U_DT_D_A" return-type="Collection">
 			<finder-column name="userId" />
 			<finder-column name="deliveryType" />
+			<finder-column name="delivered" />
+			<finder-column name="archived" />
+		</finder>
+		<finder name="U_DT_AR_A" return-type="Collection">
+			<finder-column name="userId" />
+			<finder-column name="deliveryType" />
+			<finder-column name="actionRequired" />
+			<finder-column name="archived" />
+		</finder>
+		<finder name="U_D_AR_A" return-type="Collection">
+			<finder-column name="userId" />
+			<finder-column name="delivered" />
+			<finder-column name="actionRequired" />
+			<finder-column name="archived" />
+		</finder>
+		<finder name="U_DT_D_AR_A" return-type="Collection">
+			<finder-column name="userId" />
+			<finder-column name="deliveryType" />
+			<finder-column name="delivered" />
 			<finder-column name="actionRequired" />
 			<finder-column name="archived" />
 		</finder>

--- a/portal-impl/src/com/liferay/portal/service/impl/UserNotificationEventLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserNotificationEventLocalServiceImpl.java
@@ -217,7 +217,7 @@ public class UserNotificationEventLocalServiceImpl
 	public List<UserNotificationEvent> getArchivedUserNotificationEvents(
 		long userId, boolean actionRequired, boolean archived) {
 
-		return userNotificationEventPersistence.findByU_A_A(
+		return userNotificationEventPersistence.findByU_AR_A(
 			userId, actionRequired, archived);
 	}
 
@@ -226,7 +226,7 @@ public class UserNotificationEventLocalServiceImpl
 		long userId, boolean actionRequired, boolean archived, int start,
 		int end) {
 
-		return userNotificationEventPersistence.findByU_A_A(
+		return userNotificationEventPersistence.findByU_AR_A(
 			userId, actionRequired, archived, start, end);
 	}
 
@@ -251,7 +251,7 @@ public class UserNotificationEventLocalServiceImpl
 		long userId, int deliveryType, boolean actionRequired,
 		boolean archived) {
 
-		return userNotificationEventPersistence.findByU_DT_A_A(
+		return userNotificationEventPersistence.findByU_DT_AR_A(
 			userId, deliveryType, actionRequired, archived);
 	}
 
@@ -260,7 +260,7 @@ public class UserNotificationEventLocalServiceImpl
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		int start, int end) {
 
-		return userNotificationEventPersistence.findByU_DT_A_A(
+		return userNotificationEventPersistence.findByU_DT_AR_A(
 			userId, deliveryType, actionRequired, archived, start, end);
 	}
 
@@ -269,7 +269,7 @@ public class UserNotificationEventLocalServiceImpl
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		int start, int end, OrderByComparator<UserNotificationEvent> obc) {
 
-		return userNotificationEventPersistence.findByU_DT_A_A(
+		return userNotificationEventPersistence.findByU_DT_AR_A(
 			userId, deliveryType, actionRequired, archived, start, end, obc);
 	}
 
@@ -292,7 +292,7 @@ public class UserNotificationEventLocalServiceImpl
 	public int getArchivedUserNotificationEventsCount(
 		long userId, boolean actionRequired, boolean archived) {
 
-		return userNotificationEventPersistence.countByU_A_A(
+		return userNotificationEventPersistence.countByU_AR_A(
 			userId, actionRequired, archived);
 	}
 
@@ -309,7 +309,7 @@ public class UserNotificationEventLocalServiceImpl
 		long userId, int deliveryType, boolean actionRequired,
 		boolean archived) {
 
-		return userNotificationEventPersistence.countByU_DT_A_A(
+		return userNotificationEventPersistence.countByU_DT_AR_A(
 			userId, deliveryType, actionRequired, archived);
 	}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/UserNotificationEventLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserNotificationEventLocalServiceImpl.java
@@ -62,6 +62,10 @@ public class UserNotificationEventLocalServiceImpl
 			notificationEvent.isArchived(), serviceContext);
 	}
 
+	/**
+	 * @deprecated As of Mueller (7.2.x)
+	 */
+	@Deprecated
 	@Override
 	public UserNotificationEvent addUserNotificationEvent(
 			long userId, boolean actionRequired,
@@ -112,6 +116,10 @@ public class UserNotificationEventLocalServiceImpl
 		return userNotificationEvent;
 	}
 
+	/**
+	 * @deprecated As of Mueller (7.2.x)
+	 */
+	@Deprecated
 	@Override
 	public UserNotificationEvent addUserNotificationEvent(
 			long userId, String type, long timestamp, int deliveryType,

--- a/portal-impl/src/com/liferay/portal/service/impl/UserNotificationEventLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserNotificationEventLocalServiceImpl.java
@@ -161,7 +161,7 @@ public class UserNotificationEventLocalServiceImpl
 
 		int userNotificationEventsCount =
 			getArchivedUserNotificationEventsCount(
-				userId, deliveryType, actionRequired, false);
+				userId, deliveryType, true, actionRequired, false);
 
 		final IntervalActionProcessor<Void> intervalActionProcessor =
 			new IntervalActionProcessor<>(userNotificationEventsCount);
@@ -170,8 +170,8 @@ public class UserNotificationEventLocalServiceImpl
 			(start, end) -> {
 				List<UserNotificationEvent> userNotificationEvents =
 					getArchivedUserNotificationEvents(
-						userId, deliveryType, actionRequired, false, start,
-						end);
+						userId, deliveryType, true, actionRequired, false,
+						start, end);
 
 				for (UserNotificationEvent userNotificationEvent :
 						userNotificationEvents) {
@@ -257,6 +257,27 @@ public class UserNotificationEventLocalServiceImpl
 
 	@Override
 	public List<UserNotificationEvent> getArchivedUserNotificationEvents(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived, int start, int end) {
+
+		return userNotificationEventPersistence.findByU_DT_D_AR_A(
+			userId, deliveryType, delivered, actionRequired, archived, start,
+			end);
+	}
+
+	@Override
+	public List<UserNotificationEvent> getArchivedUserNotificationEvents(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived, int start, int end,
+		OrderByComparator<UserNotificationEvent> obc) {
+
+		return userNotificationEventPersistence.findByU_DT_D_AR_A(
+			userId, deliveryType, delivered, actionRequired, archived, start,
+			end, obc);
+	}
+
+	@Override
+	public List<UserNotificationEvent> getArchivedUserNotificationEvents(
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		int start, int end) {
 
@@ -311,6 +332,23 @@ public class UserNotificationEventLocalServiceImpl
 
 		return userNotificationEventPersistence.countByU_DT_AR_A(
 			userId, deliveryType, actionRequired, archived);
+	}
+
+	@Override
+	public int getArchivedUserNotificationEventsCount(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived) {
+
+		return userNotificationEventPersistence.countByU_DT_D_AR_A(
+			userId, deliveryType, delivered, actionRequired, archived);
+	}
+
+	@Override
+	public int getDeliveredArchivedUserNotificationEventsCount(
+		long userId, int deliveryType, boolean delivered, boolean archived) {
+
+		return userNotificationEventPersistence.countByU_DT_D_A(
+			userId, deliveryType, delivered, archived);
 	}
 
 	@Override
@@ -480,6 +518,15 @@ public class UserNotificationEventLocalServiceImpl
 
 		return userNotificationEventPersistence.countByU_T_DT_D(
 			userId, type, deliveryType, archived);
+	}
+
+	@Override
+	public int getUserNotificationEventsCount(
+		long userId, String type, int deliveryType, boolean delivered,
+		boolean archived) {
+
+		return userNotificationEventPersistence.countByU_T_DT_D_A(
+			userId, type, deliveryType, delivered, archived);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/service/impl/UserNotificationEventLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserNotificationEventLocalServiceImpl.java
@@ -362,7 +362,7 @@ public class UserNotificationEventLocalServiceImpl
 	public List<UserNotificationEvent> getDeliveredUserNotificationEvents(
 		long userId, boolean delivered, boolean actionRequired) {
 
-		return userNotificationEventPersistence.findByU_D_A(
+		return userNotificationEventPersistence.findByU_D_AR(
 			userId, delivered, actionRequired);
 	}
 
@@ -371,7 +371,7 @@ public class UserNotificationEventLocalServiceImpl
 		long userId, boolean delivered, boolean actionRequired, int start,
 		int end) {
 
-		return userNotificationEventPersistence.findByU_D_A(
+		return userNotificationEventPersistence.findByU_D_AR(
 			userId, delivered, actionRequired, start, end);
 	}
 
@@ -396,7 +396,7 @@ public class UserNotificationEventLocalServiceImpl
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired) {
 
-		return userNotificationEventPersistence.findByU_DT_D_A(
+		return userNotificationEventPersistence.findByU_DT_D_AR(
 			userId, deliveryType, delivered, actionRequired);
 	}
 
@@ -405,7 +405,7 @@ public class UserNotificationEventLocalServiceImpl
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired, int start, int end) {
 
-		return userNotificationEventPersistence.findByU_DT_D_A(
+		return userNotificationEventPersistence.findByU_DT_D_AR(
 			userId, deliveryType, delivered, actionRequired, start, end);
 	}
 
@@ -415,7 +415,7 @@ public class UserNotificationEventLocalServiceImpl
 		boolean actionRequired, int start, int end,
 		OrderByComparator<UserNotificationEvent> obc) {
 
-		return userNotificationEventPersistence.findByU_DT_D_A(
+		return userNotificationEventPersistence.findByU_DT_D_AR(
 			userId, deliveryType, delivered, actionRequired, start, end, obc);
 	}
 
@@ -438,7 +438,7 @@ public class UserNotificationEventLocalServiceImpl
 	public int getDeliveredUserNotificationEventsCount(
 		long userId, boolean delivered, boolean actionRequired) {
 
-		return userNotificationEventPersistence.countByU_D_A(
+		return userNotificationEventPersistence.countByU_D_AR(
 			userId, delivered, actionRequired);
 	}
 
@@ -455,7 +455,7 @@ public class UserNotificationEventLocalServiceImpl
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired) {
 
-		return userNotificationEventPersistence.countByU_DT_D_A(
+		return userNotificationEventPersistence.countByU_DT_D_AR(
 			userId, deliveryType, delivered, actionRequired);
 	}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/UserNotificationEventLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserNotificationEventLocalServiceImpl.java
@@ -484,7 +484,7 @@ public class UserNotificationEventLocalServiceImpl
 
 	@Override
 	public UserNotificationEvent sendUserNotificationEvents(
-			long userId, String portletId, int deliveryType,
+			long userId, String portletId, int deliveryType, boolean delivered,
 			boolean actionRequired, JSONObject notificationEventJSONObject)
 		throws PortalException {
 
@@ -496,7 +496,7 @@ public class UserNotificationEventLocalServiceImpl
 		notificationEvent.setDeliveryType(deliveryType);
 
 		UserNotificationEvent userNotificationEvent = addUserNotificationEvent(
-			userId, actionRequired, notificationEvent);
+			userId, delivered, actionRequired, notificationEvent);
 
 		if (deliveryType == UserNotificationDeliveryConstants.TYPE_PUSH) {
 			sendPushNotification(notificationEvent);
@@ -508,35 +508,23 @@ public class UserNotificationEventLocalServiceImpl
 	@Override
 	public UserNotificationEvent sendUserNotificationEvents(
 			long userId, String portletId, int deliveryType,
+			boolean actionRequired, JSONObject notificationEventJSONObject)
+		throws PortalException {
+
+		return sendUserNotificationEvents(
+			userId, portletId, deliveryType, true, actionRequired,
+			notificationEventJSONObject);
+	}
+
+	@Override
+	public UserNotificationEvent sendUserNotificationEvents(
+			long userId, String portletId, int deliveryType,
 			JSONObject notificationEventJSONObject)
 		throws PortalException {
 
 		return sendUserNotificationEvents(
 			userId, portletId, deliveryType, false,
 			notificationEventJSONObject);
-	}
-
-	@Override
-	public UserNotificationEvent storeUserNotificationEvents(
-			long userId, String portletId, int deliveryType,
-			boolean actionRequired, JSONObject notificationEventJSONObject)
-		throws PortalException {
-
-		NotificationEvent notificationEvent =
-			NotificationEventFactoryUtil.createNotificationEvent(
-				System.currentTimeMillis(), portletId,
-				notificationEventJSONObject);
-
-		notificationEvent.setDeliveryType(deliveryType);
-
-		UserNotificationEvent userNotificationEvent = addUserNotificationEvent(
-			userId, false, actionRequired, notificationEvent);
-
-		if (deliveryType == UserNotificationDeliveryConstants.TYPE_PUSH) {
-			sendPushNotification(notificationEvent);
-		}
-
-		return userNotificationEvent;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserNotificationEventPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserNotificationEventPersistenceImpl.java
@@ -10357,6 +10357,739 @@ public class UserNotificationEventPersistenceImpl
 	private static final String _FINDER_COLUMN_U_D_AR_A_ARCHIVED_2 =
 		"userNotificationEvent.archived = ?";
 
+	private FinderPath _finderPathWithPaginationFindByU_T_DT_D_A;
+	private FinderPath _finderPathWithoutPaginationFindByU_T_DT_D_A;
+	private FinderPath _finderPathCountByU_T_DT_D_A;
+
+	/**
+	 * Returns all the user notification events where userId = &#63; and type = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param type the type
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @return the matching user notification events
+	 */
+	@Override
+	public List<UserNotificationEvent> findByU_T_DT_D_A(
+		long userId, String type, int deliveryType, boolean delivered,
+		boolean archived) {
+
+		return findByU_T_DT_D_A(
+			userId, type, deliveryType, delivered, archived, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the user notification events where userId = &#63; and type = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param type the type
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @return the range of matching user notification events
+	 */
+	@Override
+	public List<UserNotificationEvent> findByU_T_DT_D_A(
+		long userId, String type, int deliveryType, boolean delivered,
+		boolean archived, int start, int end) {
+
+		return findByU_T_DT_D_A(
+			userId, type, deliveryType, delivered, archived, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and type = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param type the type
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching user notification events
+	 */
+	@Override
+	public List<UserNotificationEvent> findByU_T_DT_D_A(
+		long userId, String type, int deliveryType, boolean delivered,
+		boolean archived, int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		return findByU_T_DT_D_A(
+			userId, type, deliveryType, delivered, archived, start, end,
+			orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and type = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param type the type
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching user notification events
+	 */
+	@Override
+	public List<UserNotificationEvent> findByU_T_DT_D_A(
+		long userId, String type, int deliveryType, boolean delivered,
+		boolean archived, int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator,
+		boolean useFinderCache) {
+
+		type = Objects.toString(type, "");
+
+		boolean pagination = true;
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+			(orderByComparator == null)) {
+
+			pagination = false;
+
+			if (useFinderCache) {
+				finderPath = _finderPathWithoutPaginationFindByU_T_DT_D_A;
+				finderArgs = new Object[] {
+					userId, type, deliveryType, delivered, archived
+				};
+			}
+		}
+		else if (useFinderCache) {
+			finderPath = _finderPathWithPaginationFindByU_T_DT_D_A;
+			finderArgs = new Object[] {
+				userId, type, deliveryType, delivered, archived, start, end,
+				orderByComparator
+			};
+		}
+
+		List<UserNotificationEvent> list = null;
+
+		if (useFinderCache) {
+			list = (List<UserNotificationEvent>)FinderCacheUtil.getResult(
+				finderPath, finderArgs, this);
+
+			if ((list != null) && !list.isEmpty()) {
+				for (UserNotificationEvent userNotificationEvent : list) {
+					if ((userId != userNotificationEvent.getUserId()) ||
+						!type.equals(userNotificationEvent.getType()) ||
+						(deliveryType !=
+							userNotificationEvent.getDeliveryType()) ||
+						(delivered != userNotificationEvent.isDelivered()) ||
+						(archived != userNotificationEvent.isArchived())) {
+
+						list = null;
+
+						break;
+					}
+				}
+			}
+		}
+
+		if (list == null) {
+			StringBundler query = null;
+
+			if (orderByComparator != null) {
+				query = new StringBundler(
+					7 + (orderByComparator.getOrderByFields().length * 2));
+			}
+			else {
+				query = new StringBundler(7);
+			}
+
+			query.append(_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE);
+
+			query.append(_FINDER_COLUMN_U_T_DT_D_A_USERID_2);
+
+			boolean bindType = false;
+
+			if (type.isEmpty()) {
+				query.append(_FINDER_COLUMN_U_T_DT_D_A_TYPE_3);
+			}
+			else {
+				bindType = true;
+
+				query.append(_FINDER_COLUMN_U_T_DT_D_A_TYPE_2);
+			}
+
+			query.append(_FINDER_COLUMN_U_T_DT_D_A_DELIVERYTYPE_2);
+
+			query.append(_FINDER_COLUMN_U_T_DT_D_A_DELIVERED_2);
+
+			query.append(_FINDER_COLUMN_U_T_DT_D_A_ARCHIVED_2);
+
+			if (orderByComparator != null) {
+				appendOrderByComparator(
+					query, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+			}
+			else if (pagination) {
+				query.append(UserNotificationEventModelImpl.ORDER_BY_JPQL);
+			}
+
+			String sql = query.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query q = session.createQuery(sql);
+
+				QueryPos qPos = QueryPos.getInstance(q);
+
+				qPos.add(userId);
+
+				if (bindType) {
+					qPos.add(type);
+				}
+
+				qPos.add(deliveryType);
+
+				qPos.add(delivered);
+
+				qPos.add(archived);
+
+				if (!pagination) {
+					list = (List<UserNotificationEvent>)QueryUtil.list(
+						q, getDialect(), start, end, false);
+
+					Collections.sort(list);
+
+					list = Collections.unmodifiableList(list);
+				}
+				else {
+					list = (List<UserNotificationEvent>)QueryUtil.list(
+						q, getDialect(), start, end);
+				}
+
+				cacheResult(list);
+
+				if (useFinderCache) {
+					FinderCacheUtil.putResult(finderPath, finderArgs, list);
+				}
+			}
+			catch (Exception e) {
+				if (useFinderCache) {
+					FinderCacheUtil.removeResult(finderPath, finderArgs);
+				}
+
+				throw processException(e);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return list;
+	}
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and type = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param type the type
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	@Override
+	public UserNotificationEvent findByU_T_DT_D_A_First(
+			long userId, String type, int deliveryType, boolean delivered,
+			boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException {
+
+		UserNotificationEvent userNotificationEvent = fetchByU_T_DT_D_A_First(
+			userId, type, deliveryType, delivered, archived, orderByComparator);
+
+		if (userNotificationEvent != null) {
+			return userNotificationEvent;
+		}
+
+		StringBundler msg = new StringBundler(12);
+
+		msg.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		msg.append("userId=");
+		msg.append(userId);
+
+		msg.append(", type=");
+		msg.append(type);
+
+		msg.append(", deliveryType=");
+		msg.append(deliveryType);
+
+		msg.append(", delivered=");
+		msg.append(delivered);
+
+		msg.append(", archived=");
+		msg.append(archived);
+
+		msg.append("}");
+
+		throw new NoSuchUserNotificationEventException(msg.toString());
+	}
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and type = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param type the type
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	@Override
+	public UserNotificationEvent fetchByU_T_DT_D_A_First(
+		long userId, String type, int deliveryType, boolean delivered,
+		boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		List<UserNotificationEvent> list = findByU_T_DT_D_A(
+			userId, type, deliveryType, delivered, archived, 0, 1,
+			orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and type = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param type the type
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	@Override
+	public UserNotificationEvent findByU_T_DT_D_A_Last(
+			long userId, String type, int deliveryType, boolean delivered,
+			boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException {
+
+		UserNotificationEvent userNotificationEvent = fetchByU_T_DT_D_A_Last(
+			userId, type, deliveryType, delivered, archived, orderByComparator);
+
+		if (userNotificationEvent != null) {
+			return userNotificationEvent;
+		}
+
+		StringBundler msg = new StringBundler(12);
+
+		msg.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		msg.append("userId=");
+		msg.append(userId);
+
+		msg.append(", type=");
+		msg.append(type);
+
+		msg.append(", deliveryType=");
+		msg.append(deliveryType);
+
+		msg.append(", delivered=");
+		msg.append(delivered);
+
+		msg.append(", archived=");
+		msg.append(archived);
+
+		msg.append("}");
+
+		throw new NoSuchUserNotificationEventException(msg.toString());
+	}
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and type = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param type the type
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	@Override
+	public UserNotificationEvent fetchByU_T_DT_D_A_Last(
+		long userId, String type, int deliveryType, boolean delivered,
+		boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		int count = countByU_T_DT_D_A(
+			userId, type, deliveryType, delivered, archived);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<UserNotificationEvent> list = findByU_T_DT_D_A(
+			userId, type, deliveryType, delivered, archived, count - 1, count,
+			orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the user notification events before and after the current user notification event in the ordered set where userId = &#63; and type = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userNotificationEventId the primary key of the current user notification event
+	 * @param userId the user ID
+	 * @param type the type
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next user notification event
+	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
+	 */
+	@Override
+	public UserNotificationEvent[] findByU_T_DT_D_A_PrevAndNext(
+			long userNotificationEventId, long userId, String type,
+			int deliveryType, boolean delivered, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException {
+
+		type = Objects.toString(type, "");
+
+		UserNotificationEvent userNotificationEvent = findByPrimaryKey(
+			userNotificationEventId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			UserNotificationEvent[] array = new UserNotificationEventImpl[3];
+
+			array[0] = getByU_T_DT_D_A_PrevAndNext(
+				session, userNotificationEvent, userId, type, deliveryType,
+				delivered, archived, orderByComparator, true);
+
+			array[1] = userNotificationEvent;
+
+			array[2] = getByU_T_DT_D_A_PrevAndNext(
+				session, userNotificationEvent, userId, type, deliveryType,
+				delivered, archived, orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception e) {
+			throw processException(e);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected UserNotificationEvent getByU_T_DT_D_A_PrevAndNext(
+		Session session, UserNotificationEvent userNotificationEvent,
+		long userId, String type, int deliveryType, boolean delivered,
+		boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator,
+		boolean previous) {
+
+		StringBundler query = null;
+
+		if (orderByComparator != null) {
+			query = new StringBundler(
+				8 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			query = new StringBundler(7);
+		}
+
+		query.append(_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE);
+
+		query.append(_FINDER_COLUMN_U_T_DT_D_A_USERID_2);
+
+		boolean bindType = false;
+
+		if (type.isEmpty()) {
+			query.append(_FINDER_COLUMN_U_T_DT_D_A_TYPE_3);
+		}
+		else {
+			bindType = true;
+
+			query.append(_FINDER_COLUMN_U_T_DT_D_A_TYPE_2);
+		}
+
+		query.append(_FINDER_COLUMN_U_T_DT_D_A_DELIVERYTYPE_2);
+
+		query.append(_FINDER_COLUMN_U_T_DT_D_A_DELIVERED_2);
+
+		query.append(_FINDER_COLUMN_U_T_DT_D_A_ARCHIVED_2);
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				query.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				query.append(_ORDER_BY_ENTITY_ALIAS);
+				query.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						query.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(WHERE_GREATER_THAN);
+					}
+					else {
+						query.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			query.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				query.append(_ORDER_BY_ENTITY_ALIAS);
+				query.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						query.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(ORDER_BY_ASC);
+					}
+					else {
+						query.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			query.append(UserNotificationEventModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = query.toString();
+
+		Query q = session.createQuery(sql);
+
+		q.setFirstResult(0);
+		q.setMaxResults(2);
+
+		QueryPos qPos = QueryPos.getInstance(q);
+
+		qPos.add(userId);
+
+		if (bindType) {
+			qPos.add(type);
+		}
+
+		qPos.add(deliveryType);
+
+		qPos.add(delivered);
+
+		qPos.add(archived);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						userNotificationEvent)) {
+
+				qPos.add(orderByConditionValue);
+			}
+		}
+
+		List<UserNotificationEvent> list = q.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the user notification events where userId = &#63; and type = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63; from the database.
+	 *
+	 * @param userId the user ID
+	 * @param type the type
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 */
+	@Override
+	public void removeByU_T_DT_D_A(
+		long userId, String type, int deliveryType, boolean delivered,
+		boolean archived) {
+
+		for (UserNotificationEvent userNotificationEvent :
+				findByU_T_DT_D_A(
+					userId, type, deliveryType, delivered, archived,
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)) {
+
+			remove(userNotificationEvent);
+		}
+	}
+
+	/**
+	 * Returns the number of user notification events where userId = &#63; and type = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param type the type
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @return the number of matching user notification events
+	 */
+	@Override
+	public int countByU_T_DT_D_A(
+		long userId, String type, int deliveryType, boolean delivered,
+		boolean archived) {
+
+		type = Objects.toString(type, "");
+
+		FinderPath finderPath = _finderPathCountByU_T_DT_D_A;
+
+		Object[] finderArgs = new Object[] {
+			userId, type, deliveryType, delivered, archived
+		};
+
+		Long count = (Long)FinderCacheUtil.getResult(
+			finderPath, finderArgs, this);
+
+		if (count == null) {
+			StringBundler query = new StringBundler(6);
+
+			query.append(_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE);
+
+			query.append(_FINDER_COLUMN_U_T_DT_D_A_USERID_2);
+
+			boolean bindType = false;
+
+			if (type.isEmpty()) {
+				query.append(_FINDER_COLUMN_U_T_DT_D_A_TYPE_3);
+			}
+			else {
+				bindType = true;
+
+				query.append(_FINDER_COLUMN_U_T_DT_D_A_TYPE_2);
+			}
+
+			query.append(_FINDER_COLUMN_U_T_DT_D_A_DELIVERYTYPE_2);
+
+			query.append(_FINDER_COLUMN_U_T_DT_D_A_DELIVERED_2);
+
+			query.append(_FINDER_COLUMN_U_T_DT_D_A_ARCHIVED_2);
+
+			String sql = query.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query q = session.createQuery(sql);
+
+				QueryPos qPos = QueryPos.getInstance(q);
+
+				qPos.add(userId);
+
+				if (bindType) {
+					qPos.add(type);
+				}
+
+				qPos.add(deliveryType);
+
+				qPos.add(delivered);
+
+				qPos.add(archived);
+
+				count = (Long)q.uniqueResult();
+
+				FinderCacheUtil.putResult(finderPath, finderArgs, count);
+			}
+			catch (Exception e) {
+				FinderCacheUtil.removeResult(finderPath, finderArgs);
+
+				throw processException(e);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	private static final String _FINDER_COLUMN_U_T_DT_D_A_USERID_2 =
+		"userNotificationEvent.userId = ? AND ";
+
+	private static final String _FINDER_COLUMN_U_T_DT_D_A_TYPE_2 =
+		"userNotificationEvent.type = ? AND ";
+
+	private static final String _FINDER_COLUMN_U_T_DT_D_A_TYPE_3 =
+		"(userNotificationEvent.type IS NULL OR userNotificationEvent.type = '') AND ";
+
+	private static final String _FINDER_COLUMN_U_T_DT_D_A_DELIVERYTYPE_2 =
+		"userNotificationEvent.deliveryType = ? AND ";
+
+	private static final String _FINDER_COLUMN_U_T_DT_D_A_DELIVERED_2 =
+		"userNotificationEvent.delivered = ? AND ";
+
+	private static final String _FINDER_COLUMN_U_T_DT_D_A_ARCHIVED_2 =
+		"userNotificationEvent.archived = ?";
+
 	private FinderPath _finderPathWithPaginationFindByU_DT_D_AR_A;
 	private FinderPath _finderPathWithoutPaginationFindByU_DT_D_AR_A;
 	private FinderPath _finderPathCountByU_DT_D_AR_A;
@@ -11495,6 +12228,18 @@ public class UserNotificationEventPersistenceImpl
 
 			args = new Object[] {
 				userNotificationEventModelImpl.getUserId(),
+				userNotificationEventModelImpl.getType(),
+				userNotificationEventModelImpl.getDeliveryType(),
+				userNotificationEventModelImpl.isDelivered(),
+				userNotificationEventModelImpl.isArchived()
+			};
+
+			FinderCacheUtil.removeResult(_finderPathCountByU_T_DT_D_A, args);
+			FinderCacheUtil.removeResult(
+				_finderPathWithoutPaginationFindByU_T_DT_D_A, args);
+
+			args = new Object[] {
+				userNotificationEventModelImpl.getUserId(),
 				userNotificationEventModelImpl.getDeliveryType(),
 				userNotificationEventModelImpl.isDelivered(),
 				userNotificationEventModelImpl.isActionRequired(),
@@ -11920,6 +12665,37 @@ public class UserNotificationEventPersistenceImpl
 				FinderCacheUtil.removeResult(_finderPathCountByU_D_AR_A, args);
 				FinderCacheUtil.removeResult(
 					_finderPathWithoutPaginationFindByU_D_AR_A, args);
+			}
+
+			if ((userNotificationEventModelImpl.getColumnBitmask() &
+				 _finderPathWithoutPaginationFindByU_T_DT_D_A.
+					 getColumnBitmask()) != 0) {
+
+				Object[] args = new Object[] {
+					userNotificationEventModelImpl.getOriginalUserId(),
+					userNotificationEventModelImpl.getOriginalType(),
+					userNotificationEventModelImpl.getOriginalDeliveryType(),
+					userNotificationEventModelImpl.getOriginalDelivered(),
+					userNotificationEventModelImpl.getOriginalArchived()
+				};
+
+				FinderCacheUtil.removeResult(
+					_finderPathCountByU_T_DT_D_A, args);
+				FinderCacheUtil.removeResult(
+					_finderPathWithoutPaginationFindByU_T_DT_D_A, args);
+
+				args = new Object[] {
+					userNotificationEventModelImpl.getUserId(),
+					userNotificationEventModelImpl.getType(),
+					userNotificationEventModelImpl.getDeliveryType(),
+					userNotificationEventModelImpl.isDelivered(),
+					userNotificationEventModelImpl.isArchived()
+				};
+
+				FinderCacheUtil.removeResult(
+					_finderPathCountByU_T_DT_D_A, args);
+				FinderCacheUtil.removeResult(
+					_finderPathWithoutPaginationFindByU_T_DT_D_A, args);
 			}
 
 			if ((userNotificationEventModelImpl.getColumnBitmask() &
@@ -12801,6 +13577,45 @@ public class UserNotificationEventPersistenceImpl
 			new String[] {
 				Long.class.getName(), Boolean.class.getName(),
 				Boolean.class.getName(), Boolean.class.getName()
+			});
+
+		_finderPathWithPaginationFindByU_T_DT_D_A = new FinderPath(
+			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
+			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED,
+			UserNotificationEventImpl.class,
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_T_DT_D_A",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			});
+
+		_finderPathWithoutPaginationFindByU_T_DT_D_A = new FinderPath(
+			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
+			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED,
+			UserNotificationEventImpl.class,
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_T_DT_D_A",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName()
+			},
+			UserNotificationEventModelImpl.USERID_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.TYPE_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.DELIVERYTYPE_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.DELIVERED_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.ARCHIVED_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.TIMESTAMP_COLUMN_BITMASK);
+
+		_finderPathCountByU_T_DT_D_A = new FinderPath(
+			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
+			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED, Long.class,
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_T_DT_D_A",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName()
 			});
 
 		_finderPathWithPaginationFindByU_DT_D_AR_A = new FinderPath(

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserNotificationEventPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserNotificationEventPersistenceImpl.java
@@ -5230,9 +5230,9 @@ public class UserNotificationEventPersistenceImpl
 	private static final String _FINDER_COLUMN_U_DT_A_ARCHIVED_2 =
 		"userNotificationEvent.archived = ?";
 
-	private FinderPath _finderPathWithPaginationFindByU_D_A;
-	private FinderPath _finderPathWithoutPaginationFindByU_D_A;
-	private FinderPath _finderPathCountByU_D_A;
+	private FinderPath _finderPathWithPaginationFindByU_D_AR;
+	private FinderPath _finderPathWithoutPaginationFindByU_D_AR;
+	private FinderPath _finderPathCountByU_D_AR;
 
 	/**
 	 * Returns all the user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63;.
@@ -5243,10 +5243,10 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the matching user notification events
 	 */
 	@Override
-	public List<UserNotificationEvent> findByU_D_A(
+	public List<UserNotificationEvent> findByU_D_AR(
 		long userId, boolean delivered, boolean actionRequired) {
 
-		return findByU_D_A(
+		return findByU_D_AR(
 			userId, delivered, actionRequired, QueryUtil.ALL_POS,
 			QueryUtil.ALL_POS, null);
 	}
@@ -5266,11 +5266,12 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the range of matching user notification events
 	 */
 	@Override
-	public List<UserNotificationEvent> findByU_D_A(
+	public List<UserNotificationEvent> findByU_D_AR(
 		long userId, boolean delivered, boolean actionRequired, int start,
 		int end) {
 
-		return findByU_D_A(userId, delivered, actionRequired, start, end, null);
+		return findByU_D_AR(
+			userId, delivered, actionRequired, start, end, null);
 	}
 
 	/**
@@ -5289,11 +5290,11 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the ordered range of matching user notification events
 	 */
 	@Override
-	public List<UserNotificationEvent> findByU_D_A(
+	public List<UserNotificationEvent> findByU_D_AR(
 		long userId, boolean delivered, boolean actionRequired, int start,
 		int end, OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		return findByU_D_A(
+		return findByU_D_AR(
 			userId, delivered, actionRequired, start, end, orderByComparator,
 			true);
 	}
@@ -5315,7 +5316,7 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the ordered range of matching user notification events
 	 */
 	@Override
-	public List<UserNotificationEvent> findByU_D_A(
+	public List<UserNotificationEvent> findByU_D_AR(
 		long userId, boolean delivered, boolean actionRequired, int start,
 		int end, OrderByComparator<UserNotificationEvent> orderByComparator,
 		boolean useFinderCache) {
@@ -5330,12 +5331,12 @@ public class UserNotificationEventPersistenceImpl
 			pagination = false;
 
 			if (useFinderCache) {
-				finderPath = _finderPathWithoutPaginationFindByU_D_A;
+				finderPath = _finderPathWithoutPaginationFindByU_D_AR;
 				finderArgs = new Object[] {userId, delivered, actionRequired};
 			}
 		}
 		else if (useFinderCache) {
-			finderPath = _finderPathWithPaginationFindByU_D_A;
+			finderPath = _finderPathWithPaginationFindByU_D_AR;
 			finderArgs = new Object[] {
 				userId, delivered, actionRequired, start, end, orderByComparator
 			};
@@ -5375,11 +5376,11 @@ public class UserNotificationEventPersistenceImpl
 
 			query.append(_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE);
 
-			query.append(_FINDER_COLUMN_U_D_A_USERID_2);
+			query.append(_FINDER_COLUMN_U_D_AR_USERID_2);
 
-			query.append(_FINDER_COLUMN_U_D_A_DELIVERED_2);
+			query.append(_FINDER_COLUMN_U_D_AR_DELIVERED_2);
 
-			query.append(_FINDER_COLUMN_U_D_A_ACTIONREQUIRED_2);
+			query.append(_FINDER_COLUMN_U_D_AR_ACTIONREQUIRED_2);
 
 			if (orderByComparator != null) {
 				appendOrderByComparator(
@@ -5451,12 +5452,12 @@ public class UserNotificationEventPersistenceImpl
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
 	@Override
-	public UserNotificationEvent findByU_D_A_First(
+	public UserNotificationEvent findByU_D_AR_First(
 			long userId, boolean delivered, boolean actionRequired,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws NoSuchUserNotificationEventException {
 
-		UserNotificationEvent userNotificationEvent = fetchByU_D_A_First(
+		UserNotificationEvent userNotificationEvent = fetchByU_D_AR_First(
 			userId, delivered, actionRequired, orderByComparator);
 
 		if (userNotificationEvent != null) {
@@ -5491,11 +5492,11 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
 	@Override
-	public UserNotificationEvent fetchByU_D_A_First(
+	public UserNotificationEvent fetchByU_D_AR_First(
 		long userId, boolean delivered, boolean actionRequired,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		List<UserNotificationEvent> list = findByU_D_A(
+		List<UserNotificationEvent> list = findByU_D_AR(
 			userId, delivered, actionRequired, 0, 1, orderByComparator);
 
 		if (!list.isEmpty()) {
@@ -5516,12 +5517,12 @@ public class UserNotificationEventPersistenceImpl
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
 	@Override
-	public UserNotificationEvent findByU_D_A_Last(
+	public UserNotificationEvent findByU_D_AR_Last(
 			long userId, boolean delivered, boolean actionRequired,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws NoSuchUserNotificationEventException {
 
-		UserNotificationEvent userNotificationEvent = fetchByU_D_A_Last(
+		UserNotificationEvent userNotificationEvent = fetchByU_D_AR_Last(
 			userId, delivered, actionRequired, orderByComparator);
 
 		if (userNotificationEvent != null) {
@@ -5556,17 +5557,17 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
 	@Override
-	public UserNotificationEvent fetchByU_D_A_Last(
+	public UserNotificationEvent fetchByU_D_AR_Last(
 		long userId, boolean delivered, boolean actionRequired,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		int count = countByU_D_A(userId, delivered, actionRequired);
+		int count = countByU_D_AR(userId, delivered, actionRequired);
 
 		if (count == 0) {
 			return null;
 		}
 
-		List<UserNotificationEvent> list = findByU_D_A(
+		List<UserNotificationEvent> list = findByU_D_AR(
 			userId, delivered, actionRequired, count - 1, count,
 			orderByComparator);
 
@@ -5589,7 +5590,7 @@ public class UserNotificationEventPersistenceImpl
 	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
 	 */
 	@Override
-	public UserNotificationEvent[] findByU_D_A_PrevAndNext(
+	public UserNotificationEvent[] findByU_D_AR_PrevAndNext(
 			long userNotificationEventId, long userId, boolean delivered,
 			boolean actionRequired,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
@@ -5605,13 +5606,13 @@ public class UserNotificationEventPersistenceImpl
 
 			UserNotificationEvent[] array = new UserNotificationEventImpl[3];
 
-			array[0] = getByU_D_A_PrevAndNext(
+			array[0] = getByU_D_AR_PrevAndNext(
 				session, userNotificationEvent, userId, delivered,
 				actionRequired, orderByComparator, true);
 
 			array[1] = userNotificationEvent;
 
-			array[2] = getByU_D_A_PrevAndNext(
+			array[2] = getByU_D_AR_PrevAndNext(
 				session, userNotificationEvent, userId, delivered,
 				actionRequired, orderByComparator, false);
 
@@ -5625,7 +5626,7 @@ public class UserNotificationEventPersistenceImpl
 		}
 	}
 
-	protected UserNotificationEvent getByU_D_A_PrevAndNext(
+	protected UserNotificationEvent getByU_D_AR_PrevAndNext(
 		Session session, UserNotificationEvent userNotificationEvent,
 		long userId, boolean delivered, boolean actionRequired,
 		OrderByComparator<UserNotificationEvent> orderByComparator,
@@ -5644,11 +5645,11 @@ public class UserNotificationEventPersistenceImpl
 
 		query.append(_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE);
 
-		query.append(_FINDER_COLUMN_U_D_A_USERID_2);
+		query.append(_FINDER_COLUMN_U_D_AR_USERID_2);
 
-		query.append(_FINDER_COLUMN_U_D_A_DELIVERED_2);
+		query.append(_FINDER_COLUMN_U_D_AR_DELIVERED_2);
 
-		query.append(_FINDER_COLUMN_U_D_A_ACTIONREQUIRED_2);
+		query.append(_FINDER_COLUMN_U_D_AR_ACTIONREQUIRED_2);
 
 		if (orderByComparator != null) {
 			String[] orderByConditionFields =
@@ -5752,11 +5753,11 @@ public class UserNotificationEventPersistenceImpl
 	 * @param actionRequired the action required
 	 */
 	@Override
-	public void removeByU_D_A(
+	public void removeByU_D_AR(
 		long userId, boolean delivered, boolean actionRequired) {
 
 		for (UserNotificationEvent userNotificationEvent :
-				findByU_D_A(
+				findByU_D_AR(
 					userId, delivered, actionRequired, QueryUtil.ALL_POS,
 					QueryUtil.ALL_POS, null)) {
 
@@ -5773,10 +5774,10 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the number of matching user notification events
 	 */
 	@Override
-	public int countByU_D_A(
+	public int countByU_D_AR(
 		long userId, boolean delivered, boolean actionRequired) {
 
-		FinderPath finderPath = _finderPathCountByU_D_A;
+		FinderPath finderPath = _finderPathCountByU_D_AR;
 
 		Object[] finderArgs = new Object[] {userId, delivered, actionRequired};
 
@@ -5788,11 +5789,11 @@ public class UserNotificationEventPersistenceImpl
 
 			query.append(_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE);
 
-			query.append(_FINDER_COLUMN_U_D_A_USERID_2);
+			query.append(_FINDER_COLUMN_U_D_AR_USERID_2);
 
-			query.append(_FINDER_COLUMN_U_D_A_DELIVERED_2);
+			query.append(_FINDER_COLUMN_U_D_AR_DELIVERED_2);
 
-			query.append(_FINDER_COLUMN_U_D_A_ACTIONREQUIRED_2);
+			query.append(_FINDER_COLUMN_U_D_AR_ACTIONREQUIRED_2);
 
 			String sql = query.toString();
 
@@ -5828,18 +5829,619 @@ public class UserNotificationEventPersistenceImpl
 		return count.intValue();
 	}
 
+	private static final String _FINDER_COLUMN_U_D_AR_USERID_2 =
+		"userNotificationEvent.userId = ? AND ";
+
+	private static final String _FINDER_COLUMN_U_D_AR_DELIVERED_2 =
+		"userNotificationEvent.delivered = ? AND ";
+
+	private static final String _FINDER_COLUMN_U_D_AR_ACTIONREQUIRED_2 =
+		"userNotificationEvent.actionRequired = ?";
+
+	private FinderPath _finderPathWithPaginationFindByU_D_A;
+	private FinderPath _finderPathWithoutPaginationFindByU_D_A;
+	private FinderPath _finderPathCountByU_D_A;
+
+	/**
+	 * Returns all the user notification events where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @return the matching user notification events
+	 */
+	@Override
+	public List<UserNotificationEvent> findByU_D_A(
+		long userId, boolean delivered, boolean archived) {
+
+		return findByU_D_A(
+			userId, delivered, archived, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+			null);
+	}
+
+	/**
+	 * Returns a range of all the user notification events where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @return the range of matching user notification events
+	 */
+	@Override
+	public List<UserNotificationEvent> findByU_D_A(
+		long userId, boolean delivered, boolean archived, int start, int end) {
+
+		return findByU_D_A(userId, delivered, archived, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching user notification events
+	 */
+	@Override
+	public List<UserNotificationEvent> findByU_D_A(
+		long userId, boolean delivered, boolean archived, int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		return findByU_D_A(
+			userId, delivered, archived, start, end, orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching user notification events
+	 */
+	@Override
+	public List<UserNotificationEvent> findByU_D_A(
+		long userId, boolean delivered, boolean archived, int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator,
+		boolean useFinderCache) {
+
+		boolean pagination = true;
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+			(orderByComparator == null)) {
+
+			pagination = false;
+
+			if (useFinderCache) {
+				finderPath = _finderPathWithoutPaginationFindByU_D_A;
+				finderArgs = new Object[] {userId, delivered, archived};
+			}
+		}
+		else if (useFinderCache) {
+			finderPath = _finderPathWithPaginationFindByU_D_A;
+			finderArgs = new Object[] {
+				userId, delivered, archived, start, end, orderByComparator
+			};
+		}
+
+		List<UserNotificationEvent> list = null;
+
+		if (useFinderCache) {
+			list = (List<UserNotificationEvent>)FinderCacheUtil.getResult(
+				finderPath, finderArgs, this);
+
+			if ((list != null) && !list.isEmpty()) {
+				for (UserNotificationEvent userNotificationEvent : list) {
+					if ((userId != userNotificationEvent.getUserId()) ||
+						(delivered != userNotificationEvent.isDelivered()) ||
+						(archived != userNotificationEvent.isArchived())) {
+
+						list = null;
+
+						break;
+					}
+				}
+			}
+		}
+
+		if (list == null) {
+			StringBundler query = null;
+
+			if (orderByComparator != null) {
+				query = new StringBundler(
+					5 + (orderByComparator.getOrderByFields().length * 2));
+			}
+			else {
+				query = new StringBundler(5);
+			}
+
+			query.append(_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE);
+
+			query.append(_FINDER_COLUMN_U_D_A_USERID_2);
+
+			query.append(_FINDER_COLUMN_U_D_A_DELIVERED_2);
+
+			query.append(_FINDER_COLUMN_U_D_A_ARCHIVED_2);
+
+			if (orderByComparator != null) {
+				appendOrderByComparator(
+					query, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+			}
+			else if (pagination) {
+				query.append(UserNotificationEventModelImpl.ORDER_BY_JPQL);
+			}
+
+			String sql = query.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query q = session.createQuery(sql);
+
+				QueryPos qPos = QueryPos.getInstance(q);
+
+				qPos.add(userId);
+
+				qPos.add(delivered);
+
+				qPos.add(archived);
+
+				if (!pagination) {
+					list = (List<UserNotificationEvent>)QueryUtil.list(
+						q, getDialect(), start, end, false);
+
+					Collections.sort(list);
+
+					list = Collections.unmodifiableList(list);
+				}
+				else {
+					list = (List<UserNotificationEvent>)QueryUtil.list(
+						q, getDialect(), start, end);
+				}
+
+				cacheResult(list);
+
+				if (useFinderCache) {
+					FinderCacheUtil.putResult(finderPath, finderArgs, list);
+				}
+			}
+			catch (Exception e) {
+				if (useFinderCache) {
+					FinderCacheUtil.removeResult(finderPath, finderArgs);
+				}
+
+				throw processException(e);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return list;
+	}
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	@Override
+	public UserNotificationEvent findByU_D_A_First(
+			long userId, boolean delivered, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException {
+
+		UserNotificationEvent userNotificationEvent = fetchByU_D_A_First(
+			userId, delivered, archived, orderByComparator);
+
+		if (userNotificationEvent != null) {
+			return userNotificationEvent;
+		}
+
+		StringBundler msg = new StringBundler(8);
+
+		msg.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		msg.append("userId=");
+		msg.append(userId);
+
+		msg.append(", delivered=");
+		msg.append(delivered);
+
+		msg.append(", archived=");
+		msg.append(archived);
+
+		msg.append("}");
+
+		throw new NoSuchUserNotificationEventException(msg.toString());
+	}
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	@Override
+	public UserNotificationEvent fetchByU_D_A_First(
+		long userId, boolean delivered, boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		List<UserNotificationEvent> list = findByU_D_A(
+			userId, delivered, archived, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	@Override
+	public UserNotificationEvent findByU_D_A_Last(
+			long userId, boolean delivered, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException {
+
+		UserNotificationEvent userNotificationEvent = fetchByU_D_A_Last(
+			userId, delivered, archived, orderByComparator);
+
+		if (userNotificationEvent != null) {
+			return userNotificationEvent;
+		}
+
+		StringBundler msg = new StringBundler(8);
+
+		msg.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		msg.append("userId=");
+		msg.append(userId);
+
+		msg.append(", delivered=");
+		msg.append(delivered);
+
+		msg.append(", archived=");
+		msg.append(archived);
+
+		msg.append("}");
+
+		throw new NoSuchUserNotificationEventException(msg.toString());
+	}
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	@Override
+	public UserNotificationEvent fetchByU_D_A_Last(
+		long userId, boolean delivered, boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		int count = countByU_D_A(userId, delivered, archived);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<UserNotificationEvent> list = findByU_D_A(
+			userId, delivered, archived, count - 1, count, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the user notification events before and after the current user notification event in the ordered set where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userNotificationEventId the primary key of the current user notification event
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next user notification event
+	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
+	 */
+	@Override
+	public UserNotificationEvent[] findByU_D_A_PrevAndNext(
+			long userNotificationEventId, long userId, boolean delivered,
+			boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException {
+
+		UserNotificationEvent userNotificationEvent = findByPrimaryKey(
+			userNotificationEventId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			UserNotificationEvent[] array = new UserNotificationEventImpl[3];
+
+			array[0] = getByU_D_A_PrevAndNext(
+				session, userNotificationEvent, userId, delivered, archived,
+				orderByComparator, true);
+
+			array[1] = userNotificationEvent;
+
+			array[2] = getByU_D_A_PrevAndNext(
+				session, userNotificationEvent, userId, delivered, archived,
+				orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception e) {
+			throw processException(e);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected UserNotificationEvent getByU_D_A_PrevAndNext(
+		Session session, UserNotificationEvent userNotificationEvent,
+		long userId, boolean delivered, boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator,
+		boolean previous) {
+
+		StringBundler query = null;
+
+		if (orderByComparator != null) {
+			query = new StringBundler(
+				6 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			query = new StringBundler(5);
+		}
+
+		query.append(_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE);
+
+		query.append(_FINDER_COLUMN_U_D_A_USERID_2);
+
+		query.append(_FINDER_COLUMN_U_D_A_DELIVERED_2);
+
+		query.append(_FINDER_COLUMN_U_D_A_ARCHIVED_2);
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				query.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				query.append(_ORDER_BY_ENTITY_ALIAS);
+				query.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						query.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(WHERE_GREATER_THAN);
+					}
+					else {
+						query.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			query.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				query.append(_ORDER_BY_ENTITY_ALIAS);
+				query.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						query.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(ORDER_BY_ASC);
+					}
+					else {
+						query.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			query.append(UserNotificationEventModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = query.toString();
+
+		Query q = session.createQuery(sql);
+
+		q.setFirstResult(0);
+		q.setMaxResults(2);
+
+		QueryPos qPos = QueryPos.getInstance(q);
+
+		qPos.add(userId);
+
+		qPos.add(delivered);
+
+		qPos.add(archived);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						userNotificationEvent)) {
+
+				qPos.add(orderByConditionValue);
+			}
+		}
+
+		List<UserNotificationEvent> list = q.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the user notification events where userId = &#63; and delivered = &#63; and archived = &#63; from the database.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 */
+	@Override
+	public void removeByU_D_A(
+		long userId, boolean delivered, boolean archived) {
+
+		for (UserNotificationEvent userNotificationEvent :
+				findByU_D_A(
+					userId, delivered, archived, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS, null)) {
+
+			remove(userNotificationEvent);
+		}
+	}
+
+	/**
+	 * Returns the number of user notification events where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @return the number of matching user notification events
+	 */
+	@Override
+	public int countByU_D_A(long userId, boolean delivered, boolean archived) {
+		FinderPath finderPath = _finderPathCountByU_D_A;
+
+		Object[] finderArgs = new Object[] {userId, delivered, archived};
+
+		Long count = (Long)FinderCacheUtil.getResult(
+			finderPath, finderArgs, this);
+
+		if (count == null) {
+			StringBundler query = new StringBundler(4);
+
+			query.append(_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE);
+
+			query.append(_FINDER_COLUMN_U_D_A_USERID_2);
+
+			query.append(_FINDER_COLUMN_U_D_A_DELIVERED_2);
+
+			query.append(_FINDER_COLUMN_U_D_A_ARCHIVED_2);
+
+			String sql = query.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query q = session.createQuery(sql);
+
+				QueryPos qPos = QueryPos.getInstance(q);
+
+				qPos.add(userId);
+
+				qPos.add(delivered);
+
+				qPos.add(archived);
+
+				count = (Long)q.uniqueResult();
+
+				FinderCacheUtil.putResult(finderPath, finderArgs, count);
+			}
+			catch (Exception e) {
+				FinderCacheUtil.removeResult(finderPath, finderArgs);
+
+				throw processException(e);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
 	private static final String _FINDER_COLUMN_U_D_A_USERID_2 =
 		"userNotificationEvent.userId = ? AND ";
 
 	private static final String _FINDER_COLUMN_U_D_A_DELIVERED_2 =
 		"userNotificationEvent.delivered = ? AND ";
 
-	private static final String _FINDER_COLUMN_U_D_A_ACTIONREQUIRED_2 =
-		"userNotificationEvent.actionRequired = ?";
+	private static final String _FINDER_COLUMN_U_D_A_ARCHIVED_2 =
+		"userNotificationEvent.archived = ?";
 
-	private FinderPath _finderPathWithPaginationFindByU_A_A;
-	private FinderPath _finderPathWithoutPaginationFindByU_A_A;
-	private FinderPath _finderPathCountByU_A_A;
+	private FinderPath _finderPathWithPaginationFindByU_AR_A;
+	private FinderPath _finderPathWithoutPaginationFindByU_AR_A;
+	private FinderPath _finderPathCountByU_AR_A;
 
 	/**
 	 * Returns all the user notification events where userId = &#63; and actionRequired = &#63; and archived = &#63;.
@@ -5850,10 +6452,10 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the matching user notification events
 	 */
 	@Override
-	public List<UserNotificationEvent> findByU_A_A(
+	public List<UserNotificationEvent> findByU_AR_A(
 		long userId, boolean actionRequired, boolean archived) {
 
-		return findByU_A_A(
+		return findByU_AR_A(
 			userId, actionRequired, archived, QueryUtil.ALL_POS,
 			QueryUtil.ALL_POS, null);
 	}
@@ -5873,11 +6475,11 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the range of matching user notification events
 	 */
 	@Override
-	public List<UserNotificationEvent> findByU_A_A(
+	public List<UserNotificationEvent> findByU_AR_A(
 		long userId, boolean actionRequired, boolean archived, int start,
 		int end) {
 
-		return findByU_A_A(userId, actionRequired, archived, start, end, null);
+		return findByU_AR_A(userId, actionRequired, archived, start, end, null);
 	}
 
 	/**
@@ -5896,11 +6498,11 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the ordered range of matching user notification events
 	 */
 	@Override
-	public List<UserNotificationEvent> findByU_A_A(
+	public List<UserNotificationEvent> findByU_AR_A(
 		long userId, boolean actionRequired, boolean archived, int start,
 		int end, OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		return findByU_A_A(
+		return findByU_AR_A(
 			userId, actionRequired, archived, start, end, orderByComparator,
 			true);
 	}
@@ -5922,7 +6524,7 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the ordered range of matching user notification events
 	 */
 	@Override
-	public List<UserNotificationEvent> findByU_A_A(
+	public List<UserNotificationEvent> findByU_AR_A(
 		long userId, boolean actionRequired, boolean archived, int start,
 		int end, OrderByComparator<UserNotificationEvent> orderByComparator,
 		boolean useFinderCache) {
@@ -5937,12 +6539,12 @@ public class UserNotificationEventPersistenceImpl
 			pagination = false;
 
 			if (useFinderCache) {
-				finderPath = _finderPathWithoutPaginationFindByU_A_A;
+				finderPath = _finderPathWithoutPaginationFindByU_AR_A;
 				finderArgs = new Object[] {userId, actionRequired, archived};
 			}
 		}
 		else if (useFinderCache) {
-			finderPath = _finderPathWithPaginationFindByU_A_A;
+			finderPath = _finderPathWithPaginationFindByU_AR_A;
 			finderArgs = new Object[] {
 				userId, actionRequired, archived, start, end, orderByComparator
 			};
@@ -5982,11 +6584,11 @@ public class UserNotificationEventPersistenceImpl
 
 			query.append(_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE);
 
-			query.append(_FINDER_COLUMN_U_A_A_USERID_2);
+			query.append(_FINDER_COLUMN_U_AR_A_USERID_2);
 
-			query.append(_FINDER_COLUMN_U_A_A_ACTIONREQUIRED_2);
+			query.append(_FINDER_COLUMN_U_AR_A_ACTIONREQUIRED_2);
 
-			query.append(_FINDER_COLUMN_U_A_A_ARCHIVED_2);
+			query.append(_FINDER_COLUMN_U_AR_A_ARCHIVED_2);
 
 			if (orderByComparator != null) {
 				appendOrderByComparator(
@@ -6058,12 +6660,12 @@ public class UserNotificationEventPersistenceImpl
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
 	@Override
-	public UserNotificationEvent findByU_A_A_First(
+	public UserNotificationEvent findByU_AR_A_First(
 			long userId, boolean actionRequired, boolean archived,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws NoSuchUserNotificationEventException {
 
-		UserNotificationEvent userNotificationEvent = fetchByU_A_A_First(
+		UserNotificationEvent userNotificationEvent = fetchByU_AR_A_First(
 			userId, actionRequired, archived, orderByComparator);
 
 		if (userNotificationEvent != null) {
@@ -6098,11 +6700,11 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
 	@Override
-	public UserNotificationEvent fetchByU_A_A_First(
+	public UserNotificationEvent fetchByU_AR_A_First(
 		long userId, boolean actionRequired, boolean archived,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		List<UserNotificationEvent> list = findByU_A_A(
+		List<UserNotificationEvent> list = findByU_AR_A(
 			userId, actionRequired, archived, 0, 1, orderByComparator);
 
 		if (!list.isEmpty()) {
@@ -6123,12 +6725,12 @@ public class UserNotificationEventPersistenceImpl
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
 	@Override
-	public UserNotificationEvent findByU_A_A_Last(
+	public UserNotificationEvent findByU_AR_A_Last(
 			long userId, boolean actionRequired, boolean archived,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws NoSuchUserNotificationEventException {
 
-		UserNotificationEvent userNotificationEvent = fetchByU_A_A_Last(
+		UserNotificationEvent userNotificationEvent = fetchByU_AR_A_Last(
 			userId, actionRequired, archived, orderByComparator);
 
 		if (userNotificationEvent != null) {
@@ -6163,17 +6765,17 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
 	@Override
-	public UserNotificationEvent fetchByU_A_A_Last(
+	public UserNotificationEvent fetchByU_AR_A_Last(
 		long userId, boolean actionRequired, boolean archived,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		int count = countByU_A_A(userId, actionRequired, archived);
+		int count = countByU_AR_A(userId, actionRequired, archived);
 
 		if (count == 0) {
 			return null;
 		}
 
-		List<UserNotificationEvent> list = findByU_A_A(
+		List<UserNotificationEvent> list = findByU_AR_A(
 			userId, actionRequired, archived, count - 1, count,
 			orderByComparator);
 
@@ -6196,7 +6798,7 @@ public class UserNotificationEventPersistenceImpl
 	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
 	 */
 	@Override
-	public UserNotificationEvent[] findByU_A_A_PrevAndNext(
+	public UserNotificationEvent[] findByU_AR_A_PrevAndNext(
 			long userNotificationEventId, long userId, boolean actionRequired,
 			boolean archived,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
@@ -6212,13 +6814,13 @@ public class UserNotificationEventPersistenceImpl
 
 			UserNotificationEvent[] array = new UserNotificationEventImpl[3];
 
-			array[0] = getByU_A_A_PrevAndNext(
+			array[0] = getByU_AR_A_PrevAndNext(
 				session, userNotificationEvent, userId, actionRequired,
 				archived, orderByComparator, true);
 
 			array[1] = userNotificationEvent;
 
-			array[2] = getByU_A_A_PrevAndNext(
+			array[2] = getByU_AR_A_PrevAndNext(
 				session, userNotificationEvent, userId, actionRequired,
 				archived, orderByComparator, false);
 
@@ -6232,7 +6834,7 @@ public class UserNotificationEventPersistenceImpl
 		}
 	}
 
-	protected UserNotificationEvent getByU_A_A_PrevAndNext(
+	protected UserNotificationEvent getByU_AR_A_PrevAndNext(
 		Session session, UserNotificationEvent userNotificationEvent,
 		long userId, boolean actionRequired, boolean archived,
 		OrderByComparator<UserNotificationEvent> orderByComparator,
@@ -6251,11 +6853,11 @@ public class UserNotificationEventPersistenceImpl
 
 		query.append(_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE);
 
-		query.append(_FINDER_COLUMN_U_A_A_USERID_2);
+		query.append(_FINDER_COLUMN_U_AR_A_USERID_2);
 
-		query.append(_FINDER_COLUMN_U_A_A_ACTIONREQUIRED_2);
+		query.append(_FINDER_COLUMN_U_AR_A_ACTIONREQUIRED_2);
 
-		query.append(_FINDER_COLUMN_U_A_A_ARCHIVED_2);
+		query.append(_FINDER_COLUMN_U_AR_A_ARCHIVED_2);
 
 		if (orderByComparator != null) {
 			String[] orderByConditionFields =
@@ -6359,11 +6961,11 @@ public class UserNotificationEventPersistenceImpl
 	 * @param archived the archived
 	 */
 	@Override
-	public void removeByU_A_A(
+	public void removeByU_AR_A(
 		long userId, boolean actionRequired, boolean archived) {
 
 		for (UserNotificationEvent userNotificationEvent :
-				findByU_A_A(
+				findByU_AR_A(
 					userId, actionRequired, archived, QueryUtil.ALL_POS,
 					QueryUtil.ALL_POS, null)) {
 
@@ -6380,10 +6982,10 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the number of matching user notification events
 	 */
 	@Override
-	public int countByU_A_A(
+	public int countByU_AR_A(
 		long userId, boolean actionRequired, boolean archived) {
 
-		FinderPath finderPath = _finderPathCountByU_A_A;
+		FinderPath finderPath = _finderPathCountByU_AR_A;
 
 		Object[] finderArgs = new Object[] {userId, actionRequired, archived};
 
@@ -6395,11 +6997,11 @@ public class UserNotificationEventPersistenceImpl
 
 			query.append(_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE);
 
-			query.append(_FINDER_COLUMN_U_A_A_USERID_2);
+			query.append(_FINDER_COLUMN_U_AR_A_USERID_2);
 
-			query.append(_FINDER_COLUMN_U_A_A_ACTIONREQUIRED_2);
+			query.append(_FINDER_COLUMN_U_AR_A_ACTIONREQUIRED_2);
 
-			query.append(_FINDER_COLUMN_U_A_A_ARCHIVED_2);
+			query.append(_FINDER_COLUMN_U_AR_A_ARCHIVED_2);
 
 			String sql = query.toString();
 
@@ -6435,13 +7037,13 @@ public class UserNotificationEventPersistenceImpl
 		return count.intValue();
 	}
 
-	private static final String _FINDER_COLUMN_U_A_A_USERID_2 =
+	private static final String _FINDER_COLUMN_U_AR_A_USERID_2 =
 		"userNotificationEvent.userId = ? AND ";
 
-	private static final String _FINDER_COLUMN_U_A_A_ACTIONREQUIRED_2 =
+	private static final String _FINDER_COLUMN_U_AR_A_ACTIONREQUIRED_2 =
 		"userNotificationEvent.actionRequired = ? AND ";
 
-	private static final String _FINDER_COLUMN_U_A_A_ARCHIVED_2 =
+	private static final String _FINDER_COLUMN_U_AR_A_ARCHIVED_2 =
 		"userNotificationEvent.archived = ?";
 
 	private FinderPath _finderPathWithPaginationFindByU_T_DT_D;
@@ -7134,9 +7736,9 @@ public class UserNotificationEventPersistenceImpl
 	private static final String _FINDER_COLUMN_U_T_DT_D_DELIVERED_2 =
 		"userNotificationEvent.delivered = ?";
 
-	private FinderPath _finderPathWithPaginationFindByU_DT_D_A;
-	private FinderPath _finderPathWithoutPaginationFindByU_DT_D_A;
-	private FinderPath _finderPathCountByU_DT_D_A;
+	private FinderPath _finderPathWithPaginationFindByU_DT_D_AR;
+	private FinderPath _finderPathWithoutPaginationFindByU_DT_D_AR;
+	private FinderPath _finderPathCountByU_DT_D_AR;
 
 	/**
 	 * Returns all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63;.
@@ -7148,11 +7750,11 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the matching user notification events
 	 */
 	@Override
-	public List<UserNotificationEvent> findByU_DT_D_A(
+	public List<UserNotificationEvent> findByU_DT_D_AR(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired) {
 
-		return findByU_DT_D_A(
+		return findByU_DT_D_AR(
 			userId, deliveryType, delivered, actionRequired, QueryUtil.ALL_POS,
 			QueryUtil.ALL_POS, null);
 	}
@@ -7173,11 +7775,11 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the range of matching user notification events
 	 */
 	@Override
-	public List<UserNotificationEvent> findByU_DT_D_A(
+	public List<UserNotificationEvent> findByU_DT_D_AR(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired, int start, int end) {
 
-		return findByU_DT_D_A(
+		return findByU_DT_D_AR(
 			userId, deliveryType, delivered, actionRequired, start, end, null);
 	}
 
@@ -7198,12 +7800,12 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the ordered range of matching user notification events
 	 */
 	@Override
-	public List<UserNotificationEvent> findByU_DT_D_A(
+	public List<UserNotificationEvent> findByU_DT_D_AR(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired, int start, int end,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		return findByU_DT_D_A(
+		return findByU_DT_D_AR(
 			userId, deliveryType, delivered, actionRequired, start, end,
 			orderByComparator, true);
 	}
@@ -7226,7 +7828,7 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the ordered range of matching user notification events
 	 */
 	@Override
-	public List<UserNotificationEvent> findByU_DT_D_A(
+	public List<UserNotificationEvent> findByU_DT_D_AR(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired, int start, int end,
 		OrderByComparator<UserNotificationEvent> orderByComparator,
@@ -7242,14 +7844,14 @@ public class UserNotificationEventPersistenceImpl
 			pagination = false;
 
 			if (useFinderCache) {
-				finderPath = _finderPathWithoutPaginationFindByU_DT_D_A;
+				finderPath = _finderPathWithoutPaginationFindByU_DT_D_AR;
 				finderArgs = new Object[] {
 					userId, deliveryType, delivered, actionRequired
 				};
 			}
 		}
 		else if (useFinderCache) {
-			finderPath = _finderPathWithPaginationFindByU_DT_D_A;
+			finderPath = _finderPathWithPaginationFindByU_DT_D_AR;
 			finderArgs = new Object[] {
 				userId, deliveryType, delivered, actionRequired, start, end,
 				orderByComparator
@@ -7292,13 +7894,13 @@ public class UserNotificationEventPersistenceImpl
 
 			query.append(_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE);
 
-			query.append(_FINDER_COLUMN_U_DT_D_A_USERID_2);
+			query.append(_FINDER_COLUMN_U_DT_D_AR_USERID_2);
 
-			query.append(_FINDER_COLUMN_U_DT_D_A_DELIVERYTYPE_2);
+			query.append(_FINDER_COLUMN_U_DT_D_AR_DELIVERYTYPE_2);
 
-			query.append(_FINDER_COLUMN_U_DT_D_A_DELIVERED_2);
+			query.append(_FINDER_COLUMN_U_DT_D_AR_DELIVERED_2);
 
-			query.append(_FINDER_COLUMN_U_DT_D_A_ACTIONREQUIRED_2);
+			query.append(_FINDER_COLUMN_U_DT_D_AR_ACTIONREQUIRED_2);
 
 			if (orderByComparator != null) {
 				appendOrderByComparator(
@@ -7373,13 +7975,13 @@ public class UserNotificationEventPersistenceImpl
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
 	@Override
-	public UserNotificationEvent findByU_DT_D_A_First(
+	public UserNotificationEvent findByU_DT_D_AR_First(
 			long userId, int deliveryType, boolean delivered,
 			boolean actionRequired,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws NoSuchUserNotificationEventException {
 
-		UserNotificationEvent userNotificationEvent = fetchByU_DT_D_A_First(
+		UserNotificationEvent userNotificationEvent = fetchByU_DT_D_AR_First(
 			userId, deliveryType, delivered, actionRequired, orderByComparator);
 
 		if (userNotificationEvent != null) {
@@ -7418,12 +8020,12 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
 	@Override
-	public UserNotificationEvent fetchByU_DT_D_A_First(
+	public UserNotificationEvent fetchByU_DT_D_AR_First(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		List<UserNotificationEvent> list = findByU_DT_D_A(
+		List<UserNotificationEvent> list = findByU_DT_D_AR(
 			userId, deliveryType, delivered, actionRequired, 0, 1,
 			orderByComparator);
 
@@ -7446,13 +8048,13 @@ public class UserNotificationEventPersistenceImpl
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
 	@Override
-	public UserNotificationEvent findByU_DT_D_A_Last(
+	public UserNotificationEvent findByU_DT_D_AR_Last(
 			long userId, int deliveryType, boolean delivered,
 			boolean actionRequired,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws NoSuchUserNotificationEventException {
 
-		UserNotificationEvent userNotificationEvent = fetchByU_DT_D_A_Last(
+		UserNotificationEvent userNotificationEvent = fetchByU_DT_D_AR_Last(
 			userId, deliveryType, delivered, actionRequired, orderByComparator);
 
 		if (userNotificationEvent != null) {
@@ -7491,19 +8093,19 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
 	@Override
-	public UserNotificationEvent fetchByU_DT_D_A_Last(
+	public UserNotificationEvent fetchByU_DT_D_AR_Last(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		int count = countByU_DT_D_A(
+		int count = countByU_DT_D_AR(
 			userId, deliveryType, delivered, actionRequired);
 
 		if (count == 0) {
 			return null;
 		}
 
-		List<UserNotificationEvent> list = findByU_DT_D_A(
+		List<UserNotificationEvent> list = findByU_DT_D_AR(
 			userId, deliveryType, delivered, actionRequired, count - 1, count,
 			orderByComparator);
 
@@ -7527,7 +8129,7 @@ public class UserNotificationEventPersistenceImpl
 	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
 	 */
 	@Override
-	public UserNotificationEvent[] findByU_DT_D_A_PrevAndNext(
+	public UserNotificationEvent[] findByU_DT_D_AR_PrevAndNext(
 			long userNotificationEventId, long userId, int deliveryType,
 			boolean delivered, boolean actionRequired,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
@@ -7543,13 +8145,13 @@ public class UserNotificationEventPersistenceImpl
 
 			UserNotificationEvent[] array = new UserNotificationEventImpl[3];
 
-			array[0] = getByU_DT_D_A_PrevAndNext(
+			array[0] = getByU_DT_D_AR_PrevAndNext(
 				session, userNotificationEvent, userId, deliveryType, delivered,
 				actionRequired, orderByComparator, true);
 
 			array[1] = userNotificationEvent;
 
-			array[2] = getByU_DT_D_A_PrevAndNext(
+			array[2] = getByU_DT_D_AR_PrevAndNext(
 				session, userNotificationEvent, userId, deliveryType, delivered,
 				actionRequired, orderByComparator, false);
 
@@ -7563,7 +8165,7 @@ public class UserNotificationEventPersistenceImpl
 		}
 	}
 
-	protected UserNotificationEvent getByU_DT_D_A_PrevAndNext(
+	protected UserNotificationEvent getByU_DT_D_AR_PrevAndNext(
 		Session session, UserNotificationEvent userNotificationEvent,
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired,
@@ -7583,13 +8185,13 @@ public class UserNotificationEventPersistenceImpl
 
 		query.append(_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE);
 
-		query.append(_FINDER_COLUMN_U_DT_D_A_USERID_2);
+		query.append(_FINDER_COLUMN_U_DT_D_AR_USERID_2);
 
-		query.append(_FINDER_COLUMN_U_DT_D_A_DELIVERYTYPE_2);
+		query.append(_FINDER_COLUMN_U_DT_D_AR_DELIVERYTYPE_2);
 
-		query.append(_FINDER_COLUMN_U_DT_D_A_DELIVERED_2);
+		query.append(_FINDER_COLUMN_U_DT_D_AR_DELIVERED_2);
 
-		query.append(_FINDER_COLUMN_U_DT_D_A_ACTIONREQUIRED_2);
+		query.append(_FINDER_COLUMN_U_DT_D_AR_ACTIONREQUIRED_2);
 
 		if (orderByComparator != null) {
 			String[] orderByConditionFields =
@@ -7696,12 +8298,12 @@ public class UserNotificationEventPersistenceImpl
 	 * @param actionRequired the action required
 	 */
 	@Override
-	public void removeByU_DT_D_A(
+	public void removeByU_DT_D_AR(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired) {
 
 		for (UserNotificationEvent userNotificationEvent :
-				findByU_DT_D_A(
+				findByU_DT_D_AR(
 					userId, deliveryType, delivered, actionRequired,
 					QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)) {
 
@@ -7719,11 +8321,11 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the number of matching user notification events
 	 */
 	@Override
-	public int countByU_DT_D_A(
+	public int countByU_DT_D_AR(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired) {
 
-		FinderPath finderPath = _finderPathCountByU_DT_D_A;
+		FinderPath finderPath = _finderPathCountByU_DT_D_AR;
 
 		Object[] finderArgs = new Object[] {
 			userId, deliveryType, delivered, actionRequired
@@ -7737,13 +8339,13 @@ public class UserNotificationEventPersistenceImpl
 
 			query.append(_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE);
 
-			query.append(_FINDER_COLUMN_U_DT_D_A_USERID_2);
+			query.append(_FINDER_COLUMN_U_DT_D_AR_USERID_2);
 
-			query.append(_FINDER_COLUMN_U_DT_D_A_DELIVERYTYPE_2);
+			query.append(_FINDER_COLUMN_U_DT_D_AR_DELIVERYTYPE_2);
 
-			query.append(_FINDER_COLUMN_U_DT_D_A_DELIVERED_2);
+			query.append(_FINDER_COLUMN_U_DT_D_AR_DELIVERED_2);
 
-			query.append(_FINDER_COLUMN_U_DT_D_A_ACTIONREQUIRED_2);
+			query.append(_FINDER_COLUMN_U_DT_D_AR_ACTIONREQUIRED_2);
 
 			String sql = query.toString();
 
@@ -7781,6 +8383,654 @@ public class UserNotificationEventPersistenceImpl
 		return count.intValue();
 	}
 
+	private static final String _FINDER_COLUMN_U_DT_D_AR_USERID_2 =
+		"userNotificationEvent.userId = ? AND ";
+
+	private static final String _FINDER_COLUMN_U_DT_D_AR_DELIVERYTYPE_2 =
+		"userNotificationEvent.deliveryType = ? AND ";
+
+	private static final String _FINDER_COLUMN_U_DT_D_AR_DELIVERED_2 =
+		"userNotificationEvent.delivered = ? AND ";
+
+	private static final String _FINDER_COLUMN_U_DT_D_AR_ACTIONREQUIRED_2 =
+		"userNotificationEvent.actionRequired = ?";
+
+	private FinderPath _finderPathWithPaginationFindByU_DT_D_A;
+	private FinderPath _finderPathWithoutPaginationFindByU_DT_D_A;
+	private FinderPath _finderPathCountByU_DT_D_A;
+
+	/**
+	 * Returns all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @return the matching user notification events
+	 */
+	@Override
+	public List<UserNotificationEvent> findByU_DT_D_A(
+		long userId, int deliveryType, boolean delivered, boolean archived) {
+
+		return findByU_DT_D_A(
+			userId, deliveryType, delivered, archived, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @return the range of matching user notification events
+	 */
+	@Override
+	public List<UserNotificationEvent> findByU_DT_D_A(
+		long userId, int deliveryType, boolean delivered, boolean archived,
+		int start, int end) {
+
+		return findByU_DT_D_A(
+			userId, deliveryType, delivered, archived, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching user notification events
+	 */
+	@Override
+	public List<UserNotificationEvent> findByU_DT_D_A(
+		long userId, int deliveryType, boolean delivered, boolean archived,
+		int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		return findByU_DT_D_A(
+			userId, deliveryType, delivered, archived, start, end,
+			orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching user notification events
+	 */
+	@Override
+	public List<UserNotificationEvent> findByU_DT_D_A(
+		long userId, int deliveryType, boolean delivered, boolean archived,
+		int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator,
+		boolean useFinderCache) {
+
+		boolean pagination = true;
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+			(orderByComparator == null)) {
+
+			pagination = false;
+
+			if (useFinderCache) {
+				finderPath = _finderPathWithoutPaginationFindByU_DT_D_A;
+				finderArgs = new Object[] {
+					userId, deliveryType, delivered, archived
+				};
+			}
+		}
+		else if (useFinderCache) {
+			finderPath = _finderPathWithPaginationFindByU_DT_D_A;
+			finderArgs = new Object[] {
+				userId, deliveryType, delivered, archived, start, end,
+				orderByComparator
+			};
+		}
+
+		List<UserNotificationEvent> list = null;
+
+		if (useFinderCache) {
+			list = (List<UserNotificationEvent>)FinderCacheUtil.getResult(
+				finderPath, finderArgs, this);
+
+			if ((list != null) && !list.isEmpty()) {
+				for (UserNotificationEvent userNotificationEvent : list) {
+					if ((userId != userNotificationEvent.getUserId()) ||
+						(deliveryType !=
+							userNotificationEvent.getDeliveryType()) ||
+						(delivered != userNotificationEvent.isDelivered()) ||
+						(archived != userNotificationEvent.isArchived())) {
+
+						list = null;
+
+						break;
+					}
+				}
+			}
+		}
+
+		if (list == null) {
+			StringBundler query = null;
+
+			if (orderByComparator != null) {
+				query = new StringBundler(
+					6 + (orderByComparator.getOrderByFields().length * 2));
+			}
+			else {
+				query = new StringBundler(6);
+			}
+
+			query.append(_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE);
+
+			query.append(_FINDER_COLUMN_U_DT_D_A_USERID_2);
+
+			query.append(_FINDER_COLUMN_U_DT_D_A_DELIVERYTYPE_2);
+
+			query.append(_FINDER_COLUMN_U_DT_D_A_DELIVERED_2);
+
+			query.append(_FINDER_COLUMN_U_DT_D_A_ARCHIVED_2);
+
+			if (orderByComparator != null) {
+				appendOrderByComparator(
+					query, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+			}
+			else if (pagination) {
+				query.append(UserNotificationEventModelImpl.ORDER_BY_JPQL);
+			}
+
+			String sql = query.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query q = session.createQuery(sql);
+
+				QueryPos qPos = QueryPos.getInstance(q);
+
+				qPos.add(userId);
+
+				qPos.add(deliveryType);
+
+				qPos.add(delivered);
+
+				qPos.add(archived);
+
+				if (!pagination) {
+					list = (List<UserNotificationEvent>)QueryUtil.list(
+						q, getDialect(), start, end, false);
+
+					Collections.sort(list);
+
+					list = Collections.unmodifiableList(list);
+				}
+				else {
+					list = (List<UserNotificationEvent>)QueryUtil.list(
+						q, getDialect(), start, end);
+				}
+
+				cacheResult(list);
+
+				if (useFinderCache) {
+					FinderCacheUtil.putResult(finderPath, finderArgs, list);
+				}
+			}
+			catch (Exception e) {
+				if (useFinderCache) {
+					FinderCacheUtil.removeResult(finderPath, finderArgs);
+				}
+
+				throw processException(e);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return list;
+	}
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	@Override
+	public UserNotificationEvent findByU_DT_D_A_First(
+			long userId, int deliveryType, boolean delivered, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException {
+
+		UserNotificationEvent userNotificationEvent = fetchByU_DT_D_A_First(
+			userId, deliveryType, delivered, archived, orderByComparator);
+
+		if (userNotificationEvent != null) {
+			return userNotificationEvent;
+		}
+
+		StringBundler msg = new StringBundler(10);
+
+		msg.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		msg.append("userId=");
+		msg.append(userId);
+
+		msg.append(", deliveryType=");
+		msg.append(deliveryType);
+
+		msg.append(", delivered=");
+		msg.append(delivered);
+
+		msg.append(", archived=");
+		msg.append(archived);
+
+		msg.append("}");
+
+		throw new NoSuchUserNotificationEventException(msg.toString());
+	}
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	@Override
+	public UserNotificationEvent fetchByU_DT_D_A_First(
+		long userId, int deliveryType, boolean delivered, boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		List<UserNotificationEvent> list = findByU_DT_D_A(
+			userId, deliveryType, delivered, archived, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	@Override
+	public UserNotificationEvent findByU_DT_D_A_Last(
+			long userId, int deliveryType, boolean delivered, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException {
+
+		UserNotificationEvent userNotificationEvent = fetchByU_DT_D_A_Last(
+			userId, deliveryType, delivered, archived, orderByComparator);
+
+		if (userNotificationEvent != null) {
+			return userNotificationEvent;
+		}
+
+		StringBundler msg = new StringBundler(10);
+
+		msg.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		msg.append("userId=");
+		msg.append(userId);
+
+		msg.append(", deliveryType=");
+		msg.append(deliveryType);
+
+		msg.append(", delivered=");
+		msg.append(delivered);
+
+		msg.append(", archived=");
+		msg.append(archived);
+
+		msg.append("}");
+
+		throw new NoSuchUserNotificationEventException(msg.toString());
+	}
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	@Override
+	public UserNotificationEvent fetchByU_DT_D_A_Last(
+		long userId, int deliveryType, boolean delivered, boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		int count = countByU_DT_D_A(userId, deliveryType, delivered, archived);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<UserNotificationEvent> list = findByU_DT_D_A(
+			userId, deliveryType, delivered, archived, count - 1, count,
+			orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the user notification events before and after the current user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userNotificationEventId the primary key of the current user notification event
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next user notification event
+	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
+	 */
+	@Override
+	public UserNotificationEvent[] findByU_DT_D_A_PrevAndNext(
+			long userNotificationEventId, long userId, int deliveryType,
+			boolean delivered, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException {
+
+		UserNotificationEvent userNotificationEvent = findByPrimaryKey(
+			userNotificationEventId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			UserNotificationEvent[] array = new UserNotificationEventImpl[3];
+
+			array[0] = getByU_DT_D_A_PrevAndNext(
+				session, userNotificationEvent, userId, deliveryType, delivered,
+				archived, orderByComparator, true);
+
+			array[1] = userNotificationEvent;
+
+			array[2] = getByU_DT_D_A_PrevAndNext(
+				session, userNotificationEvent, userId, deliveryType, delivered,
+				archived, orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception e) {
+			throw processException(e);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected UserNotificationEvent getByU_DT_D_A_PrevAndNext(
+		Session session, UserNotificationEvent userNotificationEvent,
+		long userId, int deliveryType, boolean delivered, boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator,
+		boolean previous) {
+
+		StringBundler query = null;
+
+		if (orderByComparator != null) {
+			query = new StringBundler(
+				7 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			query = new StringBundler(6);
+		}
+
+		query.append(_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE);
+
+		query.append(_FINDER_COLUMN_U_DT_D_A_USERID_2);
+
+		query.append(_FINDER_COLUMN_U_DT_D_A_DELIVERYTYPE_2);
+
+		query.append(_FINDER_COLUMN_U_DT_D_A_DELIVERED_2);
+
+		query.append(_FINDER_COLUMN_U_DT_D_A_ARCHIVED_2);
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				query.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				query.append(_ORDER_BY_ENTITY_ALIAS);
+				query.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						query.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(WHERE_GREATER_THAN);
+					}
+					else {
+						query.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			query.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				query.append(_ORDER_BY_ENTITY_ALIAS);
+				query.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						query.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(ORDER_BY_ASC);
+					}
+					else {
+						query.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			query.append(UserNotificationEventModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = query.toString();
+
+		Query q = session.createQuery(sql);
+
+		q.setFirstResult(0);
+		q.setMaxResults(2);
+
+		QueryPos qPos = QueryPos.getInstance(q);
+
+		qPos.add(userId);
+
+		qPos.add(deliveryType);
+
+		qPos.add(delivered);
+
+		qPos.add(archived);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						userNotificationEvent)) {
+
+				qPos.add(orderByConditionValue);
+			}
+		}
+
+		List<UserNotificationEvent> list = q.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63; from the database.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 */
+	@Override
+	public void removeByU_DT_D_A(
+		long userId, int deliveryType, boolean delivered, boolean archived) {
+
+		for (UserNotificationEvent userNotificationEvent :
+				findByU_DT_D_A(
+					userId, deliveryType, delivered, archived,
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)) {
+
+			remove(userNotificationEvent);
+		}
+	}
+
+	/**
+	 * Returns the number of user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @return the number of matching user notification events
+	 */
+	@Override
+	public int countByU_DT_D_A(
+		long userId, int deliveryType, boolean delivered, boolean archived) {
+
+		FinderPath finderPath = _finderPathCountByU_DT_D_A;
+
+		Object[] finderArgs = new Object[] {
+			userId, deliveryType, delivered, archived
+		};
+
+		Long count = (Long)FinderCacheUtil.getResult(
+			finderPath, finderArgs, this);
+
+		if (count == null) {
+			StringBundler query = new StringBundler(5);
+
+			query.append(_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE);
+
+			query.append(_FINDER_COLUMN_U_DT_D_A_USERID_2);
+
+			query.append(_FINDER_COLUMN_U_DT_D_A_DELIVERYTYPE_2);
+
+			query.append(_FINDER_COLUMN_U_DT_D_A_DELIVERED_2);
+
+			query.append(_FINDER_COLUMN_U_DT_D_A_ARCHIVED_2);
+
+			String sql = query.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query q = session.createQuery(sql);
+
+				QueryPos qPos = QueryPos.getInstance(q);
+
+				qPos.add(userId);
+
+				qPos.add(deliveryType);
+
+				qPos.add(delivered);
+
+				qPos.add(archived);
+
+				count = (Long)q.uniqueResult();
+
+				FinderCacheUtil.putResult(finderPath, finderArgs, count);
+			}
+			catch (Exception e) {
+				FinderCacheUtil.removeResult(finderPath, finderArgs);
+
+				throw processException(e);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
 	private static final String _FINDER_COLUMN_U_DT_D_A_USERID_2 =
 		"userNotificationEvent.userId = ? AND ";
 
@@ -7790,12 +9040,12 @@ public class UserNotificationEventPersistenceImpl
 	private static final String _FINDER_COLUMN_U_DT_D_A_DELIVERED_2 =
 		"userNotificationEvent.delivered = ? AND ";
 
-	private static final String _FINDER_COLUMN_U_DT_D_A_ACTIONREQUIRED_2 =
-		"userNotificationEvent.actionRequired = ?";
+	private static final String _FINDER_COLUMN_U_DT_D_A_ARCHIVED_2 =
+		"userNotificationEvent.archived = ?";
 
-	private FinderPath _finderPathWithPaginationFindByU_DT_A_A;
-	private FinderPath _finderPathWithoutPaginationFindByU_DT_A_A;
-	private FinderPath _finderPathCountByU_DT_A_A;
+	private FinderPath _finderPathWithPaginationFindByU_DT_AR_A;
+	private FinderPath _finderPathWithoutPaginationFindByU_DT_AR_A;
+	private FinderPath _finderPathCountByU_DT_AR_A;
 
 	/**
 	 * Returns all the user notification events where userId = &#63; and deliveryType = &#63; and actionRequired = &#63; and archived = &#63;.
@@ -7807,11 +9057,11 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the matching user notification events
 	 */
 	@Override
-	public List<UserNotificationEvent> findByU_DT_A_A(
+	public List<UserNotificationEvent> findByU_DT_AR_A(
 		long userId, int deliveryType, boolean actionRequired,
 		boolean archived) {
 
-		return findByU_DT_A_A(
+		return findByU_DT_AR_A(
 			userId, deliveryType, actionRequired, archived, QueryUtil.ALL_POS,
 			QueryUtil.ALL_POS, null);
 	}
@@ -7832,11 +9082,11 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the range of matching user notification events
 	 */
 	@Override
-	public List<UserNotificationEvent> findByU_DT_A_A(
+	public List<UserNotificationEvent> findByU_DT_AR_A(
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		int start, int end) {
 
-		return findByU_DT_A_A(
+		return findByU_DT_AR_A(
 			userId, deliveryType, actionRequired, archived, start, end, null);
 	}
 
@@ -7857,12 +9107,12 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the ordered range of matching user notification events
 	 */
 	@Override
-	public List<UserNotificationEvent> findByU_DT_A_A(
+	public List<UserNotificationEvent> findByU_DT_AR_A(
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		int start, int end,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		return findByU_DT_A_A(
+		return findByU_DT_AR_A(
 			userId, deliveryType, actionRequired, archived, start, end,
 			orderByComparator, true);
 	}
@@ -7885,7 +9135,7 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the ordered range of matching user notification events
 	 */
 	@Override
-	public List<UserNotificationEvent> findByU_DT_A_A(
+	public List<UserNotificationEvent> findByU_DT_AR_A(
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		int start, int end,
 		OrderByComparator<UserNotificationEvent> orderByComparator,
@@ -7901,14 +9151,14 @@ public class UserNotificationEventPersistenceImpl
 			pagination = false;
 
 			if (useFinderCache) {
-				finderPath = _finderPathWithoutPaginationFindByU_DT_A_A;
+				finderPath = _finderPathWithoutPaginationFindByU_DT_AR_A;
 				finderArgs = new Object[] {
 					userId, deliveryType, actionRequired, archived
 				};
 			}
 		}
 		else if (useFinderCache) {
-			finderPath = _finderPathWithPaginationFindByU_DT_A_A;
+			finderPath = _finderPathWithPaginationFindByU_DT_AR_A;
 			finderArgs = new Object[] {
 				userId, deliveryType, actionRequired, archived, start, end,
 				orderByComparator
@@ -7951,13 +9201,13 @@ public class UserNotificationEventPersistenceImpl
 
 			query.append(_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE);
 
-			query.append(_FINDER_COLUMN_U_DT_A_A_USERID_2);
+			query.append(_FINDER_COLUMN_U_DT_AR_A_USERID_2);
 
-			query.append(_FINDER_COLUMN_U_DT_A_A_DELIVERYTYPE_2);
+			query.append(_FINDER_COLUMN_U_DT_AR_A_DELIVERYTYPE_2);
 
-			query.append(_FINDER_COLUMN_U_DT_A_A_ACTIONREQUIRED_2);
+			query.append(_FINDER_COLUMN_U_DT_AR_A_ACTIONREQUIRED_2);
 
-			query.append(_FINDER_COLUMN_U_DT_A_A_ARCHIVED_2);
+			query.append(_FINDER_COLUMN_U_DT_AR_A_ARCHIVED_2);
 
 			if (orderByComparator != null) {
 				appendOrderByComparator(
@@ -8032,13 +9282,13 @@ public class UserNotificationEventPersistenceImpl
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
 	@Override
-	public UserNotificationEvent findByU_DT_A_A_First(
+	public UserNotificationEvent findByU_DT_AR_A_First(
 			long userId, int deliveryType, boolean actionRequired,
 			boolean archived,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws NoSuchUserNotificationEventException {
 
-		UserNotificationEvent userNotificationEvent = fetchByU_DT_A_A_First(
+		UserNotificationEvent userNotificationEvent = fetchByU_DT_AR_A_First(
 			userId, deliveryType, actionRequired, archived, orderByComparator);
 
 		if (userNotificationEvent != null) {
@@ -8077,11 +9327,11 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
 	@Override
-	public UserNotificationEvent fetchByU_DT_A_A_First(
+	public UserNotificationEvent fetchByU_DT_AR_A_First(
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		List<UserNotificationEvent> list = findByU_DT_A_A(
+		List<UserNotificationEvent> list = findByU_DT_AR_A(
 			userId, deliveryType, actionRequired, archived, 0, 1,
 			orderByComparator);
 
@@ -8104,13 +9354,13 @@ public class UserNotificationEventPersistenceImpl
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
 	@Override
-	public UserNotificationEvent findByU_DT_A_A_Last(
+	public UserNotificationEvent findByU_DT_AR_A_Last(
 			long userId, int deliveryType, boolean actionRequired,
 			boolean archived,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws NoSuchUserNotificationEventException {
 
-		UserNotificationEvent userNotificationEvent = fetchByU_DT_A_A_Last(
+		UserNotificationEvent userNotificationEvent = fetchByU_DT_AR_A_Last(
 			userId, deliveryType, actionRequired, archived, orderByComparator);
 
 		if (userNotificationEvent != null) {
@@ -8149,18 +9399,18 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
 	@Override
-	public UserNotificationEvent fetchByU_DT_A_A_Last(
+	public UserNotificationEvent fetchByU_DT_AR_A_Last(
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		int count = countByU_DT_A_A(
+		int count = countByU_DT_AR_A(
 			userId, deliveryType, actionRequired, archived);
 
 		if (count == 0) {
 			return null;
 		}
 
-		List<UserNotificationEvent> list = findByU_DT_A_A(
+		List<UserNotificationEvent> list = findByU_DT_AR_A(
 			userId, deliveryType, actionRequired, archived, count - 1, count,
 			orderByComparator);
 
@@ -8184,7 +9434,7 @@ public class UserNotificationEventPersistenceImpl
 	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
 	 */
 	@Override
-	public UserNotificationEvent[] findByU_DT_A_A_PrevAndNext(
+	public UserNotificationEvent[] findByU_DT_AR_A_PrevAndNext(
 			long userNotificationEventId, long userId, int deliveryType,
 			boolean actionRequired, boolean archived,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
@@ -8200,13 +9450,13 @@ public class UserNotificationEventPersistenceImpl
 
 			UserNotificationEvent[] array = new UserNotificationEventImpl[3];
 
-			array[0] = getByU_DT_A_A_PrevAndNext(
+			array[0] = getByU_DT_AR_A_PrevAndNext(
 				session, userNotificationEvent, userId, deliveryType,
 				actionRequired, archived, orderByComparator, true);
 
 			array[1] = userNotificationEvent;
 
-			array[2] = getByU_DT_A_A_PrevAndNext(
+			array[2] = getByU_DT_AR_A_PrevAndNext(
 				session, userNotificationEvent, userId, deliveryType,
 				actionRequired, archived, orderByComparator, false);
 
@@ -8220,7 +9470,7 @@ public class UserNotificationEventPersistenceImpl
 		}
 	}
 
-	protected UserNotificationEvent getByU_DT_A_A_PrevAndNext(
+	protected UserNotificationEvent getByU_DT_AR_A_PrevAndNext(
 		Session session, UserNotificationEvent userNotificationEvent,
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		OrderByComparator<UserNotificationEvent> orderByComparator,
@@ -8239,13 +9489,13 @@ public class UserNotificationEventPersistenceImpl
 
 		query.append(_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE);
 
-		query.append(_FINDER_COLUMN_U_DT_A_A_USERID_2);
+		query.append(_FINDER_COLUMN_U_DT_AR_A_USERID_2);
 
-		query.append(_FINDER_COLUMN_U_DT_A_A_DELIVERYTYPE_2);
+		query.append(_FINDER_COLUMN_U_DT_AR_A_DELIVERYTYPE_2);
 
-		query.append(_FINDER_COLUMN_U_DT_A_A_ACTIONREQUIRED_2);
+		query.append(_FINDER_COLUMN_U_DT_AR_A_ACTIONREQUIRED_2);
 
-		query.append(_FINDER_COLUMN_U_DT_A_A_ARCHIVED_2);
+		query.append(_FINDER_COLUMN_U_DT_AR_A_ARCHIVED_2);
 
 		if (orderByComparator != null) {
 			String[] orderByConditionFields =
@@ -8352,12 +9602,12 @@ public class UserNotificationEventPersistenceImpl
 	 * @param archived the archived
 	 */
 	@Override
-	public void removeByU_DT_A_A(
+	public void removeByU_DT_AR_A(
 		long userId, int deliveryType, boolean actionRequired,
 		boolean archived) {
 
 		for (UserNotificationEvent userNotificationEvent :
-				findByU_DT_A_A(
+				findByU_DT_AR_A(
 					userId, deliveryType, actionRequired, archived,
 					QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)) {
 
@@ -8375,11 +9625,11 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the number of matching user notification events
 	 */
 	@Override
-	public int countByU_DT_A_A(
+	public int countByU_DT_AR_A(
 		long userId, int deliveryType, boolean actionRequired,
 		boolean archived) {
 
-		FinderPath finderPath = _finderPathCountByU_DT_A_A;
+		FinderPath finderPath = _finderPathCountByU_DT_AR_A;
 
 		Object[] finderArgs = new Object[] {
 			userId, deliveryType, actionRequired, archived
@@ -8393,13 +9643,13 @@ public class UserNotificationEventPersistenceImpl
 
 			query.append(_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE);
 
-			query.append(_FINDER_COLUMN_U_DT_A_A_USERID_2);
+			query.append(_FINDER_COLUMN_U_DT_AR_A_USERID_2);
 
-			query.append(_FINDER_COLUMN_U_DT_A_A_DELIVERYTYPE_2);
+			query.append(_FINDER_COLUMN_U_DT_AR_A_DELIVERYTYPE_2);
 
-			query.append(_FINDER_COLUMN_U_DT_A_A_ACTIONREQUIRED_2);
+			query.append(_FINDER_COLUMN_U_DT_AR_A_ACTIONREQUIRED_2);
 
-			query.append(_FINDER_COLUMN_U_DT_A_A_ARCHIVED_2);
+			query.append(_FINDER_COLUMN_U_DT_AR_A_ARCHIVED_2);
 
 			String sql = query.toString();
 
@@ -8437,16 +9687,1369 @@ public class UserNotificationEventPersistenceImpl
 		return count.intValue();
 	}
 
-	private static final String _FINDER_COLUMN_U_DT_A_A_USERID_2 =
+	private static final String _FINDER_COLUMN_U_DT_AR_A_USERID_2 =
 		"userNotificationEvent.userId = ? AND ";
 
-	private static final String _FINDER_COLUMN_U_DT_A_A_DELIVERYTYPE_2 =
+	private static final String _FINDER_COLUMN_U_DT_AR_A_DELIVERYTYPE_2 =
 		"userNotificationEvent.deliveryType = ? AND ";
 
-	private static final String _FINDER_COLUMN_U_DT_A_A_ACTIONREQUIRED_2 =
+	private static final String _FINDER_COLUMN_U_DT_AR_A_ACTIONREQUIRED_2 =
 		"userNotificationEvent.actionRequired = ? AND ";
 
-	private static final String _FINDER_COLUMN_U_DT_A_A_ARCHIVED_2 =
+	private static final String _FINDER_COLUMN_U_DT_AR_A_ARCHIVED_2 =
+		"userNotificationEvent.archived = ?";
+
+	private FinderPath _finderPathWithPaginationFindByU_D_AR_A;
+	private FinderPath _finderPathWithoutPaginationFindByU_D_AR_A;
+	private FinderPath _finderPathCountByU_D_AR_A;
+
+	/**
+	 * Returns all the user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @return the matching user notification events
+	 */
+	@Override
+	public List<UserNotificationEvent> findByU_D_AR_A(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived) {
+
+		return findByU_D_AR_A(
+			userId, delivered, actionRequired, archived, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @return the range of matching user notification events
+	 */
+	@Override
+	public List<UserNotificationEvent> findByU_D_AR_A(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived, int start, int end) {
+
+		return findByU_D_AR_A(
+			userId, delivered, actionRequired, archived, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching user notification events
+	 */
+	@Override
+	public List<UserNotificationEvent> findByU_D_AR_A(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived, int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		return findByU_D_AR_A(
+			userId, delivered, actionRequired, archived, start, end,
+			orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching user notification events
+	 */
+	@Override
+	public List<UserNotificationEvent> findByU_D_AR_A(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived, int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator,
+		boolean useFinderCache) {
+
+		boolean pagination = true;
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+			(orderByComparator == null)) {
+
+			pagination = false;
+
+			if (useFinderCache) {
+				finderPath = _finderPathWithoutPaginationFindByU_D_AR_A;
+				finderArgs = new Object[] {
+					userId, delivered, actionRequired, archived
+				};
+			}
+		}
+		else if (useFinderCache) {
+			finderPath = _finderPathWithPaginationFindByU_D_AR_A;
+			finderArgs = new Object[] {
+				userId, delivered, actionRequired, archived, start, end,
+				orderByComparator
+			};
+		}
+
+		List<UserNotificationEvent> list = null;
+
+		if (useFinderCache) {
+			list = (List<UserNotificationEvent>)FinderCacheUtil.getResult(
+				finderPath, finderArgs, this);
+
+			if ((list != null) && !list.isEmpty()) {
+				for (UserNotificationEvent userNotificationEvent : list) {
+					if ((userId != userNotificationEvent.getUserId()) ||
+						(delivered != userNotificationEvent.isDelivered()) ||
+						(actionRequired !=
+							userNotificationEvent.isActionRequired()) ||
+						(archived != userNotificationEvent.isArchived())) {
+
+						list = null;
+
+						break;
+					}
+				}
+			}
+		}
+
+		if (list == null) {
+			StringBundler query = null;
+
+			if (orderByComparator != null) {
+				query = new StringBundler(
+					6 + (orderByComparator.getOrderByFields().length * 2));
+			}
+			else {
+				query = new StringBundler(6);
+			}
+
+			query.append(_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE);
+
+			query.append(_FINDER_COLUMN_U_D_AR_A_USERID_2);
+
+			query.append(_FINDER_COLUMN_U_D_AR_A_DELIVERED_2);
+
+			query.append(_FINDER_COLUMN_U_D_AR_A_ACTIONREQUIRED_2);
+
+			query.append(_FINDER_COLUMN_U_D_AR_A_ARCHIVED_2);
+
+			if (orderByComparator != null) {
+				appendOrderByComparator(
+					query, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+			}
+			else if (pagination) {
+				query.append(UserNotificationEventModelImpl.ORDER_BY_JPQL);
+			}
+
+			String sql = query.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query q = session.createQuery(sql);
+
+				QueryPos qPos = QueryPos.getInstance(q);
+
+				qPos.add(userId);
+
+				qPos.add(delivered);
+
+				qPos.add(actionRequired);
+
+				qPos.add(archived);
+
+				if (!pagination) {
+					list = (List<UserNotificationEvent>)QueryUtil.list(
+						q, getDialect(), start, end, false);
+
+					Collections.sort(list);
+
+					list = Collections.unmodifiableList(list);
+				}
+				else {
+					list = (List<UserNotificationEvent>)QueryUtil.list(
+						q, getDialect(), start, end);
+				}
+
+				cacheResult(list);
+
+				if (useFinderCache) {
+					FinderCacheUtil.putResult(finderPath, finderArgs, list);
+				}
+			}
+			catch (Exception e) {
+				if (useFinderCache) {
+					FinderCacheUtil.removeResult(finderPath, finderArgs);
+				}
+
+				throw processException(e);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return list;
+	}
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	@Override
+	public UserNotificationEvent findByU_D_AR_A_First(
+			long userId, boolean delivered, boolean actionRequired,
+			boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException {
+
+		UserNotificationEvent userNotificationEvent = fetchByU_D_AR_A_First(
+			userId, delivered, actionRequired, archived, orderByComparator);
+
+		if (userNotificationEvent != null) {
+			return userNotificationEvent;
+		}
+
+		StringBundler msg = new StringBundler(10);
+
+		msg.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		msg.append("userId=");
+		msg.append(userId);
+
+		msg.append(", delivered=");
+		msg.append(delivered);
+
+		msg.append(", actionRequired=");
+		msg.append(actionRequired);
+
+		msg.append(", archived=");
+		msg.append(archived);
+
+		msg.append("}");
+
+		throw new NoSuchUserNotificationEventException(msg.toString());
+	}
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	@Override
+	public UserNotificationEvent fetchByU_D_AR_A_First(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		List<UserNotificationEvent> list = findByU_D_AR_A(
+			userId, delivered, actionRequired, archived, 0, 1,
+			orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	@Override
+	public UserNotificationEvent findByU_D_AR_A_Last(
+			long userId, boolean delivered, boolean actionRequired,
+			boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException {
+
+		UserNotificationEvent userNotificationEvent = fetchByU_D_AR_A_Last(
+			userId, delivered, actionRequired, archived, orderByComparator);
+
+		if (userNotificationEvent != null) {
+			return userNotificationEvent;
+		}
+
+		StringBundler msg = new StringBundler(10);
+
+		msg.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		msg.append("userId=");
+		msg.append(userId);
+
+		msg.append(", delivered=");
+		msg.append(delivered);
+
+		msg.append(", actionRequired=");
+		msg.append(actionRequired);
+
+		msg.append(", archived=");
+		msg.append(archived);
+
+		msg.append("}");
+
+		throw new NoSuchUserNotificationEventException(msg.toString());
+	}
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	@Override
+	public UserNotificationEvent fetchByU_D_AR_A_Last(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		int count = countByU_D_AR_A(
+			userId, delivered, actionRequired, archived);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<UserNotificationEvent> list = findByU_D_AR_A(
+			userId, delivered, actionRequired, archived, count - 1, count,
+			orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the user notification events before and after the current user notification event in the ordered set where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userNotificationEventId the primary key of the current user notification event
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next user notification event
+	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
+	 */
+	@Override
+	public UserNotificationEvent[] findByU_D_AR_A_PrevAndNext(
+			long userNotificationEventId, long userId, boolean delivered,
+			boolean actionRequired, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException {
+
+		UserNotificationEvent userNotificationEvent = findByPrimaryKey(
+			userNotificationEventId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			UserNotificationEvent[] array = new UserNotificationEventImpl[3];
+
+			array[0] = getByU_D_AR_A_PrevAndNext(
+				session, userNotificationEvent, userId, delivered,
+				actionRequired, archived, orderByComparator, true);
+
+			array[1] = userNotificationEvent;
+
+			array[2] = getByU_D_AR_A_PrevAndNext(
+				session, userNotificationEvent, userId, delivered,
+				actionRequired, archived, orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception e) {
+			throw processException(e);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected UserNotificationEvent getByU_D_AR_A_PrevAndNext(
+		Session session, UserNotificationEvent userNotificationEvent,
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator,
+		boolean previous) {
+
+		StringBundler query = null;
+
+		if (orderByComparator != null) {
+			query = new StringBundler(
+				7 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			query = new StringBundler(6);
+		}
+
+		query.append(_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE);
+
+		query.append(_FINDER_COLUMN_U_D_AR_A_USERID_2);
+
+		query.append(_FINDER_COLUMN_U_D_AR_A_DELIVERED_2);
+
+		query.append(_FINDER_COLUMN_U_D_AR_A_ACTIONREQUIRED_2);
+
+		query.append(_FINDER_COLUMN_U_D_AR_A_ARCHIVED_2);
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				query.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				query.append(_ORDER_BY_ENTITY_ALIAS);
+				query.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						query.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(WHERE_GREATER_THAN);
+					}
+					else {
+						query.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			query.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				query.append(_ORDER_BY_ENTITY_ALIAS);
+				query.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						query.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(ORDER_BY_ASC);
+					}
+					else {
+						query.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			query.append(UserNotificationEventModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = query.toString();
+
+		Query q = session.createQuery(sql);
+
+		q.setFirstResult(0);
+		q.setMaxResults(2);
+
+		QueryPos qPos = QueryPos.getInstance(q);
+
+		qPos.add(userId);
+
+		qPos.add(delivered);
+
+		qPos.add(actionRequired);
+
+		qPos.add(archived);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						userNotificationEvent)) {
+
+				qPos.add(orderByConditionValue);
+			}
+		}
+
+		List<UserNotificationEvent> list = q.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63; from the database.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 */
+	@Override
+	public void removeByU_D_AR_A(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived) {
+
+		for (UserNotificationEvent userNotificationEvent :
+				findByU_D_AR_A(
+					userId, delivered, actionRequired, archived,
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)) {
+
+			remove(userNotificationEvent);
+		}
+	}
+
+	/**
+	 * Returns the number of user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @return the number of matching user notification events
+	 */
+	@Override
+	public int countByU_D_AR_A(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived) {
+
+		FinderPath finderPath = _finderPathCountByU_D_AR_A;
+
+		Object[] finderArgs = new Object[] {
+			userId, delivered, actionRequired, archived
+		};
+
+		Long count = (Long)FinderCacheUtil.getResult(
+			finderPath, finderArgs, this);
+
+		if (count == null) {
+			StringBundler query = new StringBundler(5);
+
+			query.append(_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE);
+
+			query.append(_FINDER_COLUMN_U_D_AR_A_USERID_2);
+
+			query.append(_FINDER_COLUMN_U_D_AR_A_DELIVERED_2);
+
+			query.append(_FINDER_COLUMN_U_D_AR_A_ACTIONREQUIRED_2);
+
+			query.append(_FINDER_COLUMN_U_D_AR_A_ARCHIVED_2);
+
+			String sql = query.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query q = session.createQuery(sql);
+
+				QueryPos qPos = QueryPos.getInstance(q);
+
+				qPos.add(userId);
+
+				qPos.add(delivered);
+
+				qPos.add(actionRequired);
+
+				qPos.add(archived);
+
+				count = (Long)q.uniqueResult();
+
+				FinderCacheUtil.putResult(finderPath, finderArgs, count);
+			}
+			catch (Exception e) {
+				FinderCacheUtil.removeResult(finderPath, finderArgs);
+
+				throw processException(e);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	private static final String _FINDER_COLUMN_U_D_AR_A_USERID_2 =
+		"userNotificationEvent.userId = ? AND ";
+
+	private static final String _FINDER_COLUMN_U_D_AR_A_DELIVERED_2 =
+		"userNotificationEvent.delivered = ? AND ";
+
+	private static final String _FINDER_COLUMN_U_D_AR_A_ACTIONREQUIRED_2 =
+		"userNotificationEvent.actionRequired = ? AND ";
+
+	private static final String _FINDER_COLUMN_U_D_AR_A_ARCHIVED_2 =
+		"userNotificationEvent.archived = ?";
+
+	private FinderPath _finderPathWithPaginationFindByU_DT_D_AR_A;
+	private FinderPath _finderPathWithoutPaginationFindByU_DT_D_AR_A;
+	private FinderPath _finderPathCountByU_DT_D_AR_A;
+
+	/**
+	 * Returns all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @return the matching user notification events
+	 */
+	@Override
+	public List<UserNotificationEvent> findByU_DT_D_AR_A(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived) {
+
+		return findByU_DT_D_AR_A(
+			userId, deliveryType, delivered, actionRequired, archived,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @return the range of matching user notification events
+	 */
+	@Override
+	public List<UserNotificationEvent> findByU_DT_D_AR_A(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived, int start, int end) {
+
+		return findByU_DT_D_AR_A(
+			userId, deliveryType, delivered, actionRequired, archived, start,
+			end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching user notification events
+	 */
+	@Override
+	public List<UserNotificationEvent> findByU_DT_D_AR_A(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived, int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		return findByU_DT_D_AR_A(
+			userId, deliveryType, delivered, actionRequired, archived, start,
+			end, orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching user notification events
+	 */
+	@Override
+	public List<UserNotificationEvent> findByU_DT_D_AR_A(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived, int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator,
+		boolean useFinderCache) {
+
+		boolean pagination = true;
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+			(orderByComparator == null)) {
+
+			pagination = false;
+
+			if (useFinderCache) {
+				finderPath = _finderPathWithoutPaginationFindByU_DT_D_AR_A;
+				finderArgs = new Object[] {
+					userId, deliveryType, delivered, actionRequired, archived
+				};
+			}
+		}
+		else if (useFinderCache) {
+			finderPath = _finderPathWithPaginationFindByU_DT_D_AR_A;
+			finderArgs = new Object[] {
+				userId, deliveryType, delivered, actionRequired, archived,
+				start, end, orderByComparator
+			};
+		}
+
+		List<UserNotificationEvent> list = null;
+
+		if (useFinderCache) {
+			list = (List<UserNotificationEvent>)FinderCacheUtil.getResult(
+				finderPath, finderArgs, this);
+
+			if ((list != null) && !list.isEmpty()) {
+				for (UserNotificationEvent userNotificationEvent : list) {
+					if ((userId != userNotificationEvent.getUserId()) ||
+						(deliveryType !=
+							userNotificationEvent.getDeliveryType()) ||
+						(delivered != userNotificationEvent.isDelivered()) ||
+						(actionRequired !=
+							userNotificationEvent.isActionRequired()) ||
+						(archived != userNotificationEvent.isArchived())) {
+
+						list = null;
+
+						break;
+					}
+				}
+			}
+		}
+
+		if (list == null) {
+			StringBundler query = null;
+
+			if (orderByComparator != null) {
+				query = new StringBundler(
+					7 + (orderByComparator.getOrderByFields().length * 2));
+			}
+			else {
+				query = new StringBundler(7);
+			}
+
+			query.append(_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE);
+
+			query.append(_FINDER_COLUMN_U_DT_D_AR_A_USERID_2);
+
+			query.append(_FINDER_COLUMN_U_DT_D_AR_A_DELIVERYTYPE_2);
+
+			query.append(_FINDER_COLUMN_U_DT_D_AR_A_DELIVERED_2);
+
+			query.append(_FINDER_COLUMN_U_DT_D_AR_A_ACTIONREQUIRED_2);
+
+			query.append(_FINDER_COLUMN_U_DT_D_AR_A_ARCHIVED_2);
+
+			if (orderByComparator != null) {
+				appendOrderByComparator(
+					query, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+			}
+			else if (pagination) {
+				query.append(UserNotificationEventModelImpl.ORDER_BY_JPQL);
+			}
+
+			String sql = query.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query q = session.createQuery(sql);
+
+				QueryPos qPos = QueryPos.getInstance(q);
+
+				qPos.add(userId);
+
+				qPos.add(deliveryType);
+
+				qPos.add(delivered);
+
+				qPos.add(actionRequired);
+
+				qPos.add(archived);
+
+				if (!pagination) {
+					list = (List<UserNotificationEvent>)QueryUtil.list(
+						q, getDialect(), start, end, false);
+
+					Collections.sort(list);
+
+					list = Collections.unmodifiableList(list);
+				}
+				else {
+					list = (List<UserNotificationEvent>)QueryUtil.list(
+						q, getDialect(), start, end);
+				}
+
+				cacheResult(list);
+
+				if (useFinderCache) {
+					FinderCacheUtil.putResult(finderPath, finderArgs, list);
+				}
+			}
+			catch (Exception e) {
+				if (useFinderCache) {
+					FinderCacheUtil.removeResult(finderPath, finderArgs);
+				}
+
+				throw processException(e);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return list;
+	}
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	@Override
+	public UserNotificationEvent findByU_DT_D_AR_A_First(
+			long userId, int deliveryType, boolean delivered,
+			boolean actionRequired, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException {
+
+		UserNotificationEvent userNotificationEvent = fetchByU_DT_D_AR_A_First(
+			userId, deliveryType, delivered, actionRequired, archived,
+			orderByComparator);
+
+		if (userNotificationEvent != null) {
+			return userNotificationEvent;
+		}
+
+		StringBundler msg = new StringBundler(12);
+
+		msg.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		msg.append("userId=");
+		msg.append(userId);
+
+		msg.append(", deliveryType=");
+		msg.append(deliveryType);
+
+		msg.append(", delivered=");
+		msg.append(delivered);
+
+		msg.append(", actionRequired=");
+		msg.append(actionRequired);
+
+		msg.append(", archived=");
+		msg.append(archived);
+
+		msg.append("}");
+
+		throw new NoSuchUserNotificationEventException(msg.toString());
+	}
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	@Override
+	public UserNotificationEvent fetchByU_DT_D_AR_A_First(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		List<UserNotificationEvent> list = findByU_DT_D_AR_A(
+			userId, deliveryType, delivered, actionRequired, archived, 0, 1,
+			orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	@Override
+	public UserNotificationEvent findByU_DT_D_AR_A_Last(
+			long userId, int deliveryType, boolean delivered,
+			boolean actionRequired, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException {
+
+		UserNotificationEvent userNotificationEvent = fetchByU_DT_D_AR_A_Last(
+			userId, deliveryType, delivered, actionRequired, archived,
+			orderByComparator);
+
+		if (userNotificationEvent != null) {
+			return userNotificationEvent;
+		}
+
+		StringBundler msg = new StringBundler(12);
+
+		msg.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		msg.append("userId=");
+		msg.append(userId);
+
+		msg.append(", deliveryType=");
+		msg.append(deliveryType);
+
+		msg.append(", delivered=");
+		msg.append(delivered);
+
+		msg.append(", actionRequired=");
+		msg.append(actionRequired);
+
+		msg.append(", archived=");
+		msg.append(archived);
+
+		msg.append("}");
+
+		throw new NoSuchUserNotificationEventException(msg.toString());
+	}
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	@Override
+	public UserNotificationEvent fetchByU_DT_D_AR_A_Last(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		int count = countByU_DT_D_AR_A(
+			userId, deliveryType, delivered, actionRequired, archived);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<UserNotificationEvent> list = findByU_DT_D_AR_A(
+			userId, deliveryType, delivered, actionRequired, archived,
+			count - 1, count, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the user notification events before and after the current user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userNotificationEventId the primary key of the current user notification event
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next user notification event
+	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
+	 */
+	@Override
+	public UserNotificationEvent[] findByU_DT_D_AR_A_PrevAndNext(
+			long userNotificationEventId, long userId, int deliveryType,
+			boolean delivered, boolean actionRequired, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException {
+
+		UserNotificationEvent userNotificationEvent = findByPrimaryKey(
+			userNotificationEventId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			UserNotificationEvent[] array = new UserNotificationEventImpl[3];
+
+			array[0] = getByU_DT_D_AR_A_PrevAndNext(
+				session, userNotificationEvent, userId, deliveryType, delivered,
+				actionRequired, archived, orderByComparator, true);
+
+			array[1] = userNotificationEvent;
+
+			array[2] = getByU_DT_D_AR_A_PrevAndNext(
+				session, userNotificationEvent, userId, deliveryType, delivered,
+				actionRequired, archived, orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception e) {
+			throw processException(e);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected UserNotificationEvent getByU_DT_D_AR_A_PrevAndNext(
+		Session session, UserNotificationEvent userNotificationEvent,
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator,
+		boolean previous) {
+
+		StringBundler query = null;
+
+		if (orderByComparator != null) {
+			query = new StringBundler(
+				8 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			query = new StringBundler(7);
+		}
+
+		query.append(_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE);
+
+		query.append(_FINDER_COLUMN_U_DT_D_AR_A_USERID_2);
+
+		query.append(_FINDER_COLUMN_U_DT_D_AR_A_DELIVERYTYPE_2);
+
+		query.append(_FINDER_COLUMN_U_DT_D_AR_A_DELIVERED_2);
+
+		query.append(_FINDER_COLUMN_U_DT_D_AR_A_ACTIONREQUIRED_2);
+
+		query.append(_FINDER_COLUMN_U_DT_D_AR_A_ARCHIVED_2);
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				query.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				query.append(_ORDER_BY_ENTITY_ALIAS);
+				query.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						query.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(WHERE_GREATER_THAN);
+					}
+					else {
+						query.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			query.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				query.append(_ORDER_BY_ENTITY_ALIAS);
+				query.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						query.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(ORDER_BY_ASC);
+					}
+					else {
+						query.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			query.append(UserNotificationEventModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = query.toString();
+
+		Query q = session.createQuery(sql);
+
+		q.setFirstResult(0);
+		q.setMaxResults(2);
+
+		QueryPos qPos = QueryPos.getInstance(q);
+
+		qPos.add(userId);
+
+		qPos.add(deliveryType);
+
+		qPos.add(delivered);
+
+		qPos.add(actionRequired);
+
+		qPos.add(archived);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						userNotificationEvent)) {
+
+				qPos.add(orderByConditionValue);
+			}
+		}
+
+		List<UserNotificationEvent> list = q.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63; from the database.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 */
+	@Override
+	public void removeByU_DT_D_AR_A(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived) {
+
+		for (UserNotificationEvent userNotificationEvent :
+				findByU_DT_D_AR_A(
+					userId, deliveryType, delivered, actionRequired, archived,
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)) {
+
+			remove(userNotificationEvent);
+		}
+	}
+
+	/**
+	 * Returns the number of user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @return the number of matching user notification events
+	 */
+	@Override
+	public int countByU_DT_D_AR_A(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived) {
+
+		FinderPath finderPath = _finderPathCountByU_DT_D_AR_A;
+
+		Object[] finderArgs = new Object[] {
+			userId, deliveryType, delivered, actionRequired, archived
+		};
+
+		Long count = (Long)FinderCacheUtil.getResult(
+			finderPath, finderArgs, this);
+
+		if (count == null) {
+			StringBundler query = new StringBundler(6);
+
+			query.append(_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE);
+
+			query.append(_FINDER_COLUMN_U_DT_D_AR_A_USERID_2);
+
+			query.append(_FINDER_COLUMN_U_DT_D_AR_A_DELIVERYTYPE_2);
+
+			query.append(_FINDER_COLUMN_U_DT_D_AR_A_DELIVERED_2);
+
+			query.append(_FINDER_COLUMN_U_DT_D_AR_A_ACTIONREQUIRED_2);
+
+			query.append(_FINDER_COLUMN_U_DT_D_AR_A_ARCHIVED_2);
+
+			String sql = query.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query q = session.createQuery(sql);
+
+				QueryPos qPos = QueryPos.getInstance(q);
+
+				qPos.add(userId);
+
+				qPos.add(deliveryType);
+
+				qPos.add(delivered);
+
+				qPos.add(actionRequired);
+
+				qPos.add(archived);
+
+				count = (Long)q.uniqueResult();
+
+				FinderCacheUtil.putResult(finderPath, finderArgs, count);
+			}
+			catch (Exception e) {
+				FinderCacheUtil.removeResult(finderPath, finderArgs);
+
+				throw processException(e);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	private static final String _FINDER_COLUMN_U_DT_D_AR_A_USERID_2 =
+		"userNotificationEvent.userId = ? AND ";
+
+	private static final String _FINDER_COLUMN_U_DT_D_AR_A_DELIVERYTYPE_2 =
+		"userNotificationEvent.deliveryType = ? AND ";
+
+	private static final String _FINDER_COLUMN_U_DT_D_AR_A_DELIVERED_2 =
+		"userNotificationEvent.delivered = ? AND ";
+
+	private static final String _FINDER_COLUMN_U_DT_D_AR_A_ACTIONREQUIRED_2 =
+		"userNotificationEvent.actionRequired = ? AND ";
+
+	private static final String _FINDER_COLUMN_U_DT_D_AR_A_ARCHIVED_2 =
 		"userNotificationEvent.archived = ?";
 
 	public UserNotificationEventPersistenceImpl() {
@@ -8811,6 +11414,16 @@ public class UserNotificationEventPersistenceImpl
 				userNotificationEventModelImpl.isActionRequired()
 			};
 
+			FinderCacheUtil.removeResult(_finderPathCountByU_D_AR, args);
+			FinderCacheUtil.removeResult(
+				_finderPathWithoutPaginationFindByU_D_AR, args);
+
+			args = new Object[] {
+				userNotificationEventModelImpl.getUserId(),
+				userNotificationEventModelImpl.isDelivered(),
+				userNotificationEventModelImpl.isArchived()
+			};
+
 			FinderCacheUtil.removeResult(_finderPathCountByU_D_A, args);
 			FinderCacheUtil.removeResult(
 				_finderPathWithoutPaginationFindByU_D_A, args);
@@ -8821,9 +11434,9 @@ public class UserNotificationEventPersistenceImpl
 				userNotificationEventModelImpl.isArchived()
 			};
 
-			FinderCacheUtil.removeResult(_finderPathCountByU_A_A, args);
+			FinderCacheUtil.removeResult(_finderPathCountByU_AR_A, args);
 			FinderCacheUtil.removeResult(
-				_finderPathWithoutPaginationFindByU_A_A, args);
+				_finderPathWithoutPaginationFindByU_AR_A, args);
 
 			args = new Object[] {
 				userNotificationEventModelImpl.getUserId(),
@@ -8843,6 +11456,17 @@ public class UserNotificationEventPersistenceImpl
 				userNotificationEventModelImpl.isActionRequired()
 			};
 
+			FinderCacheUtil.removeResult(_finderPathCountByU_DT_D_AR, args);
+			FinderCacheUtil.removeResult(
+				_finderPathWithoutPaginationFindByU_DT_D_AR, args);
+
+			args = new Object[] {
+				userNotificationEventModelImpl.getUserId(),
+				userNotificationEventModelImpl.getDeliveryType(),
+				userNotificationEventModelImpl.isDelivered(),
+				userNotificationEventModelImpl.isArchived()
+			};
+
 			FinderCacheUtil.removeResult(_finderPathCountByU_DT_D_A, args);
 			FinderCacheUtil.removeResult(
 				_finderPathWithoutPaginationFindByU_DT_D_A, args);
@@ -8854,9 +11478,32 @@ public class UserNotificationEventPersistenceImpl
 				userNotificationEventModelImpl.isArchived()
 			};
 
-			FinderCacheUtil.removeResult(_finderPathCountByU_DT_A_A, args);
+			FinderCacheUtil.removeResult(_finderPathCountByU_DT_AR_A, args);
 			FinderCacheUtil.removeResult(
-				_finderPathWithoutPaginationFindByU_DT_A_A, args);
+				_finderPathWithoutPaginationFindByU_DT_AR_A, args);
+
+			args = new Object[] {
+				userNotificationEventModelImpl.getUserId(),
+				userNotificationEventModelImpl.isDelivered(),
+				userNotificationEventModelImpl.isActionRequired(),
+				userNotificationEventModelImpl.isArchived()
+			};
+
+			FinderCacheUtil.removeResult(_finderPathCountByU_D_AR_A, args);
+			FinderCacheUtil.removeResult(
+				_finderPathWithoutPaginationFindByU_D_AR_A, args);
+
+			args = new Object[] {
+				userNotificationEventModelImpl.getUserId(),
+				userNotificationEventModelImpl.getDeliveryType(),
+				userNotificationEventModelImpl.isDelivered(),
+				userNotificationEventModelImpl.isActionRequired(),
+				userNotificationEventModelImpl.isArchived()
+			};
+
+			FinderCacheUtil.removeResult(_finderPathCountByU_DT_D_AR_A, args);
+			FinderCacheUtil.removeResult(
+				_finderPathWithoutPaginationFindByU_DT_D_AR_A, args);
 
 			FinderCacheUtil.removeResult(
 				_finderPathCountAll, FINDER_ARGS_EMPTY);
@@ -9066,13 +11713,38 @@ public class UserNotificationEventPersistenceImpl
 			}
 
 			if ((userNotificationEventModelImpl.getColumnBitmask() &
-				 _finderPathWithoutPaginationFindByU_D_A.getColumnBitmask()) !=
+				 _finderPathWithoutPaginationFindByU_D_AR.getColumnBitmask()) !=
 					 0) {
 
 				Object[] args = new Object[] {
 					userNotificationEventModelImpl.getOriginalUserId(),
 					userNotificationEventModelImpl.getOriginalDelivered(),
 					userNotificationEventModelImpl.getOriginalActionRequired()
+				};
+
+				FinderCacheUtil.removeResult(_finderPathCountByU_D_AR, args);
+				FinderCacheUtil.removeResult(
+					_finderPathWithoutPaginationFindByU_D_AR, args);
+
+				args = new Object[] {
+					userNotificationEventModelImpl.getUserId(),
+					userNotificationEventModelImpl.isDelivered(),
+					userNotificationEventModelImpl.isActionRequired()
+				};
+
+				FinderCacheUtil.removeResult(_finderPathCountByU_D_AR, args);
+				FinderCacheUtil.removeResult(
+					_finderPathWithoutPaginationFindByU_D_AR, args);
+			}
+
+			if ((userNotificationEventModelImpl.getColumnBitmask() &
+				 _finderPathWithoutPaginationFindByU_D_A.getColumnBitmask()) !=
+					 0) {
+
+				Object[] args = new Object[] {
+					userNotificationEventModelImpl.getOriginalUserId(),
+					userNotificationEventModelImpl.getOriginalDelivered(),
+					userNotificationEventModelImpl.getOriginalArchived()
 				};
 
 				FinderCacheUtil.removeResult(_finderPathCountByU_D_A, args);
@@ -9082,7 +11754,7 @@ public class UserNotificationEventPersistenceImpl
 				args = new Object[] {
 					userNotificationEventModelImpl.getUserId(),
 					userNotificationEventModelImpl.isDelivered(),
-					userNotificationEventModelImpl.isActionRequired()
+					userNotificationEventModelImpl.isArchived()
 				};
 
 				FinderCacheUtil.removeResult(_finderPathCountByU_D_A, args);
@@ -9091,7 +11763,7 @@ public class UserNotificationEventPersistenceImpl
 			}
 
 			if ((userNotificationEventModelImpl.getColumnBitmask() &
-				 _finderPathWithoutPaginationFindByU_A_A.getColumnBitmask()) !=
+				 _finderPathWithoutPaginationFindByU_AR_A.getColumnBitmask()) !=
 					 0) {
 
 				Object[] args = new Object[] {
@@ -9100,9 +11772,9 @@ public class UserNotificationEventPersistenceImpl
 					userNotificationEventModelImpl.getOriginalArchived()
 				};
 
-				FinderCacheUtil.removeResult(_finderPathCountByU_A_A, args);
+				FinderCacheUtil.removeResult(_finderPathCountByU_AR_A, args);
 				FinderCacheUtil.removeResult(
-					_finderPathWithoutPaginationFindByU_A_A, args);
+					_finderPathWithoutPaginationFindByU_AR_A, args);
 
 				args = new Object[] {
 					userNotificationEventModelImpl.getUserId(),
@@ -9110,9 +11782,9 @@ public class UserNotificationEventPersistenceImpl
 					userNotificationEventModelImpl.isArchived()
 				};
 
-				FinderCacheUtil.removeResult(_finderPathCountByU_A_A, args);
+				FinderCacheUtil.removeResult(_finderPathCountByU_AR_A, args);
 				FinderCacheUtil.removeResult(
-					_finderPathWithoutPaginationFindByU_A_A, args);
+					_finderPathWithoutPaginationFindByU_AR_A, args);
 			}
 
 			if ((userNotificationEventModelImpl.getColumnBitmask() &
@@ -9143,7 +11815,7 @@ public class UserNotificationEventPersistenceImpl
 			}
 
 			if ((userNotificationEventModelImpl.getColumnBitmask() &
-				 _finderPathWithoutPaginationFindByU_DT_D_A.
+				 _finderPathWithoutPaginationFindByU_DT_D_AR.
 					 getColumnBitmask()) != 0) {
 
 				Object[] args = new Object[] {
@@ -9151,6 +11823,33 @@ public class UserNotificationEventPersistenceImpl
 					userNotificationEventModelImpl.getOriginalDeliveryType(),
 					userNotificationEventModelImpl.getOriginalDelivered(),
 					userNotificationEventModelImpl.getOriginalActionRequired()
+				};
+
+				FinderCacheUtil.removeResult(_finderPathCountByU_DT_D_AR, args);
+				FinderCacheUtil.removeResult(
+					_finderPathWithoutPaginationFindByU_DT_D_AR, args);
+
+				args = new Object[] {
+					userNotificationEventModelImpl.getUserId(),
+					userNotificationEventModelImpl.getDeliveryType(),
+					userNotificationEventModelImpl.isDelivered(),
+					userNotificationEventModelImpl.isActionRequired()
+				};
+
+				FinderCacheUtil.removeResult(_finderPathCountByU_DT_D_AR, args);
+				FinderCacheUtil.removeResult(
+					_finderPathWithoutPaginationFindByU_DT_D_AR, args);
+			}
+
+			if ((userNotificationEventModelImpl.getColumnBitmask() &
+				 _finderPathWithoutPaginationFindByU_DT_D_A.
+					 getColumnBitmask()) != 0) {
+
+				Object[] args = new Object[] {
+					userNotificationEventModelImpl.getOriginalUserId(),
+					userNotificationEventModelImpl.getOriginalDeliveryType(),
+					userNotificationEventModelImpl.getOriginalDelivered(),
+					userNotificationEventModelImpl.getOriginalArchived()
 				};
 
 				FinderCacheUtil.removeResult(_finderPathCountByU_DT_D_A, args);
@@ -9161,7 +11860,7 @@ public class UserNotificationEventPersistenceImpl
 					userNotificationEventModelImpl.getUserId(),
 					userNotificationEventModelImpl.getDeliveryType(),
 					userNotificationEventModelImpl.isDelivered(),
-					userNotificationEventModelImpl.isActionRequired()
+					userNotificationEventModelImpl.isArchived()
 				};
 
 				FinderCacheUtil.removeResult(_finderPathCountByU_DT_D_A, args);
@@ -9170,7 +11869,7 @@ public class UserNotificationEventPersistenceImpl
 			}
 
 			if ((userNotificationEventModelImpl.getColumnBitmask() &
-				 _finderPathWithoutPaginationFindByU_DT_A_A.
+				 _finderPathWithoutPaginationFindByU_DT_AR_A.
 					 getColumnBitmask()) != 0) {
 
 				Object[] args = new Object[] {
@@ -9180,9 +11879,9 @@ public class UserNotificationEventPersistenceImpl
 					userNotificationEventModelImpl.getOriginalArchived()
 				};
 
-				FinderCacheUtil.removeResult(_finderPathCountByU_DT_A_A, args);
+				FinderCacheUtil.removeResult(_finderPathCountByU_DT_AR_A, args);
 				FinderCacheUtil.removeResult(
-					_finderPathWithoutPaginationFindByU_DT_A_A, args);
+					_finderPathWithoutPaginationFindByU_DT_AR_A, args);
 
 				args = new Object[] {
 					userNotificationEventModelImpl.getUserId(),
@@ -9191,9 +11890,67 @@ public class UserNotificationEventPersistenceImpl
 					userNotificationEventModelImpl.isArchived()
 				};
 
-				FinderCacheUtil.removeResult(_finderPathCountByU_DT_A_A, args);
+				FinderCacheUtil.removeResult(_finderPathCountByU_DT_AR_A, args);
 				FinderCacheUtil.removeResult(
-					_finderPathWithoutPaginationFindByU_DT_A_A, args);
+					_finderPathWithoutPaginationFindByU_DT_AR_A, args);
+			}
+
+			if ((userNotificationEventModelImpl.getColumnBitmask() &
+				 _finderPathWithoutPaginationFindByU_D_AR_A.
+					 getColumnBitmask()) != 0) {
+
+				Object[] args = new Object[] {
+					userNotificationEventModelImpl.getOriginalUserId(),
+					userNotificationEventModelImpl.getOriginalDelivered(),
+					userNotificationEventModelImpl.getOriginalActionRequired(),
+					userNotificationEventModelImpl.getOriginalArchived()
+				};
+
+				FinderCacheUtil.removeResult(_finderPathCountByU_D_AR_A, args);
+				FinderCacheUtil.removeResult(
+					_finderPathWithoutPaginationFindByU_D_AR_A, args);
+
+				args = new Object[] {
+					userNotificationEventModelImpl.getUserId(),
+					userNotificationEventModelImpl.isDelivered(),
+					userNotificationEventModelImpl.isActionRequired(),
+					userNotificationEventModelImpl.isArchived()
+				};
+
+				FinderCacheUtil.removeResult(_finderPathCountByU_D_AR_A, args);
+				FinderCacheUtil.removeResult(
+					_finderPathWithoutPaginationFindByU_D_AR_A, args);
+			}
+
+			if ((userNotificationEventModelImpl.getColumnBitmask() &
+				 _finderPathWithoutPaginationFindByU_DT_D_AR_A.
+					 getColumnBitmask()) != 0) {
+
+				Object[] args = new Object[] {
+					userNotificationEventModelImpl.getOriginalUserId(),
+					userNotificationEventModelImpl.getOriginalDeliveryType(),
+					userNotificationEventModelImpl.getOriginalDelivered(),
+					userNotificationEventModelImpl.getOriginalActionRequired(),
+					userNotificationEventModelImpl.getOriginalArchived()
+				};
+
+				FinderCacheUtil.removeResult(
+					_finderPathCountByU_DT_D_AR_A, args);
+				FinderCacheUtil.removeResult(
+					_finderPathWithoutPaginationFindByU_DT_D_AR_A, args);
+
+				args = new Object[] {
+					userNotificationEventModelImpl.getUserId(),
+					userNotificationEventModelImpl.getDeliveryType(),
+					userNotificationEventModelImpl.isDelivered(),
+					userNotificationEventModelImpl.isActionRequired(),
+					userNotificationEventModelImpl.isArchived()
+				};
+
+				FinderCacheUtil.removeResult(
+					_finderPathCountByU_DT_D_AR_A, args);
+				FinderCacheUtil.removeResult(
+					_finderPathWithoutPaginationFindByU_DT_D_AR_A, args);
 			}
 		}
 
@@ -9764,6 +12521,40 @@ public class UserNotificationEventPersistenceImpl
 				Boolean.class.getName()
 			});
 
+		_finderPathWithPaginationFindByU_D_AR = new FinderPath(
+			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
+			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED,
+			UserNotificationEventImpl.class,
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_D_AR",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			});
+
+		_finderPathWithoutPaginationFindByU_D_AR = new FinderPath(
+			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
+			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED,
+			UserNotificationEventImpl.class,
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_D_AR",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName()
+			},
+			UserNotificationEventModelImpl.USERID_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.DELIVERED_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.ACTIONREQUIRED_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.TIMESTAMP_COLUMN_BITMASK);
+
+		_finderPathCountByU_D_AR = new FinderPath(
+			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
+			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED, Long.class,
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_D_AR",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName()
+			});
+
 		_finderPathWithPaginationFindByU_D_A = new FinderPath(
 			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
 			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED,
@@ -9786,7 +12577,7 @@ public class UserNotificationEventPersistenceImpl
 			},
 			UserNotificationEventModelImpl.USERID_COLUMN_BITMASK |
 			UserNotificationEventModelImpl.DELIVERED_COLUMN_BITMASK |
-			UserNotificationEventModelImpl.ACTIONREQUIRED_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.ARCHIVED_COLUMN_BITMASK |
 			UserNotificationEventModelImpl.TIMESTAMP_COLUMN_BITMASK);
 
 		_finderPathCountByU_D_A = new FinderPath(
@@ -9798,22 +12589,22 @@ public class UserNotificationEventPersistenceImpl
 				Boolean.class.getName()
 			});
 
-		_finderPathWithPaginationFindByU_A_A = new FinderPath(
+		_finderPathWithPaginationFindByU_AR_A = new FinderPath(
 			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
 			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED,
 			UserNotificationEventImpl.class,
-			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_A_A",
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_AR_A",
 			new String[] {
 				Long.class.getName(), Boolean.class.getName(),
 				Boolean.class.getName(), Integer.class.getName(),
 				Integer.class.getName(), OrderByComparator.class.getName()
 			});
 
-		_finderPathWithoutPaginationFindByU_A_A = new FinderPath(
+		_finderPathWithoutPaginationFindByU_AR_A = new FinderPath(
 			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
 			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED,
 			UserNotificationEventImpl.class,
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_A_A",
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_AR_A",
 			new String[] {
 				Long.class.getName(), Boolean.class.getName(),
 				Boolean.class.getName()
@@ -9823,10 +12614,10 @@ public class UserNotificationEventPersistenceImpl
 			UserNotificationEventModelImpl.ARCHIVED_COLUMN_BITMASK |
 			UserNotificationEventModelImpl.TIMESTAMP_COLUMN_BITMASK);
 
-		_finderPathCountByU_A_A = new FinderPath(
+		_finderPathCountByU_AR_A = new FinderPath(
 			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
 			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED, Long.class,
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_A_A",
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_AR_A",
 			new String[] {
 				Long.class.getName(), Boolean.class.getName(),
 				Boolean.class.getName()
@@ -9868,6 +12659,42 @@ public class UserNotificationEventPersistenceImpl
 				Integer.class.getName(), Boolean.class.getName()
 			});
 
+		_finderPathWithPaginationFindByU_DT_D_AR = new FinderPath(
+			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
+			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED,
+			UserNotificationEventImpl.class,
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_DT_D_AR",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			});
+
+		_finderPathWithoutPaginationFindByU_DT_D_AR = new FinderPath(
+			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
+			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED,
+			UserNotificationEventImpl.class,
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_DT_D_AR",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName()
+			},
+			UserNotificationEventModelImpl.USERID_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.DELIVERYTYPE_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.DELIVERED_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.ACTIONREQUIRED_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.TIMESTAMP_COLUMN_BITMASK);
+
+		_finderPathCountByU_DT_D_AR = new FinderPath(
+			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
+			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED, Long.class,
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_DT_D_AR",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName()
+			});
+
 		_finderPathWithPaginationFindByU_DT_D_A = new FinderPath(
 			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
 			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED,
@@ -9892,7 +12719,7 @@ public class UserNotificationEventPersistenceImpl
 			UserNotificationEventModelImpl.USERID_COLUMN_BITMASK |
 			UserNotificationEventModelImpl.DELIVERYTYPE_COLUMN_BITMASK |
 			UserNotificationEventModelImpl.DELIVERED_COLUMN_BITMASK |
-			UserNotificationEventModelImpl.ACTIONREQUIRED_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.ARCHIVED_COLUMN_BITMASK |
 			UserNotificationEventModelImpl.TIMESTAMP_COLUMN_BITMASK);
 
 		_finderPathCountByU_DT_D_A = new FinderPath(
@@ -9904,11 +12731,11 @@ public class UserNotificationEventPersistenceImpl
 				Boolean.class.getName(), Boolean.class.getName()
 			});
 
-		_finderPathWithPaginationFindByU_DT_A_A = new FinderPath(
+		_finderPathWithPaginationFindByU_DT_AR_A = new FinderPath(
 			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
 			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED,
 			UserNotificationEventImpl.class,
-			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_DT_A_A",
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_DT_AR_A",
 			new String[] {
 				Long.class.getName(), Integer.class.getName(),
 				Boolean.class.getName(), Boolean.class.getName(),
@@ -9916,11 +12743,11 @@ public class UserNotificationEventPersistenceImpl
 				OrderByComparator.class.getName()
 			});
 
-		_finderPathWithoutPaginationFindByU_DT_A_A = new FinderPath(
+		_finderPathWithoutPaginationFindByU_DT_AR_A = new FinderPath(
 			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
 			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED,
 			UserNotificationEventImpl.class,
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_DT_A_A",
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_DT_AR_A",
 			new String[] {
 				Long.class.getName(), Integer.class.getName(),
 				Boolean.class.getName(), Boolean.class.getName()
@@ -9931,13 +12758,88 @@ public class UserNotificationEventPersistenceImpl
 			UserNotificationEventModelImpl.ARCHIVED_COLUMN_BITMASK |
 			UserNotificationEventModelImpl.TIMESTAMP_COLUMN_BITMASK);
 
-		_finderPathCountByU_DT_A_A = new FinderPath(
+		_finderPathCountByU_DT_AR_A = new FinderPath(
 			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
 			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED, Long.class,
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_DT_A_A",
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_DT_AR_A",
 			new String[] {
 				Long.class.getName(), Integer.class.getName(),
 				Boolean.class.getName(), Boolean.class.getName()
+			});
+
+		_finderPathWithPaginationFindByU_D_AR_A = new FinderPath(
+			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
+			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED,
+			UserNotificationEventImpl.class,
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_D_AR_A",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			});
+
+		_finderPathWithoutPaginationFindByU_D_AR_A = new FinderPath(
+			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
+			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED,
+			UserNotificationEventImpl.class,
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_D_AR_A",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName()
+			},
+			UserNotificationEventModelImpl.USERID_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.DELIVERED_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.ACTIONREQUIRED_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.ARCHIVED_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.TIMESTAMP_COLUMN_BITMASK);
+
+		_finderPathCountByU_D_AR_A = new FinderPath(
+			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
+			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED, Long.class,
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_D_AR_A",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName()
+			});
+
+		_finderPathWithPaginationFindByU_DT_D_AR_A = new FinderPath(
+			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
+			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED,
+			UserNotificationEventImpl.class,
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_DT_D_AR_A",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			});
+
+		_finderPathWithoutPaginationFindByU_DT_D_AR_A = new FinderPath(
+			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
+			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED,
+			UserNotificationEventImpl.class,
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_DT_D_AR_A",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName()
+			},
+			UserNotificationEventModelImpl.USERID_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.DELIVERYTYPE_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.DELIVERED_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.ACTIONREQUIRED_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.ARCHIVED_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.TIMESTAMP_COLUMN_BITMASK);
+
+		_finderPathCountByU_DT_D_AR_A = new FinderPath(
+			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
+			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED, Long.class,
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_DT_D_AR_A",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName()
 			});
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserNotificationEventLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserNotificationEventLocalService.java
@@ -62,12 +62,24 @@ public interface UserNotificationEventLocalService
 	 * Never modify or reference this interface directly. Always use {@link UserNotificationEventLocalServiceUtil} to access the user notification event local service. Add custom service methods to <code>com.liferay.portal.service.impl.UserNotificationEventLocalServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface.
 	 */
 	public UserNotificationEvent addUserNotificationEvent(
+			long userId, boolean delivered, boolean actionRequired,
+			NotificationEvent notificationEvent)
+		throws PortalException;
+
+	public UserNotificationEvent addUserNotificationEvent(
 			long userId, boolean actionRequired,
 			NotificationEvent notificationEvent)
 		throws PortalException;
 
 	public UserNotificationEvent addUserNotificationEvent(
 			long userId, NotificationEvent notificationEvent)
+		throws PortalException;
+
+	public UserNotificationEvent addUserNotificationEvent(
+			long userId, String type, long timestamp, int deliveryType,
+			long deliverBy, boolean delivered, String payload,
+			boolean actionRequired, boolean archived,
+			ServiceContext serviceContext)
 		throws PortalException;
 
 	public UserNotificationEvent addUserNotificationEvent(
@@ -434,6 +446,10 @@ public interface UserNotificationEventLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getUserNotificationEventsCount(
+		long userId, int deliveryType, boolean delivered, boolean archived);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int getUserNotificationEventsCount(
 		long userId, String type, int deliveryType, boolean archived);
 
 	public UserNotificationEvent sendUserNotificationEvents(
@@ -444,6 +460,11 @@ public interface UserNotificationEventLocalService
 	public UserNotificationEvent sendUserNotificationEvents(
 			long userId, String portletId, int deliveryType,
 			JSONObject notificationEventJSONObject)
+		throws PortalException;
+
+	public UserNotificationEvent storeUserNotificationEvents(
+			long userId, String portletId, int deliveryType,
+			boolean actionRequired, JSONObject notificationEventJSONObject)
 		throws PortalException;
 
 	public UserNotificationEvent updateUserNotificationEvent(

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserNotificationEventLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserNotificationEventLocalService.java
@@ -270,6 +270,17 @@ public interface UserNotificationEventLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<UserNotificationEvent> getArchivedUserNotificationEvents(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived, int start, int end);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<UserNotificationEvent> getArchivedUserNotificationEvents(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived, int start, int end,
+		OrderByComparator<UserNotificationEvent> obc);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<UserNotificationEvent> getArchivedUserNotificationEvents(
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		int start, int end);
 
@@ -298,6 +309,15 @@ public interface UserNotificationEventLocalService
 	public int getArchivedUserNotificationEventsCount(
 		long userId, int deliveryType, boolean actionRequired,
 		boolean archived);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int getArchivedUserNotificationEventsCount(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int getDeliveredArchivedUserNotificationEventsCount(
+		long userId, int deliveryType, boolean delivered, boolean archived);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<UserNotificationEvent> getDeliveredUserNotificationEvents(
@@ -451,6 +471,11 @@ public interface UserNotificationEventLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getUserNotificationEventsCount(
 		long userId, String type, int deliveryType, boolean archived);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int getUserNotificationEventsCount(
+		long userId, String type, int deliveryType, boolean delivered,
+		boolean archived);
 
 	public UserNotificationEvent sendUserNotificationEvents(
 			long userId, String portletId, int deliveryType, boolean delivered,

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserNotificationEventLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserNotificationEventLocalService.java
@@ -66,6 +66,10 @@ public interface UserNotificationEventLocalService
 			NotificationEvent notificationEvent)
 		throws PortalException;
 
+	/**
+	 * @deprecated As of Mueller (7.2.x)
+	 */
+	@Deprecated
 	public UserNotificationEvent addUserNotificationEvent(
 			long userId, boolean actionRequired,
 			NotificationEvent notificationEvent)
@@ -82,6 +86,10 @@ public interface UserNotificationEventLocalService
 			ServiceContext serviceContext)
 		throws PortalException;
 
+	/**
+	 * @deprecated As of Mueller (7.2.x)
+	 */
+	@Deprecated
 	public UserNotificationEvent addUserNotificationEvent(
 			long userId, String type, long timestamp, int deliveryType,
 			long deliverBy, String payload, boolean actionRequired,

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserNotificationEventLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserNotificationEventLocalService.java
@@ -453,6 +453,11 @@ public interface UserNotificationEventLocalService
 		long userId, String type, int deliveryType, boolean archived);
 
 	public UserNotificationEvent sendUserNotificationEvents(
+			long userId, String portletId, int deliveryType, boolean delivered,
+			boolean actionRequired, JSONObject notificationEventJSONObject)
+		throws PortalException;
+
+	public UserNotificationEvent sendUserNotificationEvents(
 			long userId, String portletId, int deliveryType,
 			boolean actionRequired, JSONObject notificationEventJSONObject)
 		throws PortalException;
@@ -460,11 +465,6 @@ public interface UserNotificationEventLocalService
 	public UserNotificationEvent sendUserNotificationEvents(
 			long userId, String portletId, int deliveryType,
 			JSONObject notificationEventJSONObject)
-		throws PortalException;
-
-	public UserNotificationEvent storeUserNotificationEvents(
-			long userId, String portletId, int deliveryType,
-			boolean actionRequired, JSONObject notificationEventJSONObject)
 		throws PortalException;
 
 	public UserNotificationEvent updateUserNotificationEvent(

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserNotificationEventLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserNotificationEventLocalServiceUtil.java
@@ -52,6 +52,10 @@ public class UserNotificationEventLocalServiceUtil {
 			userId, delivered, actionRequired, notificationEvent);
 	}
 
+	/**
+	 * @deprecated As of Mueller (7.2.x)
+	 */
+	@Deprecated
 	public static com.liferay.portal.kernel.model.UserNotificationEvent
 			addUserNotificationEvent(
 				long userId, boolean actionRequired,
@@ -86,6 +90,10 @@ public class UserNotificationEventLocalServiceUtil {
 			payload, actionRequired, archived, serviceContext);
 	}
 
+	/**
+	 * @deprecated As of Mueller (7.2.x)
+	 */
+	@Deprecated
 	public static com.liferay.portal.kernel.model.UserNotificationEvent
 			addUserNotificationEvent(
 				long userId, String type, long timestamp, int deliveryType,

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserNotificationEventLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserNotificationEventLocalServiceUtil.java
@@ -43,6 +43,17 @@ public class UserNotificationEventLocalServiceUtil {
 	 */
 	public static com.liferay.portal.kernel.model.UserNotificationEvent
 			addUserNotificationEvent(
+				long userId, boolean delivered, boolean actionRequired,
+				com.liferay.portal.kernel.notifications.NotificationEvent
+					notificationEvent)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().addUserNotificationEvent(
+			userId, delivered, actionRequired, notificationEvent);
+	}
+
+	public static com.liferay.portal.kernel.model.UserNotificationEvent
+			addUserNotificationEvent(
 				long userId, boolean actionRequired,
 				com.liferay.portal.kernel.notifications.NotificationEvent
 					notificationEvent)
@@ -60,6 +71,19 @@ public class UserNotificationEventLocalServiceUtil {
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return getService().addUserNotificationEvent(userId, notificationEvent);
+	}
+
+	public static com.liferay.portal.kernel.model.UserNotificationEvent
+			addUserNotificationEvent(
+				long userId, String type, long timestamp, int deliveryType,
+				long deliverBy, boolean delivered, String payload,
+				boolean actionRequired, boolean archived,
+				ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().addUserNotificationEvent(
+			userId, type, timestamp, deliveryType, deliverBy, delivered,
+			payload, actionRequired, archived, serviceContext);
 	}
 
 	public static com.liferay.portal.kernel.model.UserNotificationEvent
@@ -665,6 +689,13 @@ public class UserNotificationEventLocalServiceUtil {
 	}
 
 	public static int getUserNotificationEventsCount(
+		long userId, int deliveryType, boolean delivered, boolean archived) {
+
+		return getService().getUserNotificationEventsCount(
+			userId, deliveryType, delivered, archived);
+	}
+
+	public static int getUserNotificationEventsCount(
 		long userId, String type, int deliveryType, boolean archived) {
 
 		return getService().getUserNotificationEventsCount(
@@ -693,6 +724,19 @@ public class UserNotificationEventLocalServiceUtil {
 
 		return getService().sendUserNotificationEvents(
 			userId, portletId, deliveryType, notificationEventJSONObject);
+	}
+
+	public static com.liferay.portal.kernel.model.UserNotificationEvent
+			storeUserNotificationEvents(
+				long userId, String portletId, int deliveryType,
+				boolean actionRequired,
+				com.liferay.portal.kernel.json.JSONObject
+					notificationEventJSONObject)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().storeUserNotificationEvents(
+			userId, portletId, deliveryType, actionRequired,
+			notificationEventJSONObject);
 	}
 
 	public static com.liferay.portal.kernel.model.UserNotificationEvent

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserNotificationEventLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserNotificationEventLocalServiceUtil.java
@@ -705,6 +705,19 @@ public class UserNotificationEventLocalServiceUtil {
 	public static com.liferay.portal.kernel.model.UserNotificationEvent
 			sendUserNotificationEvents(
 				long userId, String portletId, int deliveryType,
+				boolean delivered, boolean actionRequired,
+				com.liferay.portal.kernel.json.JSONObject
+					notificationEventJSONObject)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().sendUserNotificationEvents(
+			userId, portletId, deliveryType, delivered, actionRequired,
+			notificationEventJSONObject);
+	}
+
+	public static com.liferay.portal.kernel.model.UserNotificationEvent
+			sendUserNotificationEvents(
+				long userId, String portletId, int deliveryType,
 				boolean actionRequired,
 				com.liferay.portal.kernel.json.JSONObject
 					notificationEventJSONObject)
@@ -724,19 +737,6 @@ public class UserNotificationEventLocalServiceUtil {
 
 		return getService().sendUserNotificationEvents(
 			userId, portletId, deliveryType, notificationEventJSONObject);
-	}
-
-	public static com.liferay.portal.kernel.model.UserNotificationEvent
-			storeUserNotificationEvents(
-				long userId, String portletId, int deliveryType,
-				boolean actionRequired,
-				com.liferay.portal.kernel.json.JSONObject
-					notificationEventJSONObject)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return getService().storeUserNotificationEvents(
-			userId, portletId, deliveryType, actionRequired,
-			notificationEventJSONObject);
 	}
 
 	public static com.liferay.portal.kernel.model.UserNotificationEvent

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserNotificationEventLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserNotificationEventLocalServiceUtil.java
@@ -383,6 +383,31 @@ public class UserNotificationEventLocalServiceUtil {
 	public static java.util.List
 		<com.liferay.portal.kernel.model.UserNotificationEvent>
 			getArchivedUserNotificationEvents(
+				long userId, int deliveryType, boolean delivered,
+				boolean actionRequired, boolean archived, int start, int end) {
+
+		return getService().getArchivedUserNotificationEvents(
+			userId, deliveryType, delivered, actionRequired, archived, start,
+			end);
+	}
+
+	public static java.util.List
+		<com.liferay.portal.kernel.model.UserNotificationEvent>
+			getArchivedUserNotificationEvents(
+				long userId, int deliveryType, boolean delivered,
+				boolean actionRequired, boolean archived, int start, int end,
+				com.liferay.portal.kernel.util.OrderByComparator
+					<com.liferay.portal.kernel.model.UserNotificationEvent>
+						obc) {
+
+		return getService().getArchivedUserNotificationEvents(
+			userId, deliveryType, delivered, actionRequired, archived, start,
+			end, obc);
+	}
+
+	public static java.util.List
+		<com.liferay.portal.kernel.model.UserNotificationEvent>
+			getArchivedUserNotificationEvents(
 				long userId, int deliveryType, boolean actionRequired,
 				boolean archived, int start, int end) {
 
@@ -440,6 +465,21 @@ public class UserNotificationEventLocalServiceUtil {
 
 		return getService().getArchivedUserNotificationEventsCount(
 			userId, deliveryType, actionRequired, archived);
+	}
+
+	public static int getArchivedUserNotificationEventsCount(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived) {
+
+		return getService().getArchivedUserNotificationEventsCount(
+			userId, deliveryType, delivered, actionRequired, archived);
+	}
+
+	public static int getDeliveredArchivedUserNotificationEventsCount(
+		long userId, int deliveryType, boolean delivered, boolean archived) {
+
+		return getService().getDeliveredArchivedUserNotificationEventsCount(
+			userId, deliveryType, delivered, archived);
 	}
 
 	public static java.util.List
@@ -700,6 +740,14 @@ public class UserNotificationEventLocalServiceUtil {
 
 		return getService().getUserNotificationEventsCount(
 			userId, type, deliveryType, archived);
+	}
+
+	public static int getUserNotificationEventsCount(
+		long userId, String type, int deliveryType, boolean delivered,
+		boolean archived) {
+
+		return getService().getUserNotificationEventsCount(
+			userId, type, deliveryType, delivered, archived);
 	}
 
 	public static com.liferay.portal.kernel.model.UserNotificationEvent

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserNotificationEventLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserNotificationEventLocalServiceWrapper.java
@@ -40,6 +40,18 @@ public class UserNotificationEventLocalServiceWrapper
 	@Override
 	public com.liferay.portal.kernel.model.UserNotificationEvent
 			addUserNotificationEvent(
+				long userId, boolean delivered, boolean actionRequired,
+				com.liferay.portal.kernel.notifications.NotificationEvent
+					notificationEvent)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _userNotificationEventLocalService.addUserNotificationEvent(
+			userId, delivered, actionRequired, notificationEvent);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.model.UserNotificationEvent
+			addUserNotificationEvent(
 				long userId, boolean actionRequired,
 				com.liferay.portal.kernel.notifications.NotificationEvent
 					notificationEvent)
@@ -59,6 +71,20 @@ public class UserNotificationEventLocalServiceWrapper
 
 		return _userNotificationEventLocalService.addUserNotificationEvent(
 			userId, notificationEvent);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.model.UserNotificationEvent
+			addUserNotificationEvent(
+				long userId, java.lang.String type, long timestamp,
+				int deliveryType, long deliverBy, boolean delivered,
+				java.lang.String payload, boolean actionRequired,
+				boolean archived, ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _userNotificationEventLocalService.addUserNotificationEvent(
+			userId, type, timestamp, deliveryType, deliverBy, delivered,
+			payload, actionRequired, archived, serviceContext);
 	}
 
 	@Override
@@ -733,6 +759,15 @@ public class UserNotificationEventLocalServiceWrapper
 
 	@Override
 	public int getUserNotificationEventsCount(
+		long userId, int deliveryType, boolean delivered, boolean archived) {
+
+		return _userNotificationEventLocalService.
+			getUserNotificationEventsCount(
+				userId, deliveryType, delivered, archived);
+	}
+
+	@Override
+	public int getUserNotificationEventsCount(
 		long userId, java.lang.String type, int deliveryType,
 		boolean archived) {
 
@@ -765,6 +800,20 @@ public class UserNotificationEventLocalServiceWrapper
 
 		return _userNotificationEventLocalService.sendUserNotificationEvents(
 			userId, portletId, deliveryType, notificationEventJSONObject);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.model.UserNotificationEvent
+			storeUserNotificationEvents(
+				long userId, java.lang.String portletId, int deliveryType,
+				boolean actionRequired,
+				com.liferay.portal.kernel.json.JSONObject
+					notificationEventJSONObject)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _userNotificationEventLocalService.storeUserNotificationEvents(
+			userId, portletId, deliveryType, actionRequired,
+			notificationEventJSONObject);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserNotificationEventLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserNotificationEventLocalServiceWrapper.java
@@ -780,6 +780,20 @@ public class UserNotificationEventLocalServiceWrapper
 	public com.liferay.portal.kernel.model.UserNotificationEvent
 			sendUserNotificationEvents(
 				long userId, java.lang.String portletId, int deliveryType,
+				boolean delivered, boolean actionRequired,
+				com.liferay.portal.kernel.json.JSONObject
+					notificationEventJSONObject)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _userNotificationEventLocalService.sendUserNotificationEvents(
+			userId, portletId, deliveryType, delivered, actionRequired,
+			notificationEventJSONObject);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.model.UserNotificationEvent
+			sendUserNotificationEvents(
+				long userId, java.lang.String portletId, int deliveryType,
 				boolean actionRequired,
 				com.liferay.portal.kernel.json.JSONObject
 					notificationEventJSONObject)
@@ -800,20 +814,6 @@ public class UserNotificationEventLocalServiceWrapper
 
 		return _userNotificationEventLocalService.sendUserNotificationEvents(
 			userId, portletId, deliveryType, notificationEventJSONObject);
-	}
-
-	@Override
-	public com.liferay.portal.kernel.model.UserNotificationEvent
-			storeUserNotificationEvents(
-				long userId, java.lang.String portletId, int deliveryType,
-				boolean actionRequired,
-				com.liferay.portal.kernel.json.JSONObject
-					notificationEventJSONObject)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _userNotificationEventLocalService.storeUserNotificationEvents(
-			userId, portletId, deliveryType, actionRequired,
-			notificationEventJSONObject);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserNotificationEventLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserNotificationEventLocalServiceWrapper.java
@@ -49,6 +49,10 @@ public class UserNotificationEventLocalServiceWrapper
 			userId, delivered, actionRequired, notificationEvent);
 	}
 
+	/**
+	 * @deprecated As of Mueller (7.2.x)
+	 */
+	@Deprecated
 	@Override
 	public com.liferay.portal.kernel.model.UserNotificationEvent
 			addUserNotificationEvent(
@@ -87,6 +91,10 @@ public class UserNotificationEventLocalServiceWrapper
 			payload, actionRequired, archived, serviceContext);
 	}
 
+	/**
+	 * @deprecated As of Mueller (7.2.x)
+	 */
+	@Deprecated
 	@Override
 	public com.liferay.portal.kernel.model.UserNotificationEvent
 			addUserNotificationEvent(

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserNotificationEventLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserNotificationEventLocalServiceWrapper.java
@@ -414,6 +414,32 @@ public class UserNotificationEventLocalServiceWrapper
 	@Override
 	public java.util.List<com.liferay.portal.kernel.model.UserNotificationEvent>
 		getArchivedUserNotificationEvents(
+			long userId, int deliveryType, boolean delivered,
+			boolean actionRequired, boolean archived, int start, int end) {
+
+		return _userNotificationEventLocalService.
+			getArchivedUserNotificationEvents(
+				userId, deliveryType, delivered, actionRequired, archived,
+				start, end);
+	}
+
+	@Override
+	public java.util.List<com.liferay.portal.kernel.model.UserNotificationEvent>
+		getArchivedUserNotificationEvents(
+			long userId, int deliveryType, boolean delivered,
+			boolean actionRequired, boolean archived, int start, int end,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<com.liferay.portal.kernel.model.UserNotificationEvent> obc) {
+
+		return _userNotificationEventLocalService.
+			getArchivedUserNotificationEvents(
+				userId, deliveryType, delivered, actionRequired, archived,
+				start, end, obc);
+	}
+
+	@Override
+	public java.util.List<com.liferay.portal.kernel.model.UserNotificationEvent>
+		getArchivedUserNotificationEvents(
 			long userId, int deliveryType, boolean actionRequired,
 			boolean archived, int start, int end) {
 
@@ -481,6 +507,25 @@ public class UserNotificationEventLocalServiceWrapper
 		return _userNotificationEventLocalService.
 			getArchivedUserNotificationEventsCount(
 				userId, deliveryType, actionRequired, archived);
+	}
+
+	@Override
+	public int getArchivedUserNotificationEventsCount(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived) {
+
+		return _userNotificationEventLocalService.
+			getArchivedUserNotificationEventsCount(
+				userId, deliveryType, delivered, actionRequired, archived);
+	}
+
+	@Override
+	public int getDeliveredArchivedUserNotificationEventsCount(
+		long userId, int deliveryType, boolean delivered, boolean archived) {
+
+		return _userNotificationEventLocalService.
+			getDeliveredArchivedUserNotificationEventsCount(
+				userId, deliveryType, delivered, archived);
 	}
 
 	@Override
@@ -774,6 +819,16 @@ public class UserNotificationEventLocalServiceWrapper
 		return _userNotificationEventLocalService.
 			getUserNotificationEventsCount(
 				userId, type, deliveryType, archived);
+	}
+
+	@Override
+	public int getUserNotificationEventsCount(
+		long userId, java.lang.String type, int deliveryType, boolean delivered,
+		boolean archived) {
+
+		return _userNotificationEventLocalService.
+			getUserNotificationEventsCount(
+				userId, type, deliveryType, delivered, archived);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/UserNotificationEventPersistence.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/UserNotificationEventPersistence.java
@@ -1432,7 +1432,7 @@ public interface UserNotificationEventPersistence
 	 * @param actionRequired the action required
 	 * @return the matching user notification events
 	 */
-	public java.util.List<UserNotificationEvent> findByU_D_A(
+	public java.util.List<UserNotificationEvent> findByU_D_AR(
 		long userId, boolean delivered, boolean actionRequired);
 
 	/**
@@ -1449,7 +1449,7 @@ public interface UserNotificationEventPersistence
 	 * @param end the upper bound of the range of user notification events (not inclusive)
 	 * @return the range of matching user notification events
 	 */
-	public java.util.List<UserNotificationEvent> findByU_D_A(
+	public java.util.List<UserNotificationEvent> findByU_D_AR(
 		long userId, boolean delivered, boolean actionRequired, int start,
 		int end);
 
@@ -1468,7 +1468,7 @@ public interface UserNotificationEventPersistence
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching user notification events
 	 */
-	public java.util.List<UserNotificationEvent> findByU_D_A(
+	public java.util.List<UserNotificationEvent> findByU_D_AR(
 		long userId, boolean delivered, boolean actionRequired, int start,
 		int end,
 		com.liferay.portal.kernel.util.OrderByComparator<UserNotificationEvent>
@@ -1490,7 +1490,7 @@ public interface UserNotificationEventPersistence
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the ordered range of matching user notification events
 	 */
-	public java.util.List<UserNotificationEvent> findByU_D_A(
+	public java.util.List<UserNotificationEvent> findByU_D_AR(
 		long userId, boolean delivered, boolean actionRequired, int start,
 		int end,
 		com.liferay.portal.kernel.util.OrderByComparator<UserNotificationEvent>
@@ -1507,7 +1507,7 @@ public interface UserNotificationEventPersistence
 	 * @return the first matching user notification event
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
-	public UserNotificationEvent findByU_D_A_First(
+	public UserNotificationEvent findByU_D_AR_First(
 			long userId, boolean delivered, boolean actionRequired,
 			com.liferay.portal.kernel.util.OrderByComparator
 				<UserNotificationEvent> orderByComparator)
@@ -1522,7 +1522,7 @@ public interface UserNotificationEventPersistence
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
-	public UserNotificationEvent fetchByU_D_A_First(
+	public UserNotificationEvent fetchByU_D_AR_First(
 		long userId, boolean delivered, boolean actionRequired,
 		com.liferay.portal.kernel.util.OrderByComparator<UserNotificationEvent>
 			orderByComparator);
@@ -1537,7 +1537,7 @@ public interface UserNotificationEventPersistence
 	 * @return the last matching user notification event
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
-	public UserNotificationEvent findByU_D_A_Last(
+	public UserNotificationEvent findByU_D_AR_Last(
 			long userId, boolean delivered, boolean actionRequired,
 			com.liferay.portal.kernel.util.OrderByComparator
 				<UserNotificationEvent> orderByComparator)
@@ -1552,7 +1552,7 @@ public interface UserNotificationEventPersistence
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
-	public UserNotificationEvent fetchByU_D_A_Last(
+	public UserNotificationEvent fetchByU_D_AR_Last(
 		long userId, boolean delivered, boolean actionRequired,
 		com.liferay.portal.kernel.util.OrderByComparator<UserNotificationEvent>
 			orderByComparator);
@@ -1568,7 +1568,7 @@ public interface UserNotificationEventPersistence
 	 * @return the previous, current, and next user notification event
 	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
 	 */
-	public UserNotificationEvent[] findByU_D_A_PrevAndNext(
+	public UserNotificationEvent[] findByU_D_AR_PrevAndNext(
 			long userNotificationEventId, long userId, boolean delivered,
 			boolean actionRequired,
 			com.liferay.portal.kernel.util.OrderByComparator
@@ -1582,7 +1582,7 @@ public interface UserNotificationEventPersistence
 	 * @param delivered the delivered
 	 * @param actionRequired the action required
 	 */
-	public void removeByU_D_A(
+	public void removeByU_D_AR(
 		long userId, boolean delivered, boolean actionRequired);
 
 	/**
@@ -1593,8 +1593,175 @@ public interface UserNotificationEventPersistence
 	 * @param actionRequired the action required
 	 * @return the number of matching user notification events
 	 */
-	public int countByU_D_A(
+	public int countByU_D_AR(
 		long userId, boolean delivered, boolean actionRequired);
+
+	/**
+	 * Returns all the user notification events where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @return the matching user notification events
+	 */
+	public java.util.List<UserNotificationEvent> findByU_D_A(
+		long userId, boolean delivered, boolean archived);
+
+	/**
+	 * Returns a range of all the user notification events where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @return the range of matching user notification events
+	 */
+	public java.util.List<UserNotificationEvent> findByU_D_A(
+		long userId, boolean delivered, boolean archived, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching user notification events
+	 */
+	public java.util.List<UserNotificationEvent> findByU_D_A(
+		long userId, boolean delivered, boolean archived, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<UserNotificationEvent>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching user notification events
+	 */
+	public java.util.List<UserNotificationEvent> findByU_D_A(
+		long userId, boolean delivered, boolean archived, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<UserNotificationEvent>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	public UserNotificationEvent findByU_D_A_First(
+			long userId, boolean delivered, boolean archived,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException;
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	public UserNotificationEvent fetchByU_D_A_First(
+		long userId, boolean delivered, boolean archived,
+		com.liferay.portal.kernel.util.OrderByComparator<UserNotificationEvent>
+			orderByComparator);
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	public UserNotificationEvent findByU_D_A_Last(
+			long userId, boolean delivered, boolean archived,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException;
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	public UserNotificationEvent fetchByU_D_A_Last(
+		long userId, boolean delivered, boolean archived,
+		com.liferay.portal.kernel.util.OrderByComparator<UserNotificationEvent>
+			orderByComparator);
+
+	/**
+	 * Returns the user notification events before and after the current user notification event in the ordered set where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userNotificationEventId the primary key of the current user notification event
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next user notification event
+	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
+	 */
+	public UserNotificationEvent[] findByU_D_A_PrevAndNext(
+			long userNotificationEventId, long userId, boolean delivered,
+			boolean archived,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException;
+
+	/**
+	 * Removes all the user notification events where userId = &#63; and delivered = &#63; and archived = &#63; from the database.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 */
+	public void removeByU_D_A(long userId, boolean delivered, boolean archived);
+
+	/**
+	 * Returns the number of user notification events where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @return the number of matching user notification events
+	 */
+	public int countByU_D_A(long userId, boolean delivered, boolean archived);
 
 	/**
 	 * Returns all the user notification events where userId = &#63; and actionRequired = &#63; and archived = &#63;.
@@ -1604,7 +1771,7 @@ public interface UserNotificationEventPersistence
 	 * @param archived the archived
 	 * @return the matching user notification events
 	 */
-	public java.util.List<UserNotificationEvent> findByU_A_A(
+	public java.util.List<UserNotificationEvent> findByU_AR_A(
 		long userId, boolean actionRequired, boolean archived);
 
 	/**
@@ -1621,7 +1788,7 @@ public interface UserNotificationEventPersistence
 	 * @param end the upper bound of the range of user notification events (not inclusive)
 	 * @return the range of matching user notification events
 	 */
-	public java.util.List<UserNotificationEvent> findByU_A_A(
+	public java.util.List<UserNotificationEvent> findByU_AR_A(
 		long userId, boolean actionRequired, boolean archived, int start,
 		int end);
 
@@ -1640,7 +1807,7 @@ public interface UserNotificationEventPersistence
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching user notification events
 	 */
-	public java.util.List<UserNotificationEvent> findByU_A_A(
+	public java.util.List<UserNotificationEvent> findByU_AR_A(
 		long userId, boolean actionRequired, boolean archived, int start,
 		int end,
 		com.liferay.portal.kernel.util.OrderByComparator<UserNotificationEvent>
@@ -1662,7 +1829,7 @@ public interface UserNotificationEventPersistence
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the ordered range of matching user notification events
 	 */
-	public java.util.List<UserNotificationEvent> findByU_A_A(
+	public java.util.List<UserNotificationEvent> findByU_AR_A(
 		long userId, boolean actionRequired, boolean archived, int start,
 		int end,
 		com.liferay.portal.kernel.util.OrderByComparator<UserNotificationEvent>
@@ -1679,7 +1846,7 @@ public interface UserNotificationEventPersistence
 	 * @return the first matching user notification event
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
-	public UserNotificationEvent findByU_A_A_First(
+	public UserNotificationEvent findByU_AR_A_First(
 			long userId, boolean actionRequired, boolean archived,
 			com.liferay.portal.kernel.util.OrderByComparator
 				<UserNotificationEvent> orderByComparator)
@@ -1694,7 +1861,7 @@ public interface UserNotificationEventPersistence
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
-	public UserNotificationEvent fetchByU_A_A_First(
+	public UserNotificationEvent fetchByU_AR_A_First(
 		long userId, boolean actionRequired, boolean archived,
 		com.liferay.portal.kernel.util.OrderByComparator<UserNotificationEvent>
 			orderByComparator);
@@ -1709,7 +1876,7 @@ public interface UserNotificationEventPersistence
 	 * @return the last matching user notification event
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
-	public UserNotificationEvent findByU_A_A_Last(
+	public UserNotificationEvent findByU_AR_A_Last(
 			long userId, boolean actionRequired, boolean archived,
 			com.liferay.portal.kernel.util.OrderByComparator
 				<UserNotificationEvent> orderByComparator)
@@ -1724,7 +1891,7 @@ public interface UserNotificationEventPersistence
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
-	public UserNotificationEvent fetchByU_A_A_Last(
+	public UserNotificationEvent fetchByU_AR_A_Last(
 		long userId, boolean actionRequired, boolean archived,
 		com.liferay.portal.kernel.util.OrderByComparator<UserNotificationEvent>
 			orderByComparator);
@@ -1740,7 +1907,7 @@ public interface UserNotificationEventPersistence
 	 * @return the previous, current, and next user notification event
 	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
 	 */
-	public UserNotificationEvent[] findByU_A_A_PrevAndNext(
+	public UserNotificationEvent[] findByU_AR_A_PrevAndNext(
 			long userNotificationEventId, long userId, boolean actionRequired,
 			boolean archived,
 			com.liferay.portal.kernel.util.OrderByComparator
@@ -1754,7 +1921,7 @@ public interface UserNotificationEventPersistence
 	 * @param actionRequired the action required
 	 * @param archived the archived
 	 */
-	public void removeByU_A_A(
+	public void removeByU_AR_A(
 		long userId, boolean actionRequired, boolean archived);
 
 	/**
@@ -1765,7 +1932,7 @@ public interface UserNotificationEventPersistence
 	 * @param archived the archived
 	 * @return the number of matching user notification events
 	 */
-	public int countByU_A_A(
+	public int countByU_AR_A(
 		long userId, boolean actionRequired, boolean archived);
 
 	/**
@@ -1960,7 +2127,7 @@ public interface UserNotificationEventPersistence
 	 * @param actionRequired the action required
 	 * @return the matching user notification events
 	 */
-	public java.util.List<UserNotificationEvent> findByU_DT_D_A(
+	public java.util.List<UserNotificationEvent> findByU_DT_D_AR(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired);
 
@@ -1979,7 +2146,7 @@ public interface UserNotificationEventPersistence
 	 * @param end the upper bound of the range of user notification events (not inclusive)
 	 * @return the range of matching user notification events
 	 */
-	public java.util.List<UserNotificationEvent> findByU_DT_D_A(
+	public java.util.List<UserNotificationEvent> findByU_DT_D_AR(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired, int start, int end);
 
@@ -1999,7 +2166,7 @@ public interface UserNotificationEventPersistence
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching user notification events
 	 */
-	public java.util.List<UserNotificationEvent> findByU_DT_D_A(
+	public java.util.List<UserNotificationEvent> findByU_DT_D_AR(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired, int start, int end,
 		com.liferay.portal.kernel.util.OrderByComparator<UserNotificationEvent>
@@ -2022,7 +2189,7 @@ public interface UserNotificationEventPersistence
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the ordered range of matching user notification events
 	 */
-	public java.util.List<UserNotificationEvent> findByU_DT_D_A(
+	public java.util.List<UserNotificationEvent> findByU_DT_D_AR(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired, int start, int end,
 		com.liferay.portal.kernel.util.OrderByComparator<UserNotificationEvent>
@@ -2040,7 +2207,7 @@ public interface UserNotificationEventPersistence
 	 * @return the first matching user notification event
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
-	public UserNotificationEvent findByU_DT_D_A_First(
+	public UserNotificationEvent findByU_DT_D_AR_First(
 			long userId, int deliveryType, boolean delivered,
 			boolean actionRequired,
 			com.liferay.portal.kernel.util.OrderByComparator
@@ -2057,7 +2224,7 @@ public interface UserNotificationEventPersistence
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
-	public UserNotificationEvent fetchByU_DT_D_A_First(
+	public UserNotificationEvent fetchByU_DT_D_AR_First(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired,
 		com.liferay.portal.kernel.util.OrderByComparator<UserNotificationEvent>
@@ -2074,7 +2241,7 @@ public interface UserNotificationEventPersistence
 	 * @return the last matching user notification event
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
-	public UserNotificationEvent findByU_DT_D_A_Last(
+	public UserNotificationEvent findByU_DT_D_AR_Last(
 			long userId, int deliveryType, boolean delivered,
 			boolean actionRequired,
 			com.liferay.portal.kernel.util.OrderByComparator
@@ -2091,7 +2258,7 @@ public interface UserNotificationEventPersistence
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
-	public UserNotificationEvent fetchByU_DT_D_A_Last(
+	public UserNotificationEvent fetchByU_DT_D_AR_Last(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired,
 		com.liferay.portal.kernel.util.OrderByComparator<UserNotificationEvent>
@@ -2109,7 +2276,7 @@ public interface UserNotificationEventPersistence
 	 * @return the previous, current, and next user notification event
 	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
 	 */
-	public UserNotificationEvent[] findByU_DT_D_A_PrevAndNext(
+	public UserNotificationEvent[] findByU_DT_D_AR_PrevAndNext(
 			long userNotificationEventId, long userId, int deliveryType,
 			boolean delivered, boolean actionRequired,
 			com.liferay.portal.kernel.util.OrderByComparator
@@ -2124,7 +2291,7 @@ public interface UserNotificationEventPersistence
 	 * @param delivered the delivered
 	 * @param actionRequired the action required
 	 */
-	public void removeByU_DT_D_A(
+	public void removeByU_DT_D_AR(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired);
 
@@ -2137,9 +2304,192 @@ public interface UserNotificationEventPersistence
 	 * @param actionRequired the action required
 	 * @return the number of matching user notification events
 	 */
-	public int countByU_DT_D_A(
+	public int countByU_DT_D_AR(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired);
+
+	/**
+	 * Returns all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @return the matching user notification events
+	 */
+	public java.util.List<UserNotificationEvent> findByU_DT_D_A(
+		long userId, int deliveryType, boolean delivered, boolean archived);
+
+	/**
+	 * Returns a range of all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @return the range of matching user notification events
+	 */
+	public java.util.List<UserNotificationEvent> findByU_DT_D_A(
+		long userId, int deliveryType, boolean delivered, boolean archived,
+		int start, int end);
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching user notification events
+	 */
+	public java.util.List<UserNotificationEvent> findByU_DT_D_A(
+		long userId, int deliveryType, boolean delivered, boolean archived,
+		int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<UserNotificationEvent>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching user notification events
+	 */
+	public java.util.List<UserNotificationEvent> findByU_DT_D_A(
+		long userId, int deliveryType, boolean delivered, boolean archived,
+		int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<UserNotificationEvent>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	public UserNotificationEvent findByU_DT_D_A_First(
+			long userId, int deliveryType, boolean delivered, boolean archived,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException;
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	public UserNotificationEvent fetchByU_DT_D_A_First(
+		long userId, int deliveryType, boolean delivered, boolean archived,
+		com.liferay.portal.kernel.util.OrderByComparator<UserNotificationEvent>
+			orderByComparator);
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	public UserNotificationEvent findByU_DT_D_A_Last(
+			long userId, int deliveryType, boolean delivered, boolean archived,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException;
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	public UserNotificationEvent fetchByU_DT_D_A_Last(
+		long userId, int deliveryType, boolean delivered, boolean archived,
+		com.liferay.portal.kernel.util.OrderByComparator<UserNotificationEvent>
+			orderByComparator);
+
+	/**
+	 * Returns the user notification events before and after the current user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userNotificationEventId the primary key of the current user notification event
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next user notification event
+	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
+	 */
+	public UserNotificationEvent[] findByU_DT_D_A_PrevAndNext(
+			long userNotificationEventId, long userId, int deliveryType,
+			boolean delivered, boolean archived,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException;
+
+	/**
+	 * Removes all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63; from the database.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 */
+	public void removeByU_DT_D_A(
+		long userId, int deliveryType, boolean delivered, boolean archived);
+
+	/**
+	 * Returns the number of user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @return the number of matching user notification events
+	 */
+	public int countByU_DT_D_A(
+		long userId, int deliveryType, boolean delivered, boolean archived);
 
 	/**
 	 * Returns all the user notification events where userId = &#63; and deliveryType = &#63; and actionRequired = &#63; and archived = &#63;.
@@ -2150,7 +2500,7 @@ public interface UserNotificationEventPersistence
 	 * @param archived the archived
 	 * @return the matching user notification events
 	 */
-	public java.util.List<UserNotificationEvent> findByU_DT_A_A(
+	public java.util.List<UserNotificationEvent> findByU_DT_AR_A(
 		long userId, int deliveryType, boolean actionRequired,
 		boolean archived);
 
@@ -2169,7 +2519,7 @@ public interface UserNotificationEventPersistence
 	 * @param end the upper bound of the range of user notification events (not inclusive)
 	 * @return the range of matching user notification events
 	 */
-	public java.util.List<UserNotificationEvent> findByU_DT_A_A(
+	public java.util.List<UserNotificationEvent> findByU_DT_AR_A(
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		int start, int end);
 
@@ -2189,7 +2539,7 @@ public interface UserNotificationEventPersistence
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching user notification events
 	 */
-	public java.util.List<UserNotificationEvent> findByU_DT_A_A(
+	public java.util.List<UserNotificationEvent> findByU_DT_AR_A(
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		int start, int end,
 		com.liferay.portal.kernel.util.OrderByComparator<UserNotificationEvent>
@@ -2212,7 +2562,7 @@ public interface UserNotificationEventPersistence
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the ordered range of matching user notification events
 	 */
-	public java.util.List<UserNotificationEvent> findByU_DT_A_A(
+	public java.util.List<UserNotificationEvent> findByU_DT_AR_A(
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		int start, int end,
 		com.liferay.portal.kernel.util.OrderByComparator<UserNotificationEvent>
@@ -2230,7 +2580,7 @@ public interface UserNotificationEventPersistence
 	 * @return the first matching user notification event
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
-	public UserNotificationEvent findByU_DT_A_A_First(
+	public UserNotificationEvent findByU_DT_AR_A_First(
 			long userId, int deliveryType, boolean actionRequired,
 			boolean archived,
 			com.liferay.portal.kernel.util.OrderByComparator
@@ -2247,7 +2597,7 @@ public interface UserNotificationEventPersistence
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
-	public UserNotificationEvent fetchByU_DT_A_A_First(
+	public UserNotificationEvent fetchByU_DT_AR_A_First(
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		com.liferay.portal.kernel.util.OrderByComparator<UserNotificationEvent>
 			orderByComparator);
@@ -2263,7 +2613,7 @@ public interface UserNotificationEventPersistence
 	 * @return the last matching user notification event
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
-	public UserNotificationEvent findByU_DT_A_A_Last(
+	public UserNotificationEvent findByU_DT_AR_A_Last(
 			long userId, int deliveryType, boolean actionRequired,
 			boolean archived,
 			com.liferay.portal.kernel.util.OrderByComparator
@@ -2280,7 +2630,7 @@ public interface UserNotificationEventPersistence
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
-	public UserNotificationEvent fetchByU_DT_A_A_Last(
+	public UserNotificationEvent fetchByU_DT_AR_A_Last(
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		com.liferay.portal.kernel.util.OrderByComparator<UserNotificationEvent>
 			orderByComparator);
@@ -2297,7 +2647,7 @@ public interface UserNotificationEventPersistence
 	 * @return the previous, current, and next user notification event
 	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
 	 */
-	public UserNotificationEvent[] findByU_DT_A_A_PrevAndNext(
+	public UserNotificationEvent[] findByU_DT_AR_A_PrevAndNext(
 			long userNotificationEventId, long userId, int deliveryType,
 			boolean actionRequired, boolean archived,
 			com.liferay.portal.kernel.util.OrderByComparator
@@ -2312,7 +2662,7 @@ public interface UserNotificationEventPersistence
 	 * @param actionRequired the action required
 	 * @param archived the archived
 	 */
-	public void removeByU_DT_A_A(
+	public void removeByU_DT_AR_A(
 		long userId, int deliveryType, boolean actionRequired,
 		boolean archived);
 
@@ -2325,9 +2675,400 @@ public interface UserNotificationEventPersistence
 	 * @param archived the archived
 	 * @return the number of matching user notification events
 	 */
-	public int countByU_DT_A_A(
+	public int countByU_DT_AR_A(
 		long userId, int deliveryType, boolean actionRequired,
 		boolean archived);
+
+	/**
+	 * Returns all the user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @return the matching user notification events
+	 */
+	public java.util.List<UserNotificationEvent> findByU_D_AR_A(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived);
+
+	/**
+	 * Returns a range of all the user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @return the range of matching user notification events
+	 */
+	public java.util.List<UserNotificationEvent> findByU_D_AR_A(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching user notification events
+	 */
+	public java.util.List<UserNotificationEvent> findByU_D_AR_A(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<UserNotificationEvent>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching user notification events
+	 */
+	public java.util.List<UserNotificationEvent> findByU_D_AR_A(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<UserNotificationEvent>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	public UserNotificationEvent findByU_D_AR_A_First(
+			long userId, boolean delivered, boolean actionRequired,
+			boolean archived,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException;
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	public UserNotificationEvent fetchByU_D_AR_A_First(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived,
+		com.liferay.portal.kernel.util.OrderByComparator<UserNotificationEvent>
+			orderByComparator);
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	public UserNotificationEvent findByU_D_AR_A_Last(
+			long userId, boolean delivered, boolean actionRequired,
+			boolean archived,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException;
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	public UserNotificationEvent fetchByU_D_AR_A_Last(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived,
+		com.liferay.portal.kernel.util.OrderByComparator<UserNotificationEvent>
+			orderByComparator);
+
+	/**
+	 * Returns the user notification events before and after the current user notification event in the ordered set where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userNotificationEventId the primary key of the current user notification event
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next user notification event
+	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
+	 */
+	public UserNotificationEvent[] findByU_D_AR_A_PrevAndNext(
+			long userNotificationEventId, long userId, boolean delivered,
+			boolean actionRequired, boolean archived,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException;
+
+	/**
+	 * Removes all the user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63; from the database.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 */
+	public void removeByU_D_AR_A(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived);
+
+	/**
+	 * Returns the number of user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @return the number of matching user notification events
+	 */
+	public int countByU_D_AR_A(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived);
+
+	/**
+	 * Returns all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @return the matching user notification events
+	 */
+	public java.util.List<UserNotificationEvent> findByU_DT_D_AR_A(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived);
+
+	/**
+	 * Returns a range of all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @return the range of matching user notification events
+	 */
+	public java.util.List<UserNotificationEvent> findByU_DT_D_AR_A(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching user notification events
+	 */
+	public java.util.List<UserNotificationEvent> findByU_DT_D_AR_A(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<UserNotificationEvent>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching user notification events
+	 */
+	public java.util.List<UserNotificationEvent> findByU_DT_D_AR_A(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<UserNotificationEvent>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	public UserNotificationEvent findByU_DT_D_AR_A_First(
+			long userId, int deliveryType, boolean delivered,
+			boolean actionRequired, boolean archived,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException;
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	public UserNotificationEvent fetchByU_DT_D_AR_A_First(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived,
+		com.liferay.portal.kernel.util.OrderByComparator<UserNotificationEvent>
+			orderByComparator);
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	public UserNotificationEvent findByU_DT_D_AR_A_Last(
+			long userId, int deliveryType, boolean delivered,
+			boolean actionRequired, boolean archived,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException;
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	public UserNotificationEvent fetchByU_DT_D_AR_A_Last(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived,
+		com.liferay.portal.kernel.util.OrderByComparator<UserNotificationEvent>
+			orderByComparator);
+
+	/**
+	 * Returns the user notification events before and after the current user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userNotificationEventId the primary key of the current user notification event
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next user notification event
+	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
+	 */
+	public UserNotificationEvent[] findByU_DT_D_AR_A_PrevAndNext(
+			long userNotificationEventId, long userId, int deliveryType,
+			boolean delivered, boolean actionRequired, boolean archived,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException;
+
+	/**
+	 * Removes all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63; from the database.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 */
+	public void removeByU_DT_D_AR_A(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived);
+
+	/**
+	 * Returns the number of user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @return the number of matching user notification events
+	 */
+	public int countByU_DT_D_AR_A(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived);
 
 	/**
 	 * Caches the user notification event in the entity cache if it is enabled.

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/UserNotificationEventPersistence.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/UserNotificationEventPersistence.java
@@ -2870,6 +2870,207 @@ public interface UserNotificationEventPersistence
 		boolean archived);
 
 	/**
+	 * Returns all the user notification events where userId = &#63; and type = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param type the type
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @return the matching user notification events
+	 */
+	public java.util.List<UserNotificationEvent> findByU_T_DT_D_A(
+		long userId, String type, int deliveryType, boolean delivered,
+		boolean archived);
+
+	/**
+	 * Returns a range of all the user notification events where userId = &#63; and type = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param type the type
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @return the range of matching user notification events
+	 */
+	public java.util.List<UserNotificationEvent> findByU_T_DT_D_A(
+		long userId, String type, int deliveryType, boolean delivered,
+		boolean archived, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and type = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param type the type
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching user notification events
+	 */
+	public java.util.List<UserNotificationEvent> findByU_T_DT_D_A(
+		long userId, String type, int deliveryType, boolean delivered,
+		boolean archived, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<UserNotificationEvent>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and type = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param type the type
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching user notification events
+	 */
+	public java.util.List<UserNotificationEvent> findByU_T_DT_D_A(
+		long userId, String type, int deliveryType, boolean delivered,
+		boolean archived, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<UserNotificationEvent>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and type = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param type the type
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	public UserNotificationEvent findByU_T_DT_D_A_First(
+			long userId, String type, int deliveryType, boolean delivered,
+			boolean archived,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException;
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and type = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param type the type
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	public UserNotificationEvent fetchByU_T_DT_D_A_First(
+		long userId, String type, int deliveryType, boolean delivered,
+		boolean archived,
+		com.liferay.portal.kernel.util.OrderByComparator<UserNotificationEvent>
+			orderByComparator);
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and type = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param type the type
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	public UserNotificationEvent findByU_T_DT_D_A_Last(
+			long userId, String type, int deliveryType, boolean delivered,
+			boolean archived,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException;
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and type = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param type the type
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	public UserNotificationEvent fetchByU_T_DT_D_A_Last(
+		long userId, String type, int deliveryType, boolean delivered,
+		boolean archived,
+		com.liferay.portal.kernel.util.OrderByComparator<UserNotificationEvent>
+			orderByComparator);
+
+	/**
+	 * Returns the user notification events before and after the current user notification event in the ordered set where userId = &#63; and type = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userNotificationEventId the primary key of the current user notification event
+	 * @param userId the user ID
+	 * @param type the type
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next user notification event
+	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
+	 */
+	public UserNotificationEvent[] findByU_T_DT_D_A_PrevAndNext(
+			long userNotificationEventId, long userId, String type,
+			int deliveryType, boolean delivered, boolean archived,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException;
+
+	/**
+	 * Removes all the user notification events where userId = &#63; and type = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63; from the database.
+	 *
+	 * @param userId the user ID
+	 * @param type the type
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 */
+	public void removeByU_T_DT_D_A(
+		long userId, String type, int deliveryType, boolean delivered,
+		boolean archived);
+
+	/**
+	 * Returns the number of user notification events where userId = &#63; and type = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param type the type
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @return the number of matching user notification events
+	 */
+	public int countByU_T_DT_D_A(
+		long userId, String type, int deliveryType, boolean delivered,
+		boolean archived);
+
+	/**
 	 * Returns all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
 	 *
 	 * @param userId the user ID

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/UserNotificationEventUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/UserNotificationEventUtil.java
@@ -1818,10 +1818,10 @@ public class UserNotificationEventUtil {
 	 * @param actionRequired the action required
 	 * @return the matching user notification events
 	 */
-	public static List<UserNotificationEvent> findByU_D_A(
+	public static List<UserNotificationEvent> findByU_D_AR(
 		long userId, boolean delivered, boolean actionRequired) {
 
-		return getPersistence().findByU_D_A(userId, delivered, actionRequired);
+		return getPersistence().findByU_D_AR(userId, delivered, actionRequired);
 	}
 
 	/**
@@ -1838,11 +1838,11 @@ public class UserNotificationEventUtil {
 	 * @param end the upper bound of the range of user notification events (not inclusive)
 	 * @return the range of matching user notification events
 	 */
-	public static List<UserNotificationEvent> findByU_D_A(
+	public static List<UserNotificationEvent> findByU_D_AR(
 		long userId, boolean delivered, boolean actionRequired, int start,
 		int end) {
 
-		return getPersistence().findByU_D_A(
+		return getPersistence().findByU_D_AR(
 			userId, delivered, actionRequired, start, end);
 	}
 
@@ -1861,11 +1861,11 @@ public class UserNotificationEventUtil {
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching user notification events
 	 */
-	public static List<UserNotificationEvent> findByU_D_A(
+	public static List<UserNotificationEvent> findByU_D_AR(
 		long userId, boolean delivered, boolean actionRequired, int start,
 		int end, OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		return getPersistence().findByU_D_A(
+		return getPersistence().findByU_D_AR(
 			userId, delivered, actionRequired, start, end, orderByComparator);
 	}
 
@@ -1885,12 +1885,12 @@ public class UserNotificationEventUtil {
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the ordered range of matching user notification events
 	 */
-	public static List<UserNotificationEvent> findByU_D_A(
+	public static List<UserNotificationEvent> findByU_D_AR(
 		long userId, boolean delivered, boolean actionRequired, int start,
 		int end, OrderByComparator<UserNotificationEvent> orderByComparator,
 		boolean useFinderCache) {
 
-		return getPersistence().findByU_D_A(
+		return getPersistence().findByU_D_AR(
 			userId, delivered, actionRequired, start, end, orderByComparator,
 			useFinderCache);
 	}
@@ -1905,13 +1905,13 @@ public class UserNotificationEventUtil {
 	 * @return the first matching user notification event
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
-	public static UserNotificationEvent findByU_D_A_First(
+	public static UserNotificationEvent findByU_D_AR_First(
 			long userId, boolean delivered, boolean actionRequired,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws com.liferay.portal.kernel.exception.
 			NoSuchUserNotificationEventException {
 
-		return getPersistence().findByU_D_A_First(
+		return getPersistence().findByU_D_AR_First(
 			userId, delivered, actionRequired, orderByComparator);
 	}
 
@@ -1924,11 +1924,11 @@ public class UserNotificationEventUtil {
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
-	public static UserNotificationEvent fetchByU_D_A_First(
+	public static UserNotificationEvent fetchByU_D_AR_First(
 		long userId, boolean delivered, boolean actionRequired,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		return getPersistence().fetchByU_D_A_First(
+		return getPersistence().fetchByU_D_AR_First(
 			userId, delivered, actionRequired, orderByComparator);
 	}
 
@@ -1942,13 +1942,13 @@ public class UserNotificationEventUtil {
 	 * @return the last matching user notification event
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
-	public static UserNotificationEvent findByU_D_A_Last(
+	public static UserNotificationEvent findByU_D_AR_Last(
 			long userId, boolean delivered, boolean actionRequired,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws com.liferay.portal.kernel.exception.
 			NoSuchUserNotificationEventException {
 
-		return getPersistence().findByU_D_A_Last(
+		return getPersistence().findByU_D_AR_Last(
 			userId, delivered, actionRequired, orderByComparator);
 	}
 
@@ -1961,11 +1961,11 @@ public class UserNotificationEventUtil {
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
-	public static UserNotificationEvent fetchByU_D_A_Last(
+	public static UserNotificationEvent fetchByU_D_AR_Last(
 		long userId, boolean delivered, boolean actionRequired,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		return getPersistence().fetchByU_D_A_Last(
+		return getPersistence().fetchByU_D_AR_Last(
 			userId, delivered, actionRequired, orderByComparator);
 	}
 
@@ -1980,14 +1980,14 @@ public class UserNotificationEventUtil {
 	 * @return the previous, current, and next user notification event
 	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
 	 */
-	public static UserNotificationEvent[] findByU_D_A_PrevAndNext(
+	public static UserNotificationEvent[] findByU_D_AR_PrevAndNext(
 			long userNotificationEventId, long userId, boolean delivered,
 			boolean actionRequired,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws com.liferay.portal.kernel.exception.
 			NoSuchUserNotificationEventException {
 
-		return getPersistence().findByU_D_A_PrevAndNext(
+		return getPersistence().findByU_D_AR_PrevAndNext(
 			userNotificationEventId, userId, delivered, actionRequired,
 			orderByComparator);
 	}
@@ -1999,10 +1999,10 @@ public class UserNotificationEventUtil {
 	 * @param delivered the delivered
 	 * @param actionRequired the action required
 	 */
-	public static void removeByU_D_A(
+	public static void removeByU_D_AR(
 		long userId, boolean delivered, boolean actionRequired) {
 
-		getPersistence().removeByU_D_A(userId, delivered, actionRequired);
+		getPersistence().removeByU_D_AR(userId, delivered, actionRequired);
 	}
 
 	/**
@@ -2013,10 +2013,219 @@ public class UserNotificationEventUtil {
 	 * @param actionRequired the action required
 	 * @return the number of matching user notification events
 	 */
-	public static int countByU_D_A(
+	public static int countByU_D_AR(
 		long userId, boolean delivered, boolean actionRequired) {
 
-		return getPersistence().countByU_D_A(userId, delivered, actionRequired);
+		return getPersistence().countByU_D_AR(
+			userId, delivered, actionRequired);
+	}
+
+	/**
+	 * Returns all the user notification events where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @return the matching user notification events
+	 */
+	public static List<UserNotificationEvent> findByU_D_A(
+		long userId, boolean delivered, boolean archived) {
+
+		return getPersistence().findByU_D_A(userId, delivered, archived);
+	}
+
+	/**
+	 * Returns a range of all the user notification events where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @return the range of matching user notification events
+	 */
+	public static List<UserNotificationEvent> findByU_D_A(
+		long userId, boolean delivered, boolean archived, int start, int end) {
+
+		return getPersistence().findByU_D_A(
+			userId, delivered, archived, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching user notification events
+	 */
+	public static List<UserNotificationEvent> findByU_D_A(
+		long userId, boolean delivered, boolean archived, int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		return getPersistence().findByU_D_A(
+			userId, delivered, archived, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching user notification events
+	 */
+	public static List<UserNotificationEvent> findByU_D_A(
+		long userId, boolean delivered, boolean archived, int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByU_D_A(
+			userId, delivered, archived, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	public static UserNotificationEvent findByU_D_A_First(
+			long userId, boolean delivered, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws com.liferay.portal.kernel.exception.
+			NoSuchUserNotificationEventException {
+
+		return getPersistence().findByU_D_A_First(
+			userId, delivered, archived, orderByComparator);
+	}
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	public static UserNotificationEvent fetchByU_D_A_First(
+		long userId, boolean delivered, boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		return getPersistence().fetchByU_D_A_First(
+			userId, delivered, archived, orderByComparator);
+	}
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	public static UserNotificationEvent findByU_D_A_Last(
+			long userId, boolean delivered, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws com.liferay.portal.kernel.exception.
+			NoSuchUserNotificationEventException {
+
+		return getPersistence().findByU_D_A_Last(
+			userId, delivered, archived, orderByComparator);
+	}
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	public static UserNotificationEvent fetchByU_D_A_Last(
+		long userId, boolean delivered, boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		return getPersistence().fetchByU_D_A_Last(
+			userId, delivered, archived, orderByComparator);
+	}
+
+	/**
+	 * Returns the user notification events before and after the current user notification event in the ordered set where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userNotificationEventId the primary key of the current user notification event
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next user notification event
+	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
+	 */
+	public static UserNotificationEvent[] findByU_D_A_PrevAndNext(
+			long userNotificationEventId, long userId, boolean delivered,
+			boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws com.liferay.portal.kernel.exception.
+			NoSuchUserNotificationEventException {
+
+		return getPersistence().findByU_D_A_PrevAndNext(
+			userNotificationEventId, userId, delivered, archived,
+			orderByComparator);
+	}
+
+	/**
+	 * Removes all the user notification events where userId = &#63; and delivered = &#63; and archived = &#63; from the database.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 */
+	public static void removeByU_D_A(
+		long userId, boolean delivered, boolean archived) {
+
+		getPersistence().removeByU_D_A(userId, delivered, archived);
+	}
+
+	/**
+	 * Returns the number of user notification events where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @return the number of matching user notification events
+	 */
+	public static int countByU_D_A(
+		long userId, boolean delivered, boolean archived) {
+
+		return getPersistence().countByU_D_A(userId, delivered, archived);
 	}
 
 	/**
@@ -2027,10 +2236,10 @@ public class UserNotificationEventUtil {
 	 * @param archived the archived
 	 * @return the matching user notification events
 	 */
-	public static List<UserNotificationEvent> findByU_A_A(
+	public static List<UserNotificationEvent> findByU_AR_A(
 		long userId, boolean actionRequired, boolean archived) {
 
-		return getPersistence().findByU_A_A(userId, actionRequired, archived);
+		return getPersistence().findByU_AR_A(userId, actionRequired, archived);
 	}
 
 	/**
@@ -2047,11 +2256,11 @@ public class UserNotificationEventUtil {
 	 * @param end the upper bound of the range of user notification events (not inclusive)
 	 * @return the range of matching user notification events
 	 */
-	public static List<UserNotificationEvent> findByU_A_A(
+	public static List<UserNotificationEvent> findByU_AR_A(
 		long userId, boolean actionRequired, boolean archived, int start,
 		int end) {
 
-		return getPersistence().findByU_A_A(
+		return getPersistence().findByU_AR_A(
 			userId, actionRequired, archived, start, end);
 	}
 
@@ -2070,11 +2279,11 @@ public class UserNotificationEventUtil {
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching user notification events
 	 */
-	public static List<UserNotificationEvent> findByU_A_A(
+	public static List<UserNotificationEvent> findByU_AR_A(
 		long userId, boolean actionRequired, boolean archived, int start,
 		int end, OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		return getPersistence().findByU_A_A(
+		return getPersistence().findByU_AR_A(
 			userId, actionRequired, archived, start, end, orderByComparator);
 	}
 
@@ -2094,12 +2303,12 @@ public class UserNotificationEventUtil {
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the ordered range of matching user notification events
 	 */
-	public static List<UserNotificationEvent> findByU_A_A(
+	public static List<UserNotificationEvent> findByU_AR_A(
 		long userId, boolean actionRequired, boolean archived, int start,
 		int end, OrderByComparator<UserNotificationEvent> orderByComparator,
 		boolean useFinderCache) {
 
-		return getPersistence().findByU_A_A(
+		return getPersistence().findByU_AR_A(
 			userId, actionRequired, archived, start, end, orderByComparator,
 			useFinderCache);
 	}
@@ -2114,13 +2323,13 @@ public class UserNotificationEventUtil {
 	 * @return the first matching user notification event
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
-	public static UserNotificationEvent findByU_A_A_First(
+	public static UserNotificationEvent findByU_AR_A_First(
 			long userId, boolean actionRequired, boolean archived,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws com.liferay.portal.kernel.exception.
 			NoSuchUserNotificationEventException {
 
-		return getPersistence().findByU_A_A_First(
+		return getPersistence().findByU_AR_A_First(
 			userId, actionRequired, archived, orderByComparator);
 	}
 
@@ -2133,11 +2342,11 @@ public class UserNotificationEventUtil {
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
-	public static UserNotificationEvent fetchByU_A_A_First(
+	public static UserNotificationEvent fetchByU_AR_A_First(
 		long userId, boolean actionRequired, boolean archived,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		return getPersistence().fetchByU_A_A_First(
+		return getPersistence().fetchByU_AR_A_First(
 			userId, actionRequired, archived, orderByComparator);
 	}
 
@@ -2151,13 +2360,13 @@ public class UserNotificationEventUtil {
 	 * @return the last matching user notification event
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
-	public static UserNotificationEvent findByU_A_A_Last(
+	public static UserNotificationEvent findByU_AR_A_Last(
 			long userId, boolean actionRequired, boolean archived,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws com.liferay.portal.kernel.exception.
 			NoSuchUserNotificationEventException {
 
-		return getPersistence().findByU_A_A_Last(
+		return getPersistence().findByU_AR_A_Last(
 			userId, actionRequired, archived, orderByComparator);
 	}
 
@@ -2170,11 +2379,11 @@ public class UserNotificationEventUtil {
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
-	public static UserNotificationEvent fetchByU_A_A_Last(
+	public static UserNotificationEvent fetchByU_AR_A_Last(
 		long userId, boolean actionRequired, boolean archived,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		return getPersistence().fetchByU_A_A_Last(
+		return getPersistence().fetchByU_AR_A_Last(
 			userId, actionRequired, archived, orderByComparator);
 	}
 
@@ -2189,14 +2398,14 @@ public class UserNotificationEventUtil {
 	 * @return the previous, current, and next user notification event
 	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
 	 */
-	public static UserNotificationEvent[] findByU_A_A_PrevAndNext(
+	public static UserNotificationEvent[] findByU_AR_A_PrevAndNext(
 			long userNotificationEventId, long userId, boolean actionRequired,
 			boolean archived,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws com.liferay.portal.kernel.exception.
 			NoSuchUserNotificationEventException {
 
-		return getPersistence().findByU_A_A_PrevAndNext(
+		return getPersistence().findByU_AR_A_PrevAndNext(
 			userNotificationEventId, userId, actionRequired, archived,
 			orderByComparator);
 	}
@@ -2208,10 +2417,10 @@ public class UserNotificationEventUtil {
 	 * @param actionRequired the action required
 	 * @param archived the archived
 	 */
-	public static void removeByU_A_A(
+	public static void removeByU_AR_A(
 		long userId, boolean actionRequired, boolean archived) {
 
-		getPersistence().removeByU_A_A(userId, actionRequired, archived);
+		getPersistence().removeByU_AR_A(userId, actionRequired, archived);
 	}
 
 	/**
@@ -2222,10 +2431,10 @@ public class UserNotificationEventUtil {
 	 * @param archived the archived
 	 * @return the number of matching user notification events
 	 */
-	public static int countByU_A_A(
+	public static int countByU_AR_A(
 		long userId, boolean actionRequired, boolean archived) {
 
-		return getPersistence().countByU_A_A(userId, actionRequired, archived);
+		return getPersistence().countByU_AR_A(userId, actionRequired, archived);
 	}
 
 	/**
@@ -2463,11 +2672,11 @@ public class UserNotificationEventUtil {
 	 * @param actionRequired the action required
 	 * @return the matching user notification events
 	 */
-	public static List<UserNotificationEvent> findByU_DT_D_A(
+	public static List<UserNotificationEvent> findByU_DT_D_AR(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired) {
 
-		return getPersistence().findByU_DT_D_A(
+		return getPersistence().findByU_DT_D_AR(
 			userId, deliveryType, delivered, actionRequired);
 	}
 
@@ -2486,11 +2695,11 @@ public class UserNotificationEventUtil {
 	 * @param end the upper bound of the range of user notification events (not inclusive)
 	 * @return the range of matching user notification events
 	 */
-	public static List<UserNotificationEvent> findByU_DT_D_A(
+	public static List<UserNotificationEvent> findByU_DT_D_AR(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired, int start, int end) {
 
-		return getPersistence().findByU_DT_D_A(
+		return getPersistence().findByU_DT_D_AR(
 			userId, deliveryType, delivered, actionRequired, start, end);
 	}
 
@@ -2510,12 +2719,12 @@ public class UserNotificationEventUtil {
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching user notification events
 	 */
-	public static List<UserNotificationEvent> findByU_DT_D_A(
+	public static List<UserNotificationEvent> findByU_DT_D_AR(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired, int start, int end,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		return getPersistence().findByU_DT_D_A(
+		return getPersistence().findByU_DT_D_AR(
 			userId, deliveryType, delivered, actionRequired, start, end,
 			orderByComparator);
 	}
@@ -2537,13 +2746,13 @@ public class UserNotificationEventUtil {
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the ordered range of matching user notification events
 	 */
-	public static List<UserNotificationEvent> findByU_DT_D_A(
+	public static List<UserNotificationEvent> findByU_DT_D_AR(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired, int start, int end,
 		OrderByComparator<UserNotificationEvent> orderByComparator,
 		boolean useFinderCache) {
 
-		return getPersistence().findByU_DT_D_A(
+		return getPersistence().findByU_DT_D_AR(
 			userId, deliveryType, delivered, actionRequired, start, end,
 			orderByComparator, useFinderCache);
 	}
@@ -2559,14 +2768,14 @@ public class UserNotificationEventUtil {
 	 * @return the first matching user notification event
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
-	public static UserNotificationEvent findByU_DT_D_A_First(
+	public static UserNotificationEvent findByU_DT_D_AR_First(
 			long userId, int deliveryType, boolean delivered,
 			boolean actionRequired,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws com.liferay.portal.kernel.exception.
 			NoSuchUserNotificationEventException {
 
-		return getPersistence().findByU_DT_D_A_First(
+		return getPersistence().findByU_DT_D_AR_First(
 			userId, deliveryType, delivered, actionRequired, orderByComparator);
 	}
 
@@ -2580,12 +2789,12 @@ public class UserNotificationEventUtil {
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
-	public static UserNotificationEvent fetchByU_DT_D_A_First(
+	public static UserNotificationEvent fetchByU_DT_D_AR_First(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		return getPersistence().fetchByU_DT_D_A_First(
+		return getPersistence().fetchByU_DT_D_AR_First(
 			userId, deliveryType, delivered, actionRequired, orderByComparator);
 	}
 
@@ -2600,14 +2809,14 @@ public class UserNotificationEventUtil {
 	 * @return the last matching user notification event
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
-	public static UserNotificationEvent findByU_DT_D_A_Last(
+	public static UserNotificationEvent findByU_DT_D_AR_Last(
 			long userId, int deliveryType, boolean delivered,
 			boolean actionRequired,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws com.liferay.portal.kernel.exception.
 			NoSuchUserNotificationEventException {
 
-		return getPersistence().findByU_DT_D_A_Last(
+		return getPersistence().findByU_DT_D_AR_Last(
 			userId, deliveryType, delivered, actionRequired, orderByComparator);
 	}
 
@@ -2621,12 +2830,12 @@ public class UserNotificationEventUtil {
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
-	public static UserNotificationEvent fetchByU_DT_D_A_Last(
+	public static UserNotificationEvent fetchByU_DT_D_AR_Last(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		return getPersistence().fetchByU_DT_D_A_Last(
+		return getPersistence().fetchByU_DT_D_AR_Last(
 			userId, deliveryType, delivered, actionRequired, orderByComparator);
 	}
 
@@ -2642,14 +2851,14 @@ public class UserNotificationEventUtil {
 	 * @return the previous, current, and next user notification event
 	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
 	 */
-	public static UserNotificationEvent[] findByU_DT_D_A_PrevAndNext(
+	public static UserNotificationEvent[] findByU_DT_D_AR_PrevAndNext(
 			long userNotificationEventId, long userId, int deliveryType,
 			boolean delivered, boolean actionRequired,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws com.liferay.portal.kernel.exception.
 			NoSuchUserNotificationEventException {
 
-		return getPersistence().findByU_DT_D_A_PrevAndNext(
+		return getPersistence().findByU_DT_D_AR_PrevAndNext(
 			userNotificationEventId, userId, deliveryType, delivered,
 			actionRequired, orderByComparator);
 	}
@@ -2662,11 +2871,11 @@ public class UserNotificationEventUtil {
 	 * @param delivered the delivered
 	 * @param actionRequired the action required
 	 */
-	public static void removeByU_DT_D_A(
+	public static void removeByU_DT_D_AR(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired) {
 
-		getPersistence().removeByU_DT_D_A(
+		getPersistence().removeByU_DT_D_AR(
 			userId, deliveryType, delivered, actionRequired);
 	}
 
@@ -2679,12 +2888,238 @@ public class UserNotificationEventUtil {
 	 * @param actionRequired the action required
 	 * @return the number of matching user notification events
 	 */
-	public static int countByU_DT_D_A(
+	public static int countByU_DT_D_AR(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired) {
 
-		return getPersistence().countByU_DT_D_A(
+		return getPersistence().countByU_DT_D_AR(
 			userId, deliveryType, delivered, actionRequired);
+	}
+
+	/**
+	 * Returns all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @return the matching user notification events
+	 */
+	public static List<UserNotificationEvent> findByU_DT_D_A(
+		long userId, int deliveryType, boolean delivered, boolean archived) {
+
+		return getPersistence().findByU_DT_D_A(
+			userId, deliveryType, delivered, archived);
+	}
+
+	/**
+	 * Returns a range of all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @return the range of matching user notification events
+	 */
+	public static List<UserNotificationEvent> findByU_DT_D_A(
+		long userId, int deliveryType, boolean delivered, boolean archived,
+		int start, int end) {
+
+		return getPersistence().findByU_DT_D_A(
+			userId, deliveryType, delivered, archived, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching user notification events
+	 */
+	public static List<UserNotificationEvent> findByU_DT_D_A(
+		long userId, int deliveryType, boolean delivered, boolean archived,
+		int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		return getPersistence().findByU_DT_D_A(
+			userId, deliveryType, delivered, archived, start, end,
+			orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching user notification events
+	 */
+	public static List<UserNotificationEvent> findByU_DT_D_A(
+		long userId, int deliveryType, boolean delivered, boolean archived,
+		int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByU_DT_D_A(
+			userId, deliveryType, delivered, archived, start, end,
+			orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	public static UserNotificationEvent findByU_DT_D_A_First(
+			long userId, int deliveryType, boolean delivered, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws com.liferay.portal.kernel.exception.
+			NoSuchUserNotificationEventException {
+
+		return getPersistence().findByU_DT_D_A_First(
+			userId, deliveryType, delivered, archived, orderByComparator);
+	}
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	public static UserNotificationEvent fetchByU_DT_D_A_First(
+		long userId, int deliveryType, boolean delivered, boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		return getPersistence().fetchByU_DT_D_A_First(
+			userId, deliveryType, delivered, archived, orderByComparator);
+	}
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	public static UserNotificationEvent findByU_DT_D_A_Last(
+			long userId, int deliveryType, boolean delivered, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws com.liferay.portal.kernel.exception.
+			NoSuchUserNotificationEventException {
+
+		return getPersistence().findByU_DT_D_A_Last(
+			userId, deliveryType, delivered, archived, orderByComparator);
+	}
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	public static UserNotificationEvent fetchByU_DT_D_A_Last(
+		long userId, int deliveryType, boolean delivered, boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		return getPersistence().fetchByU_DT_D_A_Last(
+			userId, deliveryType, delivered, archived, orderByComparator);
+	}
+
+	/**
+	 * Returns the user notification events before and after the current user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userNotificationEventId the primary key of the current user notification event
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next user notification event
+	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
+	 */
+	public static UserNotificationEvent[] findByU_DT_D_A_PrevAndNext(
+			long userNotificationEventId, long userId, int deliveryType,
+			boolean delivered, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws com.liferay.portal.kernel.exception.
+			NoSuchUserNotificationEventException {
+
+		return getPersistence().findByU_DT_D_A_PrevAndNext(
+			userNotificationEventId, userId, deliveryType, delivered, archived,
+			orderByComparator);
+	}
+
+	/**
+	 * Removes all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63; from the database.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 */
+	public static void removeByU_DT_D_A(
+		long userId, int deliveryType, boolean delivered, boolean archived) {
+
+		getPersistence().removeByU_DT_D_A(
+			userId, deliveryType, delivered, archived);
+	}
+
+	/**
+	 * Returns the number of user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @return the number of matching user notification events
+	 */
+	public static int countByU_DT_D_A(
+		long userId, int deliveryType, boolean delivered, boolean archived) {
+
+		return getPersistence().countByU_DT_D_A(
+			userId, deliveryType, delivered, archived);
 	}
 
 	/**
@@ -2696,11 +3131,11 @@ public class UserNotificationEventUtil {
 	 * @param archived the archived
 	 * @return the matching user notification events
 	 */
-	public static List<UserNotificationEvent> findByU_DT_A_A(
+	public static List<UserNotificationEvent> findByU_DT_AR_A(
 		long userId, int deliveryType, boolean actionRequired,
 		boolean archived) {
 
-		return getPersistence().findByU_DT_A_A(
+		return getPersistence().findByU_DT_AR_A(
 			userId, deliveryType, actionRequired, archived);
 	}
 
@@ -2719,11 +3154,11 @@ public class UserNotificationEventUtil {
 	 * @param end the upper bound of the range of user notification events (not inclusive)
 	 * @return the range of matching user notification events
 	 */
-	public static List<UserNotificationEvent> findByU_DT_A_A(
+	public static List<UserNotificationEvent> findByU_DT_AR_A(
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		int start, int end) {
 
-		return getPersistence().findByU_DT_A_A(
+		return getPersistence().findByU_DT_AR_A(
 			userId, deliveryType, actionRequired, archived, start, end);
 	}
 
@@ -2743,12 +3178,12 @@ public class UserNotificationEventUtil {
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching user notification events
 	 */
-	public static List<UserNotificationEvent> findByU_DT_A_A(
+	public static List<UserNotificationEvent> findByU_DT_AR_A(
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		int start, int end,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		return getPersistence().findByU_DT_A_A(
+		return getPersistence().findByU_DT_AR_A(
 			userId, deliveryType, actionRequired, archived, start, end,
 			orderByComparator);
 	}
@@ -2770,13 +3205,13 @@ public class UserNotificationEventUtil {
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the ordered range of matching user notification events
 	 */
-	public static List<UserNotificationEvent> findByU_DT_A_A(
+	public static List<UserNotificationEvent> findByU_DT_AR_A(
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		int start, int end,
 		OrderByComparator<UserNotificationEvent> orderByComparator,
 		boolean useFinderCache) {
 
-		return getPersistence().findByU_DT_A_A(
+		return getPersistence().findByU_DT_AR_A(
 			userId, deliveryType, actionRequired, archived, start, end,
 			orderByComparator, useFinderCache);
 	}
@@ -2792,14 +3227,14 @@ public class UserNotificationEventUtil {
 	 * @return the first matching user notification event
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
-	public static UserNotificationEvent findByU_DT_A_A_First(
+	public static UserNotificationEvent findByU_DT_AR_A_First(
 			long userId, int deliveryType, boolean actionRequired,
 			boolean archived,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws com.liferay.portal.kernel.exception.
 			NoSuchUserNotificationEventException {
 
-		return getPersistence().findByU_DT_A_A_First(
+		return getPersistence().findByU_DT_AR_A_First(
 			userId, deliveryType, actionRequired, archived, orderByComparator);
 	}
 
@@ -2813,11 +3248,11 @@ public class UserNotificationEventUtil {
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
-	public static UserNotificationEvent fetchByU_DT_A_A_First(
+	public static UserNotificationEvent fetchByU_DT_AR_A_First(
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		return getPersistence().fetchByU_DT_A_A_First(
+		return getPersistence().fetchByU_DT_AR_A_First(
 			userId, deliveryType, actionRequired, archived, orderByComparator);
 	}
 
@@ -2832,14 +3267,14 @@ public class UserNotificationEventUtil {
 	 * @return the last matching user notification event
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
-	public static UserNotificationEvent findByU_DT_A_A_Last(
+	public static UserNotificationEvent findByU_DT_AR_A_Last(
 			long userId, int deliveryType, boolean actionRequired,
 			boolean archived,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws com.liferay.portal.kernel.exception.
 			NoSuchUserNotificationEventException {
 
-		return getPersistence().findByU_DT_A_A_Last(
+		return getPersistence().findByU_DT_AR_A_Last(
 			userId, deliveryType, actionRequired, archived, orderByComparator);
 	}
 
@@ -2853,11 +3288,11 @@ public class UserNotificationEventUtil {
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
-	public static UserNotificationEvent fetchByU_DT_A_A_Last(
+	public static UserNotificationEvent fetchByU_DT_AR_A_Last(
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		return getPersistence().fetchByU_DT_A_A_Last(
+		return getPersistence().fetchByU_DT_AR_A_Last(
 			userId, deliveryType, actionRequired, archived, orderByComparator);
 	}
 
@@ -2873,14 +3308,14 @@ public class UserNotificationEventUtil {
 	 * @return the previous, current, and next user notification event
 	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
 	 */
-	public static UserNotificationEvent[] findByU_DT_A_A_PrevAndNext(
+	public static UserNotificationEvent[] findByU_DT_AR_A_PrevAndNext(
 			long userNotificationEventId, long userId, int deliveryType,
 			boolean actionRequired, boolean archived,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws com.liferay.portal.kernel.exception.
 			NoSuchUserNotificationEventException {
 
-		return getPersistence().findByU_DT_A_A_PrevAndNext(
+		return getPersistence().findByU_DT_AR_A_PrevAndNext(
 			userNotificationEventId, userId, deliveryType, actionRequired,
 			archived, orderByComparator);
 	}
@@ -2893,11 +3328,11 @@ public class UserNotificationEventUtil {
 	 * @param actionRequired the action required
 	 * @param archived the archived
 	 */
-	public static void removeByU_DT_A_A(
+	public static void removeByU_DT_AR_A(
 		long userId, int deliveryType, boolean actionRequired,
 		boolean archived) {
 
-		getPersistence().removeByU_DT_A_A(
+		getPersistence().removeByU_DT_AR_A(
 			userId, deliveryType, actionRequired, archived);
 	}
 
@@ -2910,12 +3345,494 @@ public class UserNotificationEventUtil {
 	 * @param archived the archived
 	 * @return the number of matching user notification events
 	 */
-	public static int countByU_DT_A_A(
+	public static int countByU_DT_AR_A(
 		long userId, int deliveryType, boolean actionRequired,
 		boolean archived) {
 
-		return getPersistence().countByU_DT_A_A(
+		return getPersistence().countByU_DT_AR_A(
 			userId, deliveryType, actionRequired, archived);
+	}
+
+	/**
+	 * Returns all the user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @return the matching user notification events
+	 */
+	public static List<UserNotificationEvent> findByU_D_AR_A(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived) {
+
+		return getPersistence().findByU_D_AR_A(
+			userId, delivered, actionRequired, archived);
+	}
+
+	/**
+	 * Returns a range of all the user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @return the range of matching user notification events
+	 */
+	public static List<UserNotificationEvent> findByU_D_AR_A(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived, int start, int end) {
+
+		return getPersistence().findByU_D_AR_A(
+			userId, delivered, actionRequired, archived, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching user notification events
+	 */
+	public static List<UserNotificationEvent> findByU_D_AR_A(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived, int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		return getPersistence().findByU_D_AR_A(
+			userId, delivered, actionRequired, archived, start, end,
+			orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching user notification events
+	 */
+	public static List<UserNotificationEvent> findByU_D_AR_A(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived, int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByU_D_AR_A(
+			userId, delivered, actionRequired, archived, start, end,
+			orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	public static UserNotificationEvent findByU_D_AR_A_First(
+			long userId, boolean delivered, boolean actionRequired,
+			boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws com.liferay.portal.kernel.exception.
+			NoSuchUserNotificationEventException {
+
+		return getPersistence().findByU_D_AR_A_First(
+			userId, delivered, actionRequired, archived, orderByComparator);
+	}
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	public static UserNotificationEvent fetchByU_D_AR_A_First(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		return getPersistence().fetchByU_D_AR_A_First(
+			userId, delivered, actionRequired, archived, orderByComparator);
+	}
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	public static UserNotificationEvent findByU_D_AR_A_Last(
+			long userId, boolean delivered, boolean actionRequired,
+			boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws com.liferay.portal.kernel.exception.
+			NoSuchUserNotificationEventException {
+
+		return getPersistence().findByU_D_AR_A_Last(
+			userId, delivered, actionRequired, archived, orderByComparator);
+	}
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	public static UserNotificationEvent fetchByU_D_AR_A_Last(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		return getPersistence().fetchByU_D_AR_A_Last(
+			userId, delivered, actionRequired, archived, orderByComparator);
+	}
+
+	/**
+	 * Returns the user notification events before and after the current user notification event in the ordered set where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userNotificationEventId the primary key of the current user notification event
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next user notification event
+	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
+	 */
+	public static UserNotificationEvent[] findByU_D_AR_A_PrevAndNext(
+			long userNotificationEventId, long userId, boolean delivered,
+			boolean actionRequired, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws com.liferay.portal.kernel.exception.
+			NoSuchUserNotificationEventException {
+
+		return getPersistence().findByU_D_AR_A_PrevAndNext(
+			userNotificationEventId, userId, delivered, actionRequired,
+			archived, orderByComparator);
+	}
+
+	/**
+	 * Removes all the user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63; from the database.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 */
+	public static void removeByU_D_AR_A(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived) {
+
+		getPersistence().removeByU_D_AR_A(
+			userId, delivered, actionRequired, archived);
+	}
+
+	/**
+	 * Returns the number of user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @return the number of matching user notification events
+	 */
+	public static int countByU_D_AR_A(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived) {
+
+		return getPersistence().countByU_D_AR_A(
+			userId, delivered, actionRequired, archived);
+	}
+
+	/**
+	 * Returns all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @return the matching user notification events
+	 */
+	public static List<UserNotificationEvent> findByU_DT_D_AR_A(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived) {
+
+		return getPersistence().findByU_DT_D_AR_A(
+			userId, deliveryType, delivered, actionRequired, archived);
+	}
+
+	/**
+	 * Returns a range of all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @return the range of matching user notification events
+	 */
+	public static List<UserNotificationEvent> findByU_DT_D_AR_A(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived, int start, int end) {
+
+		return getPersistence().findByU_DT_D_AR_A(
+			userId, deliveryType, delivered, actionRequired, archived, start,
+			end);
+	}
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching user notification events
+	 */
+	public static List<UserNotificationEvent> findByU_DT_D_AR_A(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived, int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		return getPersistence().findByU_DT_D_AR_A(
+			userId, deliveryType, delivered, actionRequired, archived, start,
+			end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching user notification events
+	 */
+	public static List<UserNotificationEvent> findByU_DT_D_AR_A(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived, int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByU_DT_D_AR_A(
+			userId, deliveryType, delivered, actionRequired, archived, start,
+			end, orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	public static UserNotificationEvent findByU_DT_D_AR_A_First(
+			long userId, int deliveryType, boolean delivered,
+			boolean actionRequired, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws com.liferay.portal.kernel.exception.
+			NoSuchUserNotificationEventException {
+
+		return getPersistence().findByU_DT_D_AR_A_First(
+			userId, deliveryType, delivered, actionRequired, archived,
+			orderByComparator);
+	}
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	public static UserNotificationEvent fetchByU_DT_D_AR_A_First(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		return getPersistence().fetchByU_DT_D_AR_A_First(
+			userId, deliveryType, delivered, actionRequired, archived,
+			orderByComparator);
+	}
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	public static UserNotificationEvent findByU_DT_D_AR_A_Last(
+			long userId, int deliveryType, boolean delivered,
+			boolean actionRequired, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws com.liferay.portal.kernel.exception.
+			NoSuchUserNotificationEventException {
+
+		return getPersistence().findByU_DT_D_AR_A_Last(
+			userId, deliveryType, delivered, actionRequired, archived,
+			orderByComparator);
+	}
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	public static UserNotificationEvent fetchByU_DT_D_AR_A_Last(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		return getPersistence().fetchByU_DT_D_AR_A_Last(
+			userId, deliveryType, delivered, actionRequired, archived,
+			orderByComparator);
+	}
+
+	/**
+	 * Returns the user notification events before and after the current user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userNotificationEventId the primary key of the current user notification event
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next user notification event
+	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
+	 */
+	public static UserNotificationEvent[] findByU_DT_D_AR_A_PrevAndNext(
+			long userNotificationEventId, long userId, int deliveryType,
+			boolean delivered, boolean actionRequired, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws com.liferay.portal.kernel.exception.
+			NoSuchUserNotificationEventException {
+
+		return getPersistence().findByU_DT_D_AR_A_PrevAndNext(
+			userNotificationEventId, userId, deliveryType, delivered,
+			actionRequired, archived, orderByComparator);
+	}
+
+	/**
+	 * Removes all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63; from the database.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 */
+	public static void removeByU_DT_D_AR_A(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived) {
+
+		getPersistence().removeByU_DT_D_AR_A(
+			userId, deliveryType, delivered, actionRequired, archived);
+	}
+
+	/**
+	 * Returns the number of user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @return the number of matching user notification events
+	 */
+	public static int countByU_DT_D_AR_A(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived) {
+
+		return getPersistence().countByU_DT_D_AR_A(
+			userId, deliveryType, delivered, actionRequired, archived);
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/UserNotificationEventUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/UserNotificationEventUtil.java
@@ -3587,6 +3587,250 @@ public class UserNotificationEventUtil {
 	}
 
 	/**
+	 * Returns all the user notification events where userId = &#63; and type = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param type the type
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @return the matching user notification events
+	 */
+	public static List<UserNotificationEvent> findByU_T_DT_D_A(
+		long userId, String type, int deliveryType, boolean delivered,
+		boolean archived) {
+
+		return getPersistence().findByU_T_DT_D_A(
+			userId, type, deliveryType, delivered, archived);
+	}
+
+	/**
+	 * Returns a range of all the user notification events where userId = &#63; and type = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param type the type
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @return the range of matching user notification events
+	 */
+	public static List<UserNotificationEvent> findByU_T_DT_D_A(
+		long userId, String type, int deliveryType, boolean delivered,
+		boolean archived, int start, int end) {
+
+		return getPersistence().findByU_T_DT_D_A(
+			userId, type, deliveryType, delivered, archived, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and type = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param type the type
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching user notification events
+	 */
+	public static List<UserNotificationEvent> findByU_T_DT_D_A(
+		long userId, String type, int deliveryType, boolean delivered,
+		boolean archived, int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		return getPersistence().findByU_T_DT_D_A(
+			userId, type, deliveryType, delivered, archived, start, end,
+			orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and type = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param type the type
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching user notification events
+	 */
+	public static List<UserNotificationEvent> findByU_T_DT_D_A(
+		long userId, String type, int deliveryType, boolean delivered,
+		boolean archived, int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByU_T_DT_D_A(
+			userId, type, deliveryType, delivered, archived, start, end,
+			orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and type = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param type the type
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	public static UserNotificationEvent findByU_T_DT_D_A_First(
+			long userId, String type, int deliveryType, boolean delivered,
+			boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws com.liferay.portal.kernel.exception.
+			NoSuchUserNotificationEventException {
+
+		return getPersistence().findByU_T_DT_D_A_First(
+			userId, type, deliveryType, delivered, archived, orderByComparator);
+	}
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and type = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param type the type
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	public static UserNotificationEvent fetchByU_T_DT_D_A_First(
+		long userId, String type, int deliveryType, boolean delivered,
+		boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		return getPersistence().fetchByU_T_DT_D_A_First(
+			userId, type, deliveryType, delivered, archived, orderByComparator);
+	}
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and type = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param type the type
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	public static UserNotificationEvent findByU_T_DT_D_A_Last(
+			long userId, String type, int deliveryType, boolean delivered,
+			boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws com.liferay.portal.kernel.exception.
+			NoSuchUserNotificationEventException {
+
+		return getPersistence().findByU_T_DT_D_A_Last(
+			userId, type, deliveryType, delivered, archived, orderByComparator);
+	}
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and type = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param type the type
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	public static UserNotificationEvent fetchByU_T_DT_D_A_Last(
+		long userId, String type, int deliveryType, boolean delivered,
+		boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		return getPersistence().fetchByU_T_DT_D_A_Last(
+			userId, type, deliveryType, delivered, archived, orderByComparator);
+	}
+
+	/**
+	 * Returns the user notification events before and after the current user notification event in the ordered set where userId = &#63; and type = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userNotificationEventId the primary key of the current user notification event
+	 * @param userId the user ID
+	 * @param type the type
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next user notification event
+	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
+	 */
+	public static UserNotificationEvent[] findByU_T_DT_D_A_PrevAndNext(
+			long userNotificationEventId, long userId, String type,
+			int deliveryType, boolean delivered, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws com.liferay.portal.kernel.exception.
+			NoSuchUserNotificationEventException {
+
+		return getPersistence().findByU_T_DT_D_A_PrevAndNext(
+			userNotificationEventId, userId, type, deliveryType, delivered,
+			archived, orderByComparator);
+	}
+
+	/**
+	 * Removes all the user notification events where userId = &#63; and type = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63; from the database.
+	 *
+	 * @param userId the user ID
+	 * @param type the type
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 */
+	public static void removeByU_T_DT_D_A(
+		long userId, String type, int deliveryType, boolean delivered,
+		boolean archived) {
+
+		getPersistence().removeByU_T_DT_D_A(
+			userId, type, deliveryType, delivered, archived);
+	}
+
+	/**
+	 * Returns the number of user notification events where userId = &#63; and type = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param type the type
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @return the number of matching user notification events
+	 */
+	public static int countByU_T_DT_D_A(
+		long userId, String type, int deliveryType, boolean delivered,
+		boolean archived) {
+
+		return getPersistence().countByU_T_DT_D_A(
+			userId, type, deliveryType, delivered, archived);
+	}
+
+	/**
 	 * Returns all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
 	 *
 	 * @param userId the user ID

--- a/portal-kernel/src/com/liferay/portal/kernel/util/SubscriptionSender.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/SubscriptionSender.java
@@ -334,6 +334,10 @@ public class SubscriptionSender implements Serializable {
 		return bulk;
 	}
 
+	public void sendEmailNotification(long userId) throws Exception {
+		sendEmailNotification(UserLocalServiceUtil.getUser(userId));
+	}
+
 	public void setBody(String body) {
 		this.body = body;
 	}
@@ -749,11 +753,23 @@ public class SubscriptionSender implements Serializable {
 		).put(
 			"classPK", _classPK
 		).put(
+			"context", _context
+		).put(
 			"entryTitle", _entryTitle
 		).put(
 			"entryURL", _entryURL
 		).put(
+			"localizedBodyMap", localizedBodyMap
+		).put(
+			"localizedContext", _localizedContext
+		).put(
+			"localizedSubjectMap", localizedSubjectMap
+		).put(
+			"mailId", mailId
+		).put(
 			"notificationType", _notificationType
+		).put(
+			"portletId", portletId
 		).put(
 			"userId", currentUserId
 		);

--- a/portal-kernel/src/com/liferay/portal/kernel/util/SubscriptionSender.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/SubscriptionSender.java
@@ -102,6 +102,13 @@ public class SubscriptionSender implements Serializable {
 		hooks.add(hook);
 	}
 
+	public void addPersistedStagingSubscribers(String className, long classPK) {
+		ObjectValuePair<String, Long> ovp = new ObjectValuePair<>(
+			className, classPK);
+
+		_persistestedStagingSubscribersOVPs.add(ovp);
+	}
+
 	public void addPersistedSubscribers(String className, long classPK) {
 		ObjectValuePair<String, Long> ovp = new ObjectValuePair<>(
 			className, classPK);
@@ -153,6 +160,30 @@ public class SubscriptionSender implements Serializable {
 			}
 
 			_persistestedSubscribersOVPs.clear();
+
+			for (ObjectValuePair<String, Long> ovp :
+					_persistestedStagingSubscribersOVPs) {
+
+				String className = ovp.getKey();
+				long classPK = ovp.getValue();
+
+				List<Subscription> subscriptions =
+					SubscriptionLocalServiceUtil.getSubscriptions(
+						companyId, className, classPK);
+
+				for (Subscription subscription : subscriptions) {
+					try {
+						notifyPersistedSubscriber(subscription, false);
+					}
+					catch (Exception e) {
+						_log.error(
+							"Unable to process subscription: " + subscription,
+							e);
+					}
+				}
+			}
+
+			_persistestedStagingSubscribersOVPs.clear();
 
 			for (ObjectValuePair<String, String> ovp :
 					_runtimeSubscribersOVPs) {
@@ -575,11 +606,27 @@ public class SubscriptionSender implements Serializable {
 	protected void notifyPersistedSubscriber(Subscription subscription)
 		throws Exception {
 
-		notifyPersistedSubscriber(subscription, _className, _classPK);
+		notifyPersistedSubscriber(subscription, true);
+	}
+
+	protected void notifyPersistedSubscriber(
+			Subscription subscription, boolean notifyImmediately)
+		throws Exception {
+
+		notifyPersistedSubscriber(
+			subscription, _className, _classPK, notifyImmediately);
 	}
 
 	protected void notifyPersistedSubscriber(
 			Subscription subscription, String className, long classPK)
+		throws Exception {
+
+		notifyPersistedSubscriber(subscription, _className, _classPK, true);
+	}
+
+	protected void notifyPersistedSubscriber(
+			Subscription subscription, String className, long classPK,
+			boolean notifyImmediately)
 		throws Exception {
 
 		User user = UserLocalServiceUtil.fetchUserById(
@@ -599,21 +646,42 @@ public class SubscriptionSender implements Serializable {
 
 		String emailAddress = user.getEmailAddress();
 
-		if (_sentEmailAddresses.contains(emailAddress)) {
-			if (_log.isDebugEnabled()) {
-				_log.debug("Do not send a duplicate email to " + emailAddress);
+		if (notifyImmediately) {
+			if (_sentEmailAddresses.contains(emailAddress)) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						"Do not send a duplicate email to " + emailAddress);
+				}
+
+				return;
 			}
 
-			return;
-		}
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Add " + emailAddress +
+						" to the list of users who have received an email");
+			}
 
-		if (_log.isDebugEnabled()) {
-			_log.debug(
-				"Add " + emailAddress +
-					" to the list of users who have received an email");
+			_sentEmailAddresses.add(emailAddress);
 		}
+		else {
+			if (_stagingOutboxEmailAddresses.contains(emailAddress)) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						"Do not send a duplicate email to " + emailAddress);
+				}
 
-		_sentEmailAddresses.add(emailAddress);
+				return;
+			}
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Add " + emailAddress +
+						" to the list of users who will receive an email");
+			}
+
+			_stagingOutboxEmailAddresses.add(emailAddress);
+		}
 
 		if (!user.isActive()) {
 			if (_log.isDebugEnabled()) {
@@ -640,7 +708,7 @@ public class SubscriptionSender implements Serializable {
 
 		_notifyHooks(Hook.Event.PERSISTED_SUBSCRIBER_FOUND, subscription);
 
-		sendNotification(user);
+		sendNotification(user, notifyImmediately);
 	}
 
 	protected void notifyRuntimeSubscriber(InternetAddress to, Locale locale)
@@ -836,6 +904,12 @@ public class SubscriptionSender implements Serializable {
 	}
 
 	protected void sendNotification(User user) throws Exception {
+		sendNotification(user, true);
+	}
+
+	protected void sendNotification(User user, boolean notifyImmediately)
+		throws Exception {
+
 		if (currentUserId == user.getUserId()) {
 			if (_log.isDebugEnabled()) {
 				_log.debug("Skip user " + currentUserId);
@@ -844,11 +918,20 @@ public class SubscriptionSender implements Serializable {
 			return;
 		}
 
-		sendEmailNotification(user);
-		sendUserNotification(user);
+		if (notifyImmediately) {
+			sendEmailNotification(user);
+		}
+
+		sendUserNotification(user, notifyImmediately);
 	}
 
 	protected void sendUserNotification(User user) throws Exception {
+		sendNotification(user, true);
+	}
+
+	protected void sendUserNotification(User user, boolean notifyImmediately)
+		throws Exception {
+
 		JSONObject notificationEventJSONObject =
 			JSONFactoryUtil.createJSONObject();
 
@@ -859,10 +942,20 @@ public class SubscriptionSender implements Serializable {
 				_notificationType,
 				UserNotificationDeliveryConstants.TYPE_PUSH)) {
 
-			UserNotificationEventLocalServiceUtil.sendUserNotificationEvents(
-				user.getUserId(), portletId,
-				UserNotificationDeliveryConstants.TYPE_PUSH,
-				notificationEventJSONObject);
+			if (notifyImmediately) {
+				UserNotificationEventLocalServiceUtil.
+					sendUserNotificationEvents(
+						user.getUserId(), portletId,
+						UserNotificationDeliveryConstants.TYPE_PUSH,
+						notificationEventJSONObject);
+			}
+			else {
+				UserNotificationEventLocalServiceUtil.
+					storeUserNotificationEvents(
+						user.getUserId(), portletId,
+						UserNotificationDeliveryConstants.TYPE_PUSH, false,
+						notificationEventJSONObject);
+			}
 		}
 
 		if (UserNotificationManagerUtil.isDeliver(
@@ -870,10 +963,20 @@ public class SubscriptionSender implements Serializable {
 				_notificationType,
 				UserNotificationDeliveryConstants.TYPE_WEBSITE)) {
 
-			UserNotificationEventLocalServiceUtil.sendUserNotificationEvents(
-				user.getUserId(), portletId,
-				UserNotificationDeliveryConstants.TYPE_WEBSITE,
-				notificationEventJSONObject);
+			if (notifyImmediately) {
+				UserNotificationEventLocalServiceUtil.
+					sendUserNotificationEvents(
+						user.getUserId(), portletId,
+						UserNotificationDeliveryConstants.TYPE_WEBSITE,
+						notificationEventJSONObject);
+			}
+			else {
+				UserNotificationEventLocalServiceUtil.
+					storeUserNotificationEvents(
+						user.getUserId(), portletId,
+						UserNotificationDeliveryConstants.TYPE_WEBSITE, false,
+						notificationEventJSONObject);
+			}
 		}
 	}
 
@@ -1029,9 +1132,12 @@ public class SubscriptionSender implements Serializable {
 	private long _notificationClassNameId;
 	private int _notificationType;
 	private final List<ObjectValuePair<String, Long>>
+		_persistestedStagingSubscribersOVPs = new ArrayList<>();
+	private final List<ObjectValuePair<String, Long>>
 		_persistestedSubscribersOVPs = new ArrayList<>();
 	private final List<ObjectValuePair<String, String>>
 		_runtimeSubscribersOVPs = new ArrayList<>();
 	private final Set<String> _sentEmailAddresses = new HashSet<>();
+	private final Set<String> _stagingOutboxEmailAddresses = new HashSet<>();
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/util/SubscriptionSender.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/SubscriptionSender.java
@@ -642,7 +642,7 @@ public class SubscriptionSender implements Serializable {
 			_sentEmailAddresses.add(emailAddress);
 		}
 		else {
-			if (_stagingOutboxEmailAddresses.contains(emailAddress)) {
+			if (_delayedSentEmailAddresses.contains(emailAddress)) {
 				if (_log.isDebugEnabled()) {
 					_log.debug(
 						"Do not send a duplicate email to " + emailAddress);
@@ -657,7 +657,7 @@ public class SubscriptionSender implements Serializable {
 						" to the list of users who will receive an email");
 			}
 
-			_stagingOutboxEmailAddresses.add(emailAddress);
+			_delayedSentEmailAddresses.add(emailAddress);
 		}
 
 		if (!user.isActive()) {
@@ -1104,6 +1104,6 @@ public class SubscriptionSender implements Serializable {
 	private final List<ObjectValuePair<String, String>>
 		_runtimeSubscribersOVPs = new ArrayList<>();
 	private final Set<String> _sentEmailAddresses = new HashSet<>();
-	private final Set<String> _stagingOutboxEmailAddresses = new HashSet<>();
+	private final Set<String> _delayedSentEmailAddresses = new HashSet<>();
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/util/SubscriptionSender.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/SubscriptionSender.java
@@ -958,20 +958,10 @@ public class SubscriptionSender implements Serializable {
 				_notificationType,
 				UserNotificationDeliveryConstants.TYPE_PUSH)) {
 
-			if (notifyImmediately) {
-				UserNotificationEventLocalServiceUtil.
-					sendUserNotificationEvents(
-						user.getUserId(), portletId,
-						UserNotificationDeliveryConstants.TYPE_PUSH,
-						notificationEventJSONObject);
-			}
-			else {
-				UserNotificationEventLocalServiceUtil.
-					storeUserNotificationEvents(
-						user.getUserId(), portletId,
-						UserNotificationDeliveryConstants.TYPE_PUSH, false,
-						notificationEventJSONObject);
-			}
+			UserNotificationEventLocalServiceUtil.sendUserNotificationEvents(
+				user.getUserId(), portletId,
+				UserNotificationDeliveryConstants.TYPE_PUSH, notifyImmediately,
+				false, notificationEventJSONObject);
 		}
 
 		if (UserNotificationManagerUtil.isDeliver(
@@ -979,20 +969,10 @@ public class SubscriptionSender implements Serializable {
 				_notificationType,
 				UserNotificationDeliveryConstants.TYPE_WEBSITE)) {
 
-			if (notifyImmediately) {
-				UserNotificationEventLocalServiceUtil.
-					sendUserNotificationEvents(
-						user.getUserId(), portletId,
-						UserNotificationDeliveryConstants.TYPE_WEBSITE,
-						notificationEventJSONObject);
-			}
-			else {
-				UserNotificationEventLocalServiceUtil.
-					storeUserNotificationEvents(
-						user.getUserId(), portletId,
-						UserNotificationDeliveryConstants.TYPE_WEBSITE, false,
-						notificationEventJSONObject);
-			}
+			UserNotificationEventLocalServiceUtil.sendUserNotificationEvents(
+				user.getUserId(), portletId,
+				UserNotificationDeliveryConstants.TYPE_WEBSITE,
+				notifyImmediately, false, notificationEventJSONObject);
 		}
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/SubscriptionSender.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/SubscriptionSender.java
@@ -1090,6 +1090,7 @@ public class SubscriptionSender implements Serializable {
 	private final Map<String, EscapableObject<String>> _context =
 		new HashMap<>();
 	private String _contextCreatorUserPrefix;
+	private final Set<String> _delayedSentEmailAddresses = new HashSet<>();
 	private String _entryTitle;
 	private String _entryURL;
 	private final Map<Hook.Event<?>, List<Hook<?>>> _hooks = new HashMap<>();
@@ -1104,6 +1105,5 @@ public class SubscriptionSender implements Serializable {
 	private final List<ObjectValuePair<String, String>>
 		_runtimeSubscribersOVPs = new ArrayList<>();
 	private final Set<String> _sentEmailAddresses = new HashSet<>();
-	private final Set<String> _delayedSentEmailAddresses = new HashSet<>();
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/util/SubscriptionSender.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/SubscriptionSender.java
@@ -109,7 +109,7 @@ public class SubscriptionSender implements Serializable {
 	public void addPersistedSubscribers(
 		String className, long classPK, boolean notifyImmediately) {
 
-		_persistedSubscribers.add(
+		_persistedSubscribersTuples.add(
 			new Tuple(className, classPK, notifyImmediately));
 	}
 
@@ -134,7 +134,7 @@ public class SubscriptionSender implements Serializable {
 				currentThread.setContextClassLoader(_classLoader);
 			}
 
-			for (Tuple tuple : _persistedSubscribers) {
+			for (Tuple tuple : _persistedSubscribersTuples) {
 				String className = (String)tuple.getObject(0);
 				long classPK = (long)tuple.getObject(1);
 				boolean notifyImmediately = (boolean)tuple.getObject(2);
@@ -156,7 +156,7 @@ public class SubscriptionSender implements Serializable {
 				}
 			}
 
-			_persistedSubscribers.clear();
+			_persistedSubscribersTuples.clear();
 
 			for (ObjectValuePair<String, String> ovp :
 					_runtimeSubscribersOVPs) {
@@ -1100,7 +1100,7 @@ public class SubscriptionSender implements Serializable {
 	private String _mailIdPopPortletPrefix;
 	private long _notificationClassNameId;
 	private int _notificationType;
-	private final List<Tuple> _persistedSubscribers = new ArrayList<>();
+	private final List<Tuple> _persistedSubscribersTuples = new ArrayList<>();
 	private final List<ObjectValuePair<String, String>>
 		_runtimeSubscribersOVPs = new ArrayList<>();
 	private final Set<String> _sentEmailAddresses = new HashSet<>();

--- a/portal-kernel/src/com/liferay/portal/kernel/util/SubscriptionSender.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/SubscriptionSender.java
@@ -580,6 +580,10 @@ public class SubscriptionSender implements Serializable {
 		return Boolean.TRUE;
 	}
 
+	/**
+	 * @deprecated As of Mueller (7.2.x)
+	 */
+	@Deprecated
 	protected void notifyPersistedSubscriber(Subscription subscription)
 		throws Exception {
 
@@ -594,6 +598,10 @@ public class SubscriptionSender implements Serializable {
 			subscription, _className, _classPK, notifyImmediately);
 	}
 
+	/**
+	 * @deprecated As of Mueller (7.2.x)
+	 */
+	@Deprecated
 	protected void notifyPersistedSubscriber(
 			Subscription subscription, String className, long classPK)
 		throws Exception {
@@ -892,6 +900,10 @@ public class SubscriptionSender implements Serializable {
 		}
 	}
 
+	/**
+	 * @deprecated As of Mueller (7.2.x)
+	 */
+	@Deprecated
 	protected void sendNotification(User user) throws Exception {
 		sendNotification(user, true);
 	}
@@ -914,6 +926,10 @@ public class SubscriptionSender implements Serializable {
 		sendUserNotification(user, notifyImmediately);
 	}
 
+	/**
+	 * @deprecated As of Mueller (7.2.x)
+	 */
+	@Deprecated
 	protected void sendUserNotification(User user) throws Exception {
 		sendNotification(user, true);
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 9.11.0
+version 9.12.0

--- a/sql/indexes.sql
+++ b/sql/indexes.sql
@@ -412,10 +412,12 @@ create unique index IX_8B6E3ACE on UserNotificationDelivery (userId, portletId[$
 create index IX_BF29100B on UserNotificationEvent (type_[$COLUMN_LENGTH:200$]);
 create index IX_5CE95F03 on UserNotificationEvent (userId, actionRequired, archived);
 create index IX_3DBB361A on UserNotificationEvent (userId, archived);
-create index IX_E32CC19 on UserNotificationEvent (userId, delivered, actionRequired);
+create index IX_9D34232F on UserNotificationEvent (userId, delivered, actionRequired, archived);
+create index IX_BD8BD246 on UserNotificationEvent (userId, delivered, archived);
 create index IX_C4EFBD45 on UserNotificationEvent (userId, deliveryType, actionRequired, archived);
 create index IX_A87A585C on UserNotificationEvent (userId, deliveryType, archived);
-create index IX_A6F83617 on UserNotificationEvent (userId, deliveryType, delivered, actionRequired);
+create index IX_4BF3A7AD on UserNotificationEvent (userId, deliveryType, delivered, actionRequired, archived);
+create index IX_93012C4 on UserNotificationEvent (userId, deliveryType, delivered, archived);
 create index IX_8FB65EC1 on UserNotificationEvent (userId, type_[$COLUMN_LENGTH:200$], deliveryType, delivered);
 create index IX_A6BAFDFE on UserNotificationEvent (uuid_[$COLUMN_LENGTH:75$], companyId);
 

--- a/sql/indexes.sql
+++ b/sql/indexes.sql
@@ -418,7 +418,7 @@ create index IX_C4EFBD45 on UserNotificationEvent (userId, deliveryType, actionR
 create index IX_A87A585C on UserNotificationEvent (userId, deliveryType, archived);
 create index IX_4BF3A7AD on UserNotificationEvent (userId, deliveryType, delivered, actionRequired, archived);
 create index IX_93012C4 on UserNotificationEvent (userId, deliveryType, delivered, archived);
-create index IX_8FB65EC1 on UserNotificationEvent (userId, type_[$COLUMN_LENGTH:200$], deliveryType, delivered);
+create index IX_7AFE83D7 on UserNotificationEvent (userId, type_[$COLUMN_LENGTH:200$], deliveryType, delivered, archived);
 create index IX_A6BAFDFE on UserNotificationEvent (uuid_[$COLUMN_LENGTH:75$], companyId);
 
 create index IX_29BA1CF5 on UserTracker (companyId);


### PR DESCRIPTION
@adolfopa,

The new changes are the following:

https://github.com/adolfopa/liferay-portal/pull/1096/commits/85b717c8e1cb8c33209d756191ca67d1e9a41b37 - The existing APIs did not consider whether or not a notification was delivered and this resolves that. For instance, when choose "Mark all notifications as read" it would archive all notifications whether or not they had been delivered yet. I had to use `getDeliveredArchivedUserNotificationEventsCount` as a method name because the method signature conflicted with another one with the name of `getArchivedUserNotificationEventsCount`. Feel free to rename this as you see fit.

https://github.com/adolfopa/liferay-portal/pull/1096/commits/55c3af9f25a8f1e63923ad15d4cb67d63e6e7002 - As part of the renaming in the service.xml these calls also need to be updated (A -> AR)

https://github.com/adolfopa/liferay-portal/pull/1096/commits/3d1a4a91c7c5ed2bac9b4572e55604bba57adbba - The deprecations were asked for by Brian but I'm not entirely sure if these are the right ones or if I'm missing any. Feel free to amend this commit if there is something missing.

If you have any questions or concerns please let me know.