### PR TITLE
[TECHNICAL-SUPPORT] LPS-102022

### DIFF
--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_category_entries.jspf
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_category_entries.jspf
@@ -49,6 +49,10 @@ MBCategoryDisplay categoryDisplay = new MBCategoryDisplay(scopeGroupId, category
 				<aui:a href="<%= rowURL.toString() %>">
 					<%= curCategory.getName() %>
 				</aui:a>
+
+				<c:if test='<%= curCategory.getDisplayStyle().equals("question") %>'>
+					<aui:icon cssClass="icon-monospaced" image="question-circle" markupView="lexicon" message="question" />
+				</c:if>
 			</h4>
 
 			<h5 class="text-default">


### PR DESCRIPTION
@adolfopa,

The "Question" display style is used to force all threads created within it to be marked as a question. This change adds a question mark icon to the side of the category name much like question threads:

https://github.com/liferay/liferay-portal/blob/master/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_thread_entries.jspf#L81-L83

If you'd rather remove this question style altogether let me know but that will be a larger change requiring an upgrade process to convert question style categories to default.

Thanks.