### PR TITLE
LPS-102179 Not possible to create shortcuts to files from a different site in Documents and Media

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_shortcut.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_shortcut.jsp
@@ -249,6 +249,13 @@ if (portletTitleBasedNavigation) {
 			url += '&<portlet:namespace />fileEntryId=' + toFileEntryIdElement.value;
 		}
 
+		var scopeGroupId = <%= themeDisplay.getScopeGroupId() %>;
+		var toGroupId = toGroupIdElement.value;
+
+		if (scopeGroupId != toGroupId) {
+			url += '&<portlet:namespace />folderId=' + '<%= DLFolderConstants.DEFAULT_PARENT_FOLDER_ID %>';
+		}
+
 		return url;
 	}
 


### PR DESCRIPTION
Hi @robertoDiaz 

Could you please review this pull request?

The root cause of the issue is, that when an arbitrary folder has been chosen as the DM portlet's root folder, and not the current site is selected while creating a shortcut, the portlet will search in the configured root folder on the other site, where it doesn't exist.

The solution: If another site is selected, the portlet's configured root folder should be reset (eg. change it's folderId to 0).
 
Thank you and best regards,
István