### PR TITLE
LPS-103091 Avoid truncating in the middle of an encoded characters taking into account surrogate pairs

### DIFF
--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/service/test/FriendlyURLEntryLocalServiceTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/service/test/FriendlyURLEntryLocalServiceTest.java
@@ -154,7 +154,7 @@ public class FriendlyURLEntryLocalServiceTest {
 	}
 
 	@Test
-	public void testGetUniqueUrlTitleWithNonAsciiCharsShortensToMaxLength()
+	public void testGetUniqueUrlTitleWithNonasciiCharsShortensToMaxLength()
 		throws Exception {
 
 		long classNameId = ClassNameLocalServiceUtil.getClassNameId(User.class);

--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/service/test/FriendlyURLEntryLocalServiceTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/service/test/FriendlyURLEntryLocalServiceTest.java
@@ -153,6 +153,27 @@ public class FriendlyURLEntryLocalServiceTest {
 		Assert.assertEquals(maxLength, uniqueUrlTitle.length());
 	}
 
+	@Test
+	public void testGetUniqueUrlTitleWithNonAsciiCharsShortensToMaxLength()
+		throws Exception {
+
+		long classNameId = ClassNameLocalServiceUtil.getClassNameId(User.class);
+
+		int maxLength = ModelHintsUtil.getMaxLength(
+			FriendlyURLEntryLocalization.class.getName(), "urlTitle");
+
+		String urlTitle = StringUtil.randomString(maxLength - 1);
+
+		urlTitle += "あ";
+
+		String uniqueUrlTitle =
+			FriendlyURLEntryLocalServiceUtil.getUniqueUrlTitle(
+				_group.getGroupId(), classNameId, TestPropsValues.getUserId(),
+				urlTitle);
+
+		Assert.assertEquals(maxLength - 1, uniqueUrlTitle.length());
+	}
+
 	@Test(expected = DuplicateFriendlyURLEntryException.class)
 	public void testValidateDuplicateUrlTitle() throws Exception {
 		long classNameId = ClassNameLocalServiceUtil.getClassNameId(User.class);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-103091

Hi @adolfopa  ,

Can you help review the following fix? Feel free to let me know if this should be reviewed by another reviewer.

Issue: The current logic for truncating the urlTitle does not properly account for surrogate pairs.

For additional context, please see: https://issues.liferay.com/browse/PTR-1224?focusedCommentId=1969372#comment-1969372

/cc @dacousalr

Please let us know if you have any questions.
Thanks!