### PR TITLE
LPS-104559

### DIFF
--- a/modules/apps/flags/flags-taglib/src/main/java/com/liferay/flags/taglib/servlet/taglib/react/FlagsTag.java
+++ b/modules/apps/flags/flags-taglib/src/main/java/com/liferay/flags/taglib/servlet/taglib/react/FlagsTag.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.taglib.util.IncludeTag;
+import com.liferay.taglib.util.TagResourceBundleUtil;
 
 import java.util.Map;
 import java.util.ResourceBundle;
@@ -248,7 +249,7 @@ public class FlagsTag extends IncludeTag {
 
 	private String _getMessage() {
 		ResourceBundle resourceBundle = new AggregateResourceBundle(
-			(ResourceBundle)pageContext.getAttribute("resourceBundle"),
+			TagResourceBundleUtil.getResourceBundle(pageContext),
 			ResourceBundleUtil.getBundle(
 				PortalUtil.getLocale(request), "com.liferay.flags.taglib"));
 


### PR DESCRIPTION
Hi @adolfopa, This issue was reported by a customer for a portlet using the taglib for flags. The problem seemed to be that there's no resourcebundle in the pageContext, so I've used a different method that tries searching in other places, including the portlet's resourcebundle. Please let me know if you have any questions or if I should try another approach. Regards.