### PR TITLE
LPS-104547 Do not allow users to add unapproved contents into editors…

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/ItemSelectorDialog.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/ItemSelectorDialog.es.js
@@ -14,6 +14,7 @@
 
 import Component from 'metal-component';
 import {Config} from 'metal-state';
+import openToast from "./toast/commands/OpenToast.es";
 
 /**
  * Shows a dialog and handles the selected item.
@@ -92,8 +93,16 @@ class ItemSelectorDialog extends Component {
 		);
 
 		Liferay.on(eventName + 'AddItem', () => {
-			this._selectedItem = this._currentItem;
-			this.close();
+			if (this._currentItem.status == Liferay.Workflow.STATUS_APPROVED) {
+				this._selectedItem = this._currentItem;
+				this.close();
+			} else {
+				const errorMessage = Liferay.Util.sub(
+					Liferay.Language.get('x-is-not-approved'),
+					[this._currentItem.title]
+				);
+				this._showError(errorMessage);
+			}
 		});
 	}
 
@@ -114,9 +123,27 @@ class ItemSelectorDialog extends Component {
 			.get('boundingBox')
 			.one('#addButton');
 
-		Liferay.Util.toggleDisabled(addButton, !currentItem);
+		Liferay.Util.toggleDisabled(
+			addButton,
+			currentItem.length < 1 ||
+				currentItem.status != Liferay.Workflow.STATUS_APPROVED
+		);
 
 		this._currentItem = currentItem;
+	}
+
+	/**
+	 * Shows an error message
+	 *
+	 * @param {String} message
+	 * @private
+	 */
+	_showError(message) {
+		openToast({
+			message,
+			title: Liferay.Language.get('error'),
+			type: 'danger'
+		});
 	}
 }
 

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es.js
@@ -157,6 +157,8 @@ class ItemSelectorRepositoryEntryBrowser extends PortletBase {
 
 					this._onItemSelected({
 						returntype: this.uploadItemReturnType,
+						status: itemData.file.status,
+						title: itemData.file.title,
 						value: updatedImage.getData('value')
 					});
 				}),
@@ -356,6 +358,8 @@ class ItemSelectorRepositoryEntryBrowser extends PortletBase {
 		this.emit('selectedItem', {
 			data: {
 				returnType: item.returntype,
+				status: item.status,
+				title: item.title,
 				value: item.value
 			}
 		});

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
@@ -163,7 +163,7 @@ ItemSelectorRepositoryEntryManagementToolbarDisplayContext itemSelectorRepositor
 							<liferay-ui:search-container-column-text
 								name="title"
 							>
-								<a class="item-preview" data-metadata="<%= HtmlUtil.escapeAttribute(itemMedatadaJSONObject.toString()) %>" data-returnType="<%= HtmlUtil.escapeAttribute(ItemSelectorRepositoryEntryBrowserUtil.getItemSelectorReturnTypeClassName(itemSelectorReturnTypeResolver, existingFileEntryReturnType)) %>" data-url="<%= HtmlUtil.escapeAttribute(DLURLHelperUtil.getPreviewURL(fileEntry, latestFileVersion, themeDisplay, StringPool.BLANK)) %>" data-value="<%= HtmlUtil.escapeAttribute(ItemSelectorRepositoryEntryBrowserUtil.getValue(itemSelectorReturnTypeResolver, existingFileEntryReturnType, fileEntry, themeDisplay)) %>" href="<%= Validator.isNotNull(thumbnailSrc) ? HtmlUtil.escapeHREF(DLURLHelperUtil.getImagePreviewURL(fileEntry, themeDisplay)) : themeDisplay.getPathThemeImages() + "/file_system/large/default.png" %>" title="<%= HtmlUtil.escapeAttribute(title) %>">
+								<a class="item-preview" data-metadata="<%= HtmlUtil.escapeAttribute(itemMedatadaJSONObject.toString()) %>" data-returnType="<%= HtmlUtil.escapeAttribute(ItemSelectorRepositoryEntryBrowserUtil.getItemSelectorReturnTypeClassName(itemSelectorReturnTypeResolver, existingFileEntryReturnType)) %>" data-status="<%= latestFileVersion.getStatus() %>" data-url="<%= HtmlUtil.escapeAttribute(DLURLHelperUtil.getPreviewURL(fileEntry, latestFileVersion, themeDisplay, StringPool.BLANK)) %>" data-value="<%= HtmlUtil.escapeAttribute(ItemSelectorRepositoryEntryBrowserUtil.getValue(itemSelectorReturnTypeResolver, existingFileEntryReturnType, fileEntry, themeDisplay)) %>" href="<%= Validator.isNotNull(thumbnailSrc) ? HtmlUtil.escapeHREF(DLURLHelperUtil.getImagePreviewURL(fileEntry, themeDisplay)) : themeDisplay.getPathThemeImages() + "/file_system/large/default.png" %>" title="<%= HtmlUtil.escapeAttribute(title) %>">
 
 									<%
 									String iconCssClass = DLUtil.getFileIconCssClass(fileEntry.getExtension());
@@ -324,6 +324,7 @@ ItemSelectorRepositoryEntryManagementToolbarDisplayContext itemSelectorRepositor
 
 									data.put("metadata", itemMedatadaJSONObject.toString());
 									data.put("returnType", ItemSelectorRepositoryEntryBrowserUtil.getItemSelectorReturnTypeClassName(itemSelectorReturnTypeResolver, existingFileEntryReturnType));
+									data.put("status", latestFileVersion.getStatus());
 									data.put("title", title);
 									data.put("url", DLURLHelperUtil.getPreviewURL(fileEntry, latestFileVersion, themeDisplay, StringPool.BLANK));
 									data.put("value", ItemSelectorRepositoryEntryBrowserUtil.getValue(itemSelectorReturnTypeResolver, existingFileEntryReturnType, fileEntry, themeDisplay));
@@ -442,7 +443,7 @@ ItemSelectorRepositoryEntryManagementToolbarDisplayContext itemSelectorRepositor
 									<liferay-ui:search-container-column-text
 										colspan="<%= 2 %>"
 									>
-										<div class="item-preview" data-href="<%= Validator.isNotNull(thumbnailSrc) ? HtmlUtil.escapeHREF(DLURLHelperUtil.getImagePreviewURL(fileEntry, themeDisplay)) : themeDisplay.getPathThemeImages() + "/file_system/large/default.png" %>" data-metadata="<%= HtmlUtil.escapeAttribute(itemMedatadaJSONObject.toString()) %>" data-returnType="<%= HtmlUtil.escapeAttribute(ItemSelectorRepositoryEntryBrowserUtil.getItemSelectorReturnTypeClassName(itemSelectorReturnTypeResolver, existingFileEntryReturnType)) %>" data-title="<%= HtmlUtil.escapeAttribute(title) %>" data-url="<%= HtmlUtil.escapeAttribute(DLURLHelperUtil.getPreviewURL(fileEntry, latestFileVersion, themeDisplay, StringPool.BLANK)) %>" data-value="<%= HtmlUtil.escapeAttribute(ItemSelectorRepositoryEntryBrowserUtil.getValue(itemSelectorReturnTypeResolver, existingFileEntryReturnType, fileEntry, themeDisplay)) %>">
+										<div class="item-preview" data-href="<%= Validator.isNotNull(thumbnailSrc) ? HtmlUtil.escapeHREF(DLURLHelperUtil.getImagePreviewURL(fileEntry, themeDisplay)) : themeDisplay.getPathThemeImages() + "/file_system/large/default.png" %>" data-metadata="<%= HtmlUtil.escapeAttribute(itemMedatadaJSONObject.toString()) %>" data-returnType="<%= HtmlUtil.escapeAttribute(ItemSelectorRepositoryEntryBrowserUtil.getItemSelectorReturnTypeClassName(itemSelectorReturnTypeResolver, existingFileEntryReturnType)) %>" data-status="<%= latestFileVersion.getStatus() %>" data-title="<%= HtmlUtil.escapeAttribute(title) %>" data-url="<%= HtmlUtil.escapeAttribute(DLURLHelperUtil.getPreviewURL(fileEntry, latestFileVersion, themeDisplay, StringPool.BLANK)) %>" data-value="<%= HtmlUtil.escapeAttribute(ItemSelectorRepositoryEntryBrowserUtil.getValue(itemSelectorReturnTypeResolver, existingFileEntryReturnType, fileEntry, themeDisplay)) %>">
 											<liferay-ui:app-view-entry
 												assetCategoryClassName="<%= DLFileEntry.class.getName() %>"
 												assetCategoryClassPK="<%= fileEntry.getFileEntryId() %>"

--- a/modules/apps/upload/upload-web/src/main/java/com/liferay/upload/web/internal/DefaultUploadResponseHandler.java
+++ b/modules/apps/upload/upload-web/src/main/java/com/liferay/upload/web/internal/DefaultUploadResponseHandler.java
@@ -19,6 +19,7 @@ import com.liferay.document.library.kernel.antivirus.AntivirusScannerException;
 import com.liferay.document.library.kernel.exception.FileExtensionException;
 import com.liferay.document.library.kernel.exception.FileNameException;
 import com.liferay.document.library.kernel.exception.FileSizeException;
+import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.editor.EditorConstants;
@@ -127,9 +128,15 @@ public class DefaultUploadResponseHandler implements UploadResponseHandler {
 
 		String randomId = ParamUtil.getString(uploadPortletRequest, "randomId");
 
+		imageJSONObject.put("randomId", randomId);
+
+		if (fileEntry.getModel() instanceof DLFileEntry) {
+			DLFileEntry dlFileEntry = (DLFileEntry)fileEntry.getModel();
+
+			imageJSONObject.put("status", dlFileEntry.getStatus());
+		}
+
 		imageJSONObject.put(
-			"randomId", randomId
-		).put(
 			"title", fileEntry.getTitle()
 		).put(
 			"type", "document"


### PR DESCRIPTION
/cc @brianikim

Notes from Brian:
> See https://issues.liferay.com/browse/LPS-104547 for issue description.
> 
> Fix is to pass in the status of the fileEntry so that the add button can be disabled if status is not approved.
> 
> Sincerely,
> Brian Kim