### PR TITLE
LPS-104711 Check the parameter map for use of portletId and compare i…

### DIFF
--- a/portal-web/docroot/html/portal/init.jsp
+++ b/portal-web/docroot/html/portal/init.jsp
@@ -35,6 +35,7 @@ page import="com.liferay.portal.kernel.exception.UserReminderQueryException" %><
 page import="com.liferay.portal.kernel.license.util.LicenseManagerUtil" %><%@
 page import="com.liferay.portal.kernel.parsers.bbcode.BBCodeTranslatorUtil" %><%@
 page import="com.liferay.portal.kernel.portlet.PortletConfigurationLayoutUtil" %><%@
+page import="com.liferay.portal.kernel.servlet.DynamicServletRequest" %><%@
 page import="com.liferay.portal.kernel.servlet.HttpHeaders" %><%@
 page import="com.liferay.portal.kernel.templateparser.TransformException" %><%@
 page import="com.liferay.portal.kernel.terms.of.use.TermsOfUseContentProvider" %><%@

--- a/portal-web/docroot/html/portal/render_portlet.jsp
+++ b/portal-web/docroot/html/portal/render_portlet.jsp
@@ -144,6 +144,25 @@ catch (RuntimeException re) {
 	_log.error(re, re);
 }
 
+Map<String, String[]> requestParam = request.getParameterMap();
+
+if (Validator.isNotNull(requestParam) && !portletId.equals(rootPortletId)) {
+	Set<Map.Entry<String, String[]>> requestParamSet = requestParam.entrySet();
+
+	requestParamSet.forEach(
+		stringEntry -> {
+			String key = stringEntry.getKey();
+
+			if (key.contains(rootPortletId) && !key.contains(portletId)) {
+				String updatedKey = key.replaceAll(rootPortletId, portletId);
+
+				String[] value = requestParam.get(key);
+
+				((DynamicServletRequest)request).setParameterValues(updatedKey, value);
+			}
+		});
+}
+
 LiferayRenderRequest liferayRenderRequest = RenderRequestFactory.create(request, portlet, invokerPortlet, portletCtx, windowState, portletMode, portletPreferences, plid);
 
 BufferCacheServletResponse bufferCacheServletResponse = new BufferCacheServletResponse(response);


### PR DESCRIPTION
/cc @knchau

Notes from Kim:
> https://issues.liferay.com/browse/LPS-104711
> 
> **Issue:**
> Not all portlet tab options are properly functioning (i.e. Message Boards and Wiki). When clicking on the tab, the portlet does not render the appropriate view.
> 
> i.e. Message Board tab options ("Recent Posts", "My Posts", "Subscriptions", and "Statistics") are not functioning when the Message Board widget is added to a **Content Page**. It has been confirmed that only the "Categories" tab is highlighted, whereas if a Message Board widget is added to a **Widget Page**, all of the tab options are functioning as expected.
> 
> This issue is due to the use of the wrong portletId name so the mapping's key is inappropriately named.
> 
> The current implementation grabs the portletId name from the Portlet table, but the portlets that are used in Content Page have its own portletId names that is found in the PortletPreferences table. This causes the issue when fetching the parameters to render the tab because the mapping's portletId name does not match the portletId's name in the content page. Thus, it uses the default view since it could not find the value associated with its "portletId name" from the parameter map.
> 
> **Solution:**
> My solution is to loop through the httpServletRequest parameter's mapping. If the parameter's key contains the rootPortletId but it does not contain the actual portletId, then the key needs to be replaced with the actual portletId. Otherwise, the parameter key does use the actual portletId and does not need to be replaced.