### PR TITLE
[TS] LPS-107145

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/AudioProcessorImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/AudioProcessorImpl.java
@@ -350,6 +350,11 @@ public class AudioProcessorImpl
 
 		try {
 			if (PropsValues.DL_FILE_ENTRY_PREVIEW_FORK_PROCESS_ENABLED) {
+				String originalLogLevel = Log4JUtil.getOriginalLevel(
+					PropsUtil.class.getName());
+
+				Log4JUtil.setLevel(PropsUtil.class.getName(), "WARN", true);
+
 				ProcessCallable<String> processCallable =
 					new LiferayAudioProcessCallable(
 						ServerDetector.getServerId(),
@@ -358,6 +363,9 @@ public class AudioProcessorImpl
 						containerType,
 						PropsUtil.getProperties(
 							PropsKeys.DL_FILE_ENTRY_PREVIEW_AUDIO, false));
+
+				Log4JUtil.setLevel(
+					PropsUtil.class.getName(), originalLogLevel, true);
 
 				ProcessChannel<String> processChannel =
 					_processExecutor.execute(

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/PDFProcessorImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/PDFProcessorImpl.java
@@ -682,6 +682,11 @@ public class PDFProcessorImpl
 		stopWatch.start();
 
 		if (PropsValues.DL_FILE_ENTRY_PREVIEW_FORK_PROCESS_ENABLED) {
+			String originalLogLevel = Log4JUtil.getOriginalLevel(
+				PropsUtil.class.getName());
+
+			Log4JUtil.setLevel(PropsUtil.class.getName(), "WARN", true);
+
 			ProcessCallable<String> processCallable =
 				new LiferayPDFBoxProcessCallable(
 					ServerDetector.getServerId(),
@@ -693,6 +698,9 @@ public class PDFProcessorImpl
 					PropsValues.DL_FILE_ENTRY_PREVIEW_DOCUMENT_MAX_HEIGHT,
 					PropsValues.DL_FILE_ENTRY_PREVIEW_DOCUMENT_MAX_WIDTH,
 					generatePreview, generateThumbnail);
+
+			Log4JUtil.setLevel(
+				PropsUtil.class.getName(), originalLogLevel, true);
 
 			ProcessChannel<String> processChannel = _processExecutor.execute(
 				PortalClassPathUtil.getPortalProcessConfig(), processCallable);

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/VideoProcessorImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/VideoProcessorImpl.java
@@ -332,6 +332,11 @@ public class VideoProcessorImpl
 		try {
 			try {
 				if (PropsValues.DL_FILE_ENTRY_PREVIEW_FORK_PROCESS_ENABLED) {
+					String originalLogLevel = Log4JUtil.getOriginalLevel(
+						PropsUtil.class.getName());
+
+					Log4JUtil.setLevel(PropsUtil.class.getName(), "WARN", true);
+
 					ProcessCallable<String> processCallable =
 						new LiferayVideoThumbnailProcessCallable(
 							ServerDetector.getServerId(),
@@ -340,6 +345,9 @@ public class VideoProcessorImpl
 							thumbnailTempFile, THUMBNAIL_TYPE, height, width,
 							PropsValues.
 								DL_FILE_ENTRY_THUMBNAIL_VIDEO_FRAME_PERCENTAGE);
+
+					Log4JUtil.setLevel(
+						PropsUtil.class.getName(), originalLogLevel, true);
 
 					ProcessChannel<String> processChannel =
 						_processExecutor.execute(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-107145

From @wanderlast:

> So the issue is that when a user uploads a PDF, logging appears for each PDF that does not appear to be related. Specifically, it'll be similar to:
> 
> ```
> Loading jar:file:/home/matt/repos/lfrgs-liferay-damage-control/build/exported-standalone-bundle/tomcat/webapps/ROOT/WEB-INF/lib/portal-impl.jar!/system.properties
>  Jan 15, 2020 11:10:51 AM com.liferay.portal.kernel.log.Jdk14LogImpl info
>  INFO: Detected server tomcat
>  [dxp] INFO [main][PropsUtil:385] Global shared lib directory /home/matt/repos/lfrgs-liferay-damage-control/build/exported-standalone-bundle/tomcat/lib/
>  [dxp] INFO [main][PropsUtil:396] Global lib directory /home/matt/repos/lfrgs-liferay-damage-control/build/exported-standalone-bundle/tomcat/lib/ext/
>  [dxp] INFO [main][PropsUtil:419] Portal lib directory /home/matt/repos/lfrgs-liferay-damage-control/build/exported-standalone-bundle/tomcat/webapps/ROOT/WEB-INF/lib/
>  Loading jar:file:/home/matt/repos/lfrgs-liferay-damage-control/build/exported-standalone-bundle/tomcat/webapps/ROOT/WEB-INF/lib/portal-impl.jar!/portal.properties
> ```
> 
> The cause of this logging can be traced back to PDFProcessorImpl. Specifically, if the DL_FILE_ENTRY_PREVIEW_FORK_PROCESS_ENABLED property is enabled, we fork our process which causes certain lines of logging to appear when the classes are accessed again in this new forked process. The fix reduces the logging, but does not completely eliminate it. Specifically, it passes on custom log settings to remove the **PropsUtil** log messages. The other log messages do not appear to be removable without extensive effort (e.g. completely disabling logging), so they have not been addressed.
> 
> Please let me know if you have any questions. Thanks!