### PR TITLE
LPS-107603 Non-unique ids due to more than one comment discussion in the same portlet

### DIFF
--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
@@ -51,7 +51,7 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 		<div class="taglib-discussion" id="<%= namespace %>discussionContainer">
 			<aui:form action="<%= discussionTaglibHelper.getFormAction() %>" method="post" name="<%= discussionTaglibHelper.getFormName() %>" portletNamespace="<%= namespace + randomNamespace %>">
 				<input name="p_auth" type="hidden" value="<%= AuthTokenUtil.getToken(request) %>" />
-				<input name="namespace" type="hidden" value="<%= namespace %>" />
+				<input name="namespace" type="hidden" value="<%= namespace + randomNamespace %>" />
 
 				<%
 				String contentURL = PortalUtil.getCanonicalURL(discussionTaglibHelper.getRedirect(), themeDisplay, layout);

--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
@@ -132,8 +132,8 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 													configKey="commentEditor"
 													contents=""
 													editorName='<%= PropsUtil.get("editor.wysiwyg.portal-web.docroot.html.taglib.ui.discussion.jsp") %>'
-													name='<%= "postReplyBody0" %>'
-													onChangeMethod='<%= "0ReplyOnChange" %>'
+													name="postReplyBody0"
+													onChangeMethod="0ReplyOnChange"
 													placeholder="type-your-comment-here"
 													showSource="<%= false %>"
 													skipEditorLoading="<%= skipEditorLoading %>"
@@ -142,7 +142,7 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 												<aui:input name="postReplyBody0" type="hidden" />
 
 												<aui:button-row>
-													<aui:button cssClass="btn-comment btn-primary btn-sm" disabled="<%= true %>" id='<%= "postReplyButton0" %>' onClick='<%= randomNamespace + "postReply(0);" %>' value='<%= themeDisplay.isSignedIn() ? "reply" : "reply-as" %>' />
+													<aui:button cssClass="btn-comment btn-primary btn-sm" disabled="<%= true %>" id="postReplyButton0" onClick='<%= randomNamespace + "postReply(0);" %>' value='<%= themeDisplay.isSignedIn() ? "reply" : "reply-as" %>' />
 												</aui:button-row>
 											</div>
 										</div>

--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
@@ -270,7 +270,7 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 				if (commentIdElement) {
 					Util.setFormValues(form, {
 						commentId: commentIdElement.value,
-						<%= randomNamespace + Constants.CMD %>: '<%= Constants.DELETE %>'
+						<%= Constants.CMD %>: '<%= Constants.DELETE %>'
 					});
 
 					<%= namespace + randomNamespace %>sendMessage(form);
@@ -311,7 +311,7 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 					Util.setFormValues(form, {
 						body: editorInstance.getHTML(),
 						parentCommentId: parentCommentIdElement.value,
-						<%= randomNamespace + Constants.CMD %>: '<%= Constants.ADD %>'
+						<%= Constants.CMD %>: '<%= Constants.ADD %>'
 					});
 				}
 
@@ -562,7 +562,7 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 				Util.setFormValues(form, {
 					<%= randomNamespace %>className:
 						'<%= discussionTaglibHelper.getSubscriptionClassName() %>',
-					<%= randomNamespace + Constants.CMD %>: subscribe
+					<%= Constants.CMD %>: subscribe
 						? '<%= Constants.SUBSCRIBE_TO_COMMENTS %>'
 						: '<%= Constants.UNSUBSCRIBE_FROM_COMMENTS %>'
 				});
@@ -589,7 +589,7 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 					Util.setFormValues(form, {
 						body: editorInstance.getHTML(),
 						commentId: commentIdElement.value,
-						<%= randomNamespace + Constants.CMD %>: '<%= Constants.UPDATE %>'
+						<%= Constants.CMD %>: '<%= Constants.UPDATE %>'
 					});
 
 					<%= namespace + randomNamespace %>sendMessage(form);

--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
@@ -62,7 +62,7 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 				<input name="contentURL" type="hidden" value="<%= contentURL %>" />
 
 				<aui:input name="randomNamespace" type="hidden" value="<%= randomNamespace %>" />
-				<aui:input id="<%= randomNamespace + Constants.CMD %>" name="<%= Constants.CMD %>" type="hidden" />
+				<aui:input id="<%= Constants.CMD %>" name="<%= Constants.CMD %>" type="hidden" />
 				<aui:input name="redirect" type="hidden" value="<%= discussionTaglibHelper.getRedirect() %>" />
 				<aui:input name="assetEntryVisible" type="hidden" value="<%= discussionTaglibHelper.isAssetEntryVisible() %>" />
 				<aui:input name="className" type="hidden" value="<%= discussionTaglibHelper.getClassName() %>" />

--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
@@ -455,7 +455,14 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 				formId,
 				options
 			) {
-				if (!window['<%= namespace %>' + options.name]) {
+				var element = window['<%= namespace %>' + options.name];
+				var editorWrapper;
+
+				if (element) {
+					editorWrapper = element.querySelector('#' + formId + ' .editor-wrapper');
+				}
+
+				if (!element || (editorWrapper && editorWrapper.childNodes.length === 0)) {
 
 					<%
 					String editorURL = GetterUtil.getString(request.getAttribute("liferay-comment:discussion:editorURL"));

--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
@@ -250,7 +250,7 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 
 			var form =
 				document[
-					'<%= namespace + HtmlUtil.escapeJS(discussionTaglibHelper.getFormName()) %>'
+					'<%= namespace + randomNamespace + HtmlUtil.escapeJS(discussionTaglibHelper.getFormName()) %>'
 				];
 
 			Liferay.provide(window, '<%= randomNamespace %>afterLogin', function(
@@ -261,7 +261,7 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 					emailAddress: emailAddress
 				});
 
-				<%= namespace %>sendMessage(form, !anonymousAccount);
+				<%= namespace + randomNamespace %>sendMessage(form, !anonymousAccount);
 			});
 
 			Liferay.provide(window, '<%= randomNamespace %>deleteMessage', function(i) {
@@ -273,7 +273,7 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 						<%= randomNamespace + Constants.CMD %>: '<%= Constants.DELETE %>'
 					});
 
-					<%= namespace %>sendMessage(form);
+					<%= namespace + randomNamespace %>sendMessage(form);
 				}
 			});
 
@@ -330,7 +330,7 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 					});
 				}
 				else {
-					<%= namespace %>sendMessage(form);
+					<%= namespace + randomNamespace %>sendMessage(form);
 
 					editorInstance.dispose();
 				}
@@ -344,7 +344,7 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 					.scrollIntoView();
 			});
 
-			Liferay.provide(window, '<%= namespace %>sendMessage', function(
+			Liferay.provide(window, '<%= namespace + randomNamespace %>sendMessage', function(
 				form,
 				refreshPage
 			) {
@@ -567,7 +567,7 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 						: '<%= Constants.UNSUBSCRIBE_FROM_COMMENTS %>'
 				});
 
-				<%= namespace %>sendMessage(form);
+				<%= namespace + randomNamespace %>sendMessage(form);
 			});
 
 			Liferay.provide(window, '<%= randomNamespace %>updateMessage', function(
@@ -592,7 +592,7 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 						<%= randomNamespace + Constants.CMD %>: '<%= Constants.UPDATE %>'
 					});
 
-					<%= namespace %>sendMessage(form);
+					<%= namespace + randomNamespace %>sendMessage(form);
 				}
 
 				editorInstance.dispose();

--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
@@ -49,7 +49,7 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 
 	<c:if test="<%= commentSectionDisplayContext.isDiscussionVisible() %>">
 		<div class="taglib-discussion" id="<%= namespace %>discussionContainer">
-			<aui:form action="<%= discussionTaglibHelper.getFormAction() %>" method="post" name="<%= discussionTaglibHelper.getFormName() %>">
+			<aui:form action="<%= discussionTaglibHelper.getFormAction() %>" method="post" name="<%= discussionTaglibHelper.getFormName() %>" portletNamespace="<%= namespace + randomNamespace %>">
 				<input name="p_auth" type="hidden" value="<%= AuthTokenUtil.getToken(request) %>" />
 				<input name="namespace" type="hidden" value="<%= namespace %>" />
 

--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
@@ -132,8 +132,8 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 													configKey="commentEditor"
 													contents=""
 													editorName='<%= PropsUtil.get("editor.wysiwyg.portal-web.docroot.html.taglib.ui.discussion.jsp") %>'
-													name='<%= randomNamespace + "postReplyBody0" %>'
-													onChangeMethod='<%= randomNamespace + "0ReplyOnChange" %>'
+													name='<%= "postReplyBody0" %>'
+													onChangeMethod='<%= "0ReplyOnChange" %>'
 													placeholder="type-your-comment-here"
 													showSource="<%= false %>"
 													skipEditorLoading="<%= skipEditorLoading %>"
@@ -142,7 +142,7 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 												<aui:input name="postReplyBody0" type="hidden" />
 
 												<aui:button-row>
-													<aui:button cssClass="btn-comment btn-primary btn-sm" disabled="<%= true %>" id='<%= randomNamespace + "postReplyButton0" %>' onClick='<%= randomNamespace + "postReply(0);" %>' value='<%= themeDisplay.isSignedIn() ? "reply" : "reply-as" %>' />
+													<aui:button cssClass="btn-comment btn-primary btn-sm" disabled="<%= true %>" id='<%= "postReplyButton0" %>' onClick='<%= randomNamespace + "postReply(0);" %>' value='<%= themeDisplay.isSignedIn() ? "reply" : "reply-as" %>' />
 												</aui:button-row>
 											</div>
 										</div>

--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/view_message_thread.jsp
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/view_message_thread.jsp
@@ -200,12 +200,12 @@ Format dateFormatDateTime = FastDateFormatFactoryUtil.getDateTime(locale, timeZo
 				</div>
 
 				<div class="lfr-discussion-message">
-					<div class="lfr-discussion-message-body" id="<%= namespace + randomNamespace + "discussionMessage" + index %>">
+					<div class="lfr-discussion-message-body" id="<%= namespace + "discussionMessage" + index %>">
 						<%= discussionComment.getTranslatedBody(themeDisplay.getPathThemeImages()) %>
 					</div>
 
 					<c:if test="<%= commentTreeDisplayContext.isEditControlsVisible() %>">
-						<div class="lfr-discussion-form lfr-discussion-form-edit" id="<%= namespace + randomNamespace %>editForm<%= index %>" style="display: none;">
+						<div class="lfr-discussion-form lfr-discussion-form-edit" id="<%= namespace %>editForm<%= index %>" style="display: none;">
 							<div class="editor-wrapper"></div>
 
 							<aui:input name='<%= "editReplyBody" + index %>' type="hidden" value="<%= discussionComment.getBody() %>" />
@@ -214,18 +214,18 @@ Format dateFormatDateTime = FastDateFormatFactoryUtil.getDateTime(locale, timeZo
 								<aui:button cssClass="btn-comment btn-primary btn-sm" name='<%= randomNamespace + "editReplyButton" + index %>' onClick='<%= randomNamespace + "updateMessage(" + index + ");" %>' value="<%= commentTreeDisplayContext.getPublishButtonLabel(locale) %>" />
 
 								<%
-								String taglibCancel = randomNamespace + "showEl('" + namespace + randomNamespace + "discussionMessage" + index + "');" + randomNamespace + "hideEditor('" + randomNamespace + "editReplyBody" + index + "', '" + namespace + randomNamespace + "editForm" + index + "');";
+								String taglibCancel = randomNamespace + "showEl('" + namespace + "discussionMessage" + index + "');" + randomNamespace + "hideEditor('" + randomNamespace + "editReplyBody" + index + "', '" + namespace + "editForm" + index + "');";
 								%>
 
 								<aui:button cssClass="btn-comment btn-primary btn-sm" onClick="<%= taglibCancel %>" type="cancel" />
 							</aui:button-row>
 
 							<aui:script>
-								window['<%= namespace + randomNamespace + index %>EditOnChange'] = function(
+								window['<%= namespace + index %>EditOnChange'] = function(
 									html
 								) {
 									Liferay.Util.toggleDisabled(
-										'#<%= namespace + randomNamespace %>editReplyButton<%= index %>',
+										'#<%= namespace %>editReplyButton<%= index %>',
 										html.trim() === ''
 									);
 								};
@@ -269,7 +269,7 @@ Format dateFormatDateTime = FastDateFormatFactoryUtil.getDateTime(locale, timeZo
 			</div>
 		</div>
 
-		<div class="lfr-discussion lfr-discussion-form-reply" id="<%= namespace + randomNamespace + "postReplyForm" + index %>" style="display: none;">
+		<div class="lfr-discussion lfr-discussion-form-reply" id="<%= namespace + "postReplyForm" + index %>" style="display: none;">
 			<div class="lfr-discussion-reply-container">
 				<div class="autofit-padded-no-gutters autofit-row">
 					<div class="autofit-col lfr-discussion-details">
@@ -285,21 +285,21 @@ Format dateFormatDateTime = FastDateFormatFactoryUtil.getDateTime(locale, timeZo
 						<aui:input name='<%= "postReplyBody" + index %>' type="hidden" />
 
 						<aui:button-row>
-							<aui:button cssClass="btn-comment btn-primary btn-sm" disabled="<%= true %>" id='<%= randomNamespace + "postReplyButton" + index %>' onClick='<%= randomNamespace + "postReply(" + index + ");" %>' value='<%= themeDisplay.isSignedIn() ? "reply" : "reply-as" %>' />
+							<aui:button cssClass="btn-comment btn-primary btn-sm" disabled="<%= true %>" id='<%= "postReplyButton" + index %>' onClick='<%= randomNamespace + "postReply(" + index + ");" %>' value='<%= themeDisplay.isSignedIn() ? "reply" : "reply-as" %>' />
 
 							<%
-							String taglibCancel = randomNamespace + "hideEditor('" + randomNamespace + "postReplyBody" + index + "', '" + namespace + randomNamespace + "postReplyForm" + index + "')";
+							String taglibCancel = randomNamespace + "hideEditor('" + randomNamespace + "postReplyBody" + index + "', '" + namespace + "postReplyForm" + index + "')";
 							%>
 
 							<aui:button cssClass="btn-comment btn-sm" onClick="<%= taglibCancel %>" type="cancel" />
 						</aui:button-row>
 
 						<aui:script>
-							window['<%= namespace + randomNamespace + index %>ReplyOnChange'] = function(
+							window['<%= namespace + index %>ReplyOnChange'] = function(
 								html
 							) {
 								Liferay.Util.toggleDisabled(
-									'#<%= namespace + randomNamespace %>postReplyButton<%= index %>',
+									'#<%= namespace %>postReplyButton<%= index %>',
 									html.trim() === ''
 								);
 							};

--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/view_message_thread.jsp
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/view_message_thread.jsp
@@ -208,8 +208,6 @@ Format dateFormatDateTime = FastDateFormatFactoryUtil.getDateTime(locale, timeZo
 						<div class="lfr-discussion-form lfr-discussion-form-edit" id="<%= namespace %>editForm<%= index %>" style="display: none;">
 							<div class="editor-wrapper"></div>
 
-							<aui:input name='<%= "editReplyBody" + index %>' type="hidden" value="<%= discussionComment.getBody() %>" />
-
 							<aui:button-row>
 								<aui:button cssClass="btn-comment btn-primary btn-sm" name='<%= randomNamespace + "editReplyButton" + index %>' onClick='<%= randomNamespace + "updateMessage(" + index + ");" %>' value="<%= commentTreeDisplayContext.getPublishButtonLabel(locale) %>" />
 
@@ -281,8 +279,6 @@ Format dateFormatDateTime = FastDateFormatFactoryUtil.getDateTime(locale, timeZo
 
 					<div class="autofit-col autofit-col-expand">
 						<div class="editor-wrapper"></div>
-
-						<aui:input name='<%= "postReplyBody" + index %>' type="hidden" />
 
 						<aui:button-row>
 							<aui:button cssClass="btn-comment btn-primary btn-sm" disabled="<%= true %>" id='<%= "postReplyButton" + index %>' onClick='<%= randomNamespace + "postReply(" + index + ");" %>' value='<%= themeDisplay.isSignedIn() ? "reply" : "reply-as" %>' />


### PR DESCRIPTION
Hi @adolfopa, 

This issue was found by user in Liferay 7.2. The solution ensures that the portletNamespace of the form includes the randomNamespace string (first commit) and adapts the rest of the code to correct redundant or missing randomNamespaces's. 

Please let me know if you have any questions. Thanks! 

PS: @robertoDiaz has been informed of the solution.