### PR TITLE
LPS-107018 | No friendly url generated for web content when two locales share same title

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -576,34 +576,33 @@ public class FriendlyURLEntryLocalServiceImpl
 					friendlyURLEntry.getGroupId(), classNameId,
 					normalizedUrlTitle);
 
-			if ((existingFriendlyURLEntryLocalization != null) &&
-				(existingFriendlyURLEntryLocalization.getClassPK() ==
-					classPK)) {
-
+			if (existingFriendlyURLEntryLocalization != null) {
 				String existingLanguageId =
 					existingFriendlyURLEntryLocalization.getLanguageId();
 
-				if (!existingLanguageId.equals(entry.getKey())) {
+				if ((existingFriendlyURLEntryLocalization.getClassPK() ==
+						classPK) &&
+					existingLanguageId.equals(entry.getKey())) {
+
 					String existingUrlTitle =
 						existingFriendlyURLEntryLocalization.getUrlTitle();
 
-					if (existingUrlTitle.equals(
-							urlTitleMap.get(existingLanguageId))) {
+					if (existingUrlTitle.equals(entry.getValue())) {
+						existingFriendlyURLEntryLocalization.
+							setFriendlyURLEntryId(
+								friendlyURLEntry.getFriendlyURLEntryId());
+
+						updateFriendlyURLLocalization(
+							existingFriendlyURLEntryLocalization);
 
 						continue;
 					}
-
-					existingFriendlyURLEntryLocalization.setLanguageId(
-						entry.getKey());
 				}
-
-				existingFriendlyURLEntryLocalization.setFriendlyURLEntryId(
-					friendlyURLEntry.getFriendlyURLEntryId());
-
-				updateFriendlyURLLocalization(
-					existingFriendlyURLEntryLocalization);
-
-				continue;
+				else {
+					normalizedUrlTitle = getUniqueUrlTitle(
+						friendlyURLEntry.getGroupId(), classNameId, classPK,
+						normalizedUrlTitle);
+				}
 			}
 
 			updateFriendlyURLEntryLocalization(

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.ModelHintsUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -39,7 +40,9 @@ import com.liferay.portal.kernel.util.Validator;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
@@ -596,10 +599,33 @@ public class FriendlyURLEntryLocalServiceImpl
 		return map;
 	}
 
+	private Map<String, String> _sortUrlTitleMapByGroupLocaleSettings(
+		long groupId, Map<String, String> urlTitleMap) {
+
+		Map<String, String> sortedUrlTitleMap = new LinkedHashMap<>();
+
+		for (Locale locale : LanguageUtil.getAvailableLocales(groupId)) {
+			String languageId = LocaleUtil.toLanguageId(locale);
+
+			String value = urlTitleMap.get(languageId);
+
+			if (value == null) {
+				continue;
+			}
+
+			sortedUrlTitleMap.put(languageId, value);
+		}
+
+		return sortedUrlTitleMap;
+	}
+
 	private void _updateFriendlyURLEntryLocalizations(
 			FriendlyURLEntry friendlyURLEntry, long classNameId, long classPK,
 			Map<String, String> urlTitleMap)
 		throws PortalException {
+
+		urlTitleMap = _sortUrlTitleMapByGroupLocaleSettings(
+			friendlyURLEntry.getGroupId(), urlTitleMap);
 
 		for (Map.Entry<String, String> entry : urlTitleMap.entrySet()) {
 			String normalizedUrlTitle =

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -508,6 +508,45 @@ public class FriendlyURLEntryLocalServiceImpl
 		return true;
 	}
 
+	private String _getUniqueUrlTitle(
+		long groupId, long classNameId, long classPK, String languageId,
+		String urlTitle) {
+
+		String normalizedUrlTitle =
+			FriendlyURLNormalizerUtil.normalizeWithEncoding(urlTitle);
+
+		int maxLength = ModelHintsUtil.getMaxLength(
+			FriendlyURLEntryLocalization.class.getName(), "urlTitle");
+
+		String curUrlTitle = _getURLEncodedSubstring(
+			urlTitle, normalizedUrlTitle, maxLength);
+
+		String prefix = curUrlTitle;
+
+		for (int i = 1;; i++) {
+			FriendlyURLEntryLocalization friendlyURLEntryLocalization =
+				friendlyURLEntryLocalizationPersistence.fetchByG_C_U(
+					groupId, classNameId, curUrlTitle);
+
+			if ((friendlyURLEntryLocalization == null) ||
+				((friendlyURLEntryLocalization.getClassPK() == classPK) &&
+				 languageId.equals(
+					 friendlyURLEntryLocalization.getLanguageId()))) {
+
+				break;
+			}
+
+			String suffix = StringPool.DASH + i;
+
+			prefix = _getURLEncodedSubstring(
+				urlTitle, prefix, maxLength - suffix.length());
+
+			curUrlTitle = prefix + suffix;
+		}
+
+		return curUrlTitle;
+	}
+
 	private String _getURLEncodedSubstring(
 		String decodedString, String encodedString, int maxLength) {
 
@@ -599,9 +638,9 @@ public class FriendlyURLEntryLocalServiceImpl
 					}
 				}
 				else {
-					normalizedUrlTitle = getUniqueUrlTitle(
+					normalizedUrlTitle = _getUniqueUrlTitle(
 						friendlyURLEntry.getGroupId(), classNameId, classPK,
-						normalizedUrlTitle);
+						entry.getKey(), normalizedUrlTitle);
 				}
 			}
 


### PR DESCRIPTION
Hi @adolfopa, 

This pr comes from https://github.com/ealonso/liferay-portal/pull/2795. 

Besides [LPS-107018](https://issues.liferay.com/browse/LPS-107018), there's further information about this issue in [PTR-1438](https://issues.liferay.com/browse/PTR-1438). 

The solution takes into account two factors when creating a `urlTitleMap` for a new or an existing web content: 

1. One is whether another web content is already using the friendly url created from the title.
2. The second is whether two localizations for the same web content will end up having the same friendly url. 

The first factor is taken care of by `JournalArticleLocalServiceImpl._getURLTitleMap`.

The second factor, namely getting unique titles for different locales, is not covered by this method for new web contents because nothing has been persisted to the database at that point, so checking for unique url titles never fails. The second factor is actually taken care of by `FriendlyURLEntryLocalServiceImpl._getUniqueUrlTitle`. 

The logic for updating friendly url entry localizations is also corrected. 

Please let me know if you have any questions. Thanks!