### PR TITLE
[TS] LPS-108098

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/upload/DLUploadFileEntryHandler.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/upload/DLUploadFileEntryHandler.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.upload.UploadPortletRequest;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.upload.UniqueFileNameProvider;
 import com.liferay.upload.UploadFileEntryHandler;
@@ -132,6 +133,11 @@ public class DLUploadFileEntryHandler implements UploadFileEntryHandler {
 
 		String customFieldsKeys = uploadPortletRequest.getParameter(
 			"customFieldsKeys");
+
+		if (Validator.isNull(customFieldsKeys)) {
+			return new HashMap<>();
+		}
+
 		String customFieldsTypes = uploadPortletRequest.getParameter(
 			"customFieldsTypes");
 		String customFieldsValues = uploadPortletRequest.getParameter(

--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/java/com/liferay/frontend/image/editor/web/internal/portlet/action/ViewMVCRenderCommand.java
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/java/com/liferay/frontend/image/editor/web/internal/portlet/action/ViewMVCRenderCommand.java
@@ -83,6 +83,21 @@ public class ViewMVCRenderCommand implements MVCRenderCommand {
 
 		template.put("saveEventName", eventName);
 
+		String saveFileCustomFieldsKeys = ParamUtil.getString(
+			renderRequest, "saveFileCustomFieldsKeys");
+
+		template.put("saveFileCustomFieldsKeys", saveFileCustomFieldsKeys);
+
+		String saveFileCustomFieldsTypes = ParamUtil.getString(
+			renderRequest, "saveFileCustomFieldsTypes");
+
+		template.put("saveFileCustomFieldsTypes", saveFileCustomFieldsTypes);
+
+		String saveFileCustomFieldsValues = ParamUtil.getString(
+			renderRequest, "saveFileCustomFieldsValues");
+
+		template.put("saveFileCustomFieldsValues", saveFileCustomFieldsValues);
+
 		String saveFileDescription = ParamUtil.getString(
 			renderRequest, "saveFileDescription");
 

--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditor.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditor.es.js
@@ -393,12 +393,18 @@ class ImageEditor extends PortletBase {
 	submitBlob_(imageBlob) {
 		const saveFileName = this.saveFileName;
 		const saveParamName = this.saveParamName;
+		const saveFileCustomFieldsKeys = this.saveFileCustomFieldsKeys;
+		const saveFileCustomFieldsTypes = this.saveFileCustomFieldsTypes;
+		const saveFileCustomFieldsValues = this.saveFileCustomFieldsValues;
 		const saveFileDescription = this.saveFileDescription;
 
 		const promise = new Promise((resolve, reject) => {
 			const formData = new FormData();
 
 			formData.append(saveParamName, imageBlob, saveFileName);
+			formData.append('customFieldsKeys', saveFileCustomFieldsKeys);
+			formData.append('customFieldsTypes', saveFileCustomFieldsTypes);
+			formData.append('customFieldsValues', saveFileCustomFieldsValues);
 			formData.append('description', saveFileDescription);
 
 			this.fetch(this.saveURL, formData)
@@ -529,6 +535,30 @@ ImageEditor.STATE = {
 	 */
 	saveEventName: {
 		validator: core.isString,
+	},
+
+	/**
+	 * Custom Fields keys of the saved image to send to the server for the save action.
+	 * @type {String}
+	 */
+	saveFileCustomFieldsKeys: {
+		validator: core.isString
+	},
+
+	/**
+	 * Custom Fields types of the saved image to send to the server for the save action.
+	 * @type {String}
+	 */
+	saveFileCustomFieldsTypes: {
+		validator: core.isString
+	},
+
+	/**
+	 * Custom Fields values of the saved image to send to the server for the save action.
+	 * @type {String}
+	 */
+	saveFileCustomFieldsValues: {
+		validator: core.isString
 	},
 
 	/**

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/ItemSelectorPreview.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/ItemSelectorPreview.es.js
@@ -130,6 +130,9 @@ const ItemSelectorPreview = ({
 				uri: editItemURL,
 				urlParams: {
 					entityURL: currentItem.url,
+					saveFileCustomFieldsKeys: currentItem.customfieldskeys,
+					saveFileCustomFieldsTypes: currentItem.customfieldstypes,
+					saveFileCustomFieldsValues: currentItem.customfieldsvalues,
 					saveFileDescription: currentItem.description,
 					saveFileName: itemTitle,
 					saveParamName: 'imageSelectorFileName',

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/init.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/init.jsp
@@ -21,8 +21,14 @@
 <%@ page import="com.liferay.document.library.util.DLURLHelperUtil" %><%@
 page import="com.liferay.item.selector.ItemSelectorReturnType" %><%@
 page import="com.liferay.item.selector.taglib.internal.display.context.ItemSelectorRepositoryEntryManagementToolbarDisplayContext" %><%@
+page import="com.liferay.portal.kernel.json.JSONFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.model.Image" %><%@
 page import="com.liferay.portal.kernel.portlet.LiferayWindowState" %><%@
 page import="com.liferay.portal.kernel.portlet.PortletProvider" %><%@
 page import="com.liferay.portal.kernel.portlet.PortletProviderUtil" %><%@
 page import="com.liferay.portal.kernel.servlet.BrowserSnifferUtil" %>
+
+<%@ page import="java.io.Serializable" %>
+
+<%@ page import="java.util.ArrayList" %><%@
+page import="java.util.stream.Collectors" %>

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
@@ -317,6 +317,25 @@ ItemSelectorRepositoryEntryManagementToolbarDisplayContext itemSelectorRepositor
 
 									Map<String, Object> data = new HashMap<>();
 
+									Map<String, Serializable> customFieldsMap = fileEntry.getExpandoBridge().getAttributes();
+
+									Set<Map.Entry<String, Serializable>> customFields = customFieldsMap.entrySet();
+
+									String customFieldsKeys = customFields.stream().map(x -> x.getKey()).collect(Collectors.joining(","));
+
+									List<String> customFieldsValuesList = new ArrayList<>();
+
+									for (Map.Entry<String, Serializable> entry : customFields) {
+										customFieldsValuesList.add(JSONFactoryUtil.looseSerialize(entry.getValue()));
+									}
+
+									String customFieldsValues = JSONFactoryUtil.looseSerialize(customFieldsValuesList);
+
+									String customFieldsTypes = customFields.stream().map(x -> x.getValue().getClass().getName()).collect(Collectors.joining(","));
+
+									data.put("customFieldsKeys", customFieldsKeys);
+									data.put("customFieldsTypes", customFieldsTypes);
+									data.put("customFieldsValues", customFieldsValues);
 									data.put("description", fileEntry.getDescription());
 
 									String thumbnailSrc = DLURLHelperUtil.getThumbnailSrc(fileEntry, themeDisplay);

--- a/portal-impl/src/com/liferay/portlet/expando/service/impl/ExpandoValueLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/expando/service/impl/ExpandoValueLocalServiceImpl.java
@@ -25,6 +25,7 @@ import com.liferay.expando.kernel.util.ExpandoValueDeleteHandler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONMap;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -50,6 +51,8 @@ import java.util.Objects;
 
 import jodd.typeconverter.TypeConverterManager;
 import jodd.typeconverter.TypeConverterManagerBean;
+
+import org.apache.commons.lang.ArrayUtils;
 
 /**
  * @author Raymond Augé
@@ -795,8 +798,18 @@ public class ExpandoValueLocalServiceImpl
 				value.setFloatArray((float[])attributeValue);
 			}
 			else if (type == ExpandoColumnConstants.GEOLOCATION) {
-				JSONObject geolocation = JSONFactoryUtil.createJSONObject(
-					attributeValue.toString());
+				JSONObject geolocation;
+
+				if (attributeValue instanceof HashMap) {
+					geolocation = JSONFactoryUtil.createJSONObject(
+						new JSONMap(
+							(HashMap)attributeValue
+						).toString());
+				}
+				else {
+					geolocation = JSONFactoryUtil.createJSONObject(
+						attributeValue.toString());
+				}
 
 				value.setGeolocationJSONObject(geolocation);
 			}
@@ -810,6 +823,14 @@ public class ExpandoValueLocalServiceImpl
 				value.setLong((Long)attributeValue);
 			}
 			else if (type == ExpandoColumnConstants.LONG_ARRAY) {
+				if (attributeValue instanceof List) {
+					List list = (List)attributeValue;
+
+					attributeValue = list.toArray(new Long[0]);
+					attributeValue = ArrayUtils.toPrimitive(
+						(Long[])attributeValue);
+				}
+
 				value.setLongArray((long[])attributeValue);
 			}
 			else if (type == ExpandoColumnConstants.NUMBER) {

--- a/portal-kernel/src/com/liferay/portal/kernel/json/JSONMap.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/json/JSONMap.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.json;
+
+import java.util.HashMap;
+import java.util.Iterator;
+
+/**
+ * @author Jesse Yeh
+ */
+public class JSONMap<K, V> extends HashMap<K, V> {
+
+	public JSONMap(HashMap map) {
+		super(map);
+	}
+
+	@Override
+	public String toString() {
+		Iterator<Entry<K, V>> i = entrySet().iterator();
+
+		if (!i.hasNext())
+
+			return "{}";
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append('{');
+
+		while (true) {
+			Entry<K, V> entry = i.next();
+
+			sb.append(entry.getKey());
+			sb.append(':');
+			sb.append(entry.getValue());
+
+			if (!i.hasNext()) {
+				sb.append('}');
+
+				return sb.toString();
+			}
+
+			sb.append(", ");
+		}
+	}
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/json/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/json/packageinfo
@@ -1,1 +1,1 @@
-version 8.5.0
+version 8.6.0


### PR DESCRIPTION
From @jesseyeh-liferay:

> ## Problem :grimacing:
> 
> **[LPS-108098](https://issues.liferay.com/browse/LPS-108098)**
> 
> In Web Content, when an image is edited and saved, a new image is created containing the edits while the original image is left unchanged. However, the Custom Fields from the original image are not carried over into the new image.
> 
> ## Analysis :nerd_face:
> 
> Upon saving the edited image, an upload request is made containing metadata for the new image. However, certain metadata from the original image, such as Custom Fields, is absent from the request.
> 
> ## Solution :tada:
> 
> The implementation for how image metadata is obtained and forwarded is based on the solution introduced by [LPS-1070966](https://issues.liferay.com/browse/LPS-107966). The remainder of this write-up provides an overview for how the Custom Fields are serialized/deserialized and use the following example to illustrate each step in the process:
> 
> | Key | Type | Value |
> | --- | ---- | ----- |
> | "myboolean" | `Boolean` | true |
> | "mygeolocation" | `JSONObjectImpl` | \{"latitude":-10.175806, "longitude":-59.4439663\} |
> | "mydropdown" | `long[]` | [3] |
> | "mydate" | `Date` | Tue Feb 25 16:28:00 GMT 2020 |
> | "mycheckbox" | `String[]` | ["1", "4", "5"] |
> | "myradio" | `long[]` | [13] |
> | "myinputfield" | `Double` | 1.23 |
> | "mytextbox" | `String` | "234798af"""~"!""#""$#%)#W&%#*)""""}{}{}{{{{{{}}}" |
> 
> ### [Serialization](https://github.com/jesseyeh-liferay/liferay-portal/blob/3d5c86c0920d323579b8749bb6c043e4901a01c3/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp#L316-L334)
> ---
> 
> 1. We first capture the Custom Fields of the original image in three parts: `customFieldsKeys`, `customFieldsValues`, and `customFieldsTypes`. This is done separately in order to facilitate scenarios in which objects are serialized as one type, but deserialized as another, e.g., a `Date` being serialized as a `String` representing a `long`, which is then deserialized as a `long` when a `Date` is required.
> 2. Individual keys cannot contain invalid characters such as `,`. This allows us to combine all the keys together into a single `String`, using `,` as a delimiter.
> 
> ```
> customFieldsKeys: "myboolean,mygeolocation,mydropdown,mydate,mycheckbox,myradio,myinputfield,mytextbox"
> ```
> 
> 3. Values are first individually serialized as `String`s. Each serialized value is then added to a `List<String>`.
> 
> ```
> customFieldsValuesList = {ArrayList@53220}  size = 8
>  0 = "true"
>  1 = "{"latitude":-10.175806,"longitude":-59.4439663}"
>  2 = "[3]"
>  3 = "1582648080000"
>  4 = "["1","4","5"]"
>  5 = "[13]"
>  6 = "1.23"
>  7 = ""234798af\"\"\"~\"!\"\"#\"\"$#%)#W&%#*)\"\"\"\"}{}{}{{{{{{}}}""
> ```
> 
> 4. The list of values itself is then serialized as a single `String` after all the values have been added
> 
> ```
> customFieldsValues: "["true","{\"latitude\":-10.175806,\"longitude\":-59.4439663}","[3]","1582648080000","[\"1\",\"4\",\"5\"]","[13]","1.23","\"234798af\\\"\\\"\\\"~\\\"!\\\"\\\"#\\\"\\\"$#%)#W&%#*)\\\"\\\"\\\"\\\"}{}{}{{{{{{}}}\""]"
> ```
> 
> 5. Similar to keys, individual types cannot contain `,`. This allows us to combine all the types together into a single `String`, using `,` as a delimiter.
> 
> ```
> customFieldsTypes: "java.lang.Boolean,com.liferay.portal.json.JSONObjectImpl,[J,java.util.Date,[Ljava.lang.String;,[J,java.lang.Double,java.lang.String"
> ```
> 
> 6. The serialized strings (`customFieldsKeys`, `customFieldsValues`, and `customFieldsTypes`) are then forwarded into the request's `form-data`, which `DLUploadFileEntryHandler` can retrieve and use when adding a new `FileEntry` for the edited image
> 
> ### [Deserialization](https://github.com/jesseyeh-liferay/liferay-portal/blob/3d5c86c0920d323579b8749bb6c043e4901a01c3/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/upload/DLUploadFileEntryHandler.java#L130)
> ---
> 
> 1. Keys are split on the `,` and stored in an array
> 
> ```
> customFieldsKeysArray = {String[8]@54719} 
>  0 = "myboolean"
>  1 = "mygeolocation"
>  2 = "mydropdown"
>  3 = "mydate"
>  4 = "mycheckbox"
>  5 = "myradio"
>  6 = "myinputfield"
>  7 = "mytextbox"
> ```
> 
> 2. Values are deserialized as a `List<String>`
> 
> ```
> customFieldsValuesList = {ArrayList@54734}  size = 8
>  0 = "true"
>  1 = "{"latitude":-10.175806,"longitude":-59.4439663}"
>  2 = "[3]"
>  3 = "1582648080000"
>  4 = "["1","4","5"]"
>  5 = "[13]"
>  6 = "1.23"
>  7 = ""234798af\"\"\"~\"!\"\"#\"\"$#%)#W&%#*)\"\"\"\"}{}{}{{{{{{}}}""
> ```
> 
> 3. Similar to keys, types are split on the `,`, but stored in a `List<String>` instead
> 4. We iterate over the `List<String>` of types and convert each `String` to a `Class`
> 
> ```
> customFieldsTypesList = {ArrayList@54754}  size = 8
>  0 = {Class@52306} "class java.lang.Boolean"
>  1 = null
>  2 = {Class@52399} "class [J"
>  3 = {Class@51798} "class java.util.Date"
>  4 = {Class@52234} "class [Ljava.lang.String;"
>  5 = {Class@52399} "class [J"
>  6 = {Class@52302} "class java.lang.Double"
>  7 = {Class@52394} "class java.lang.String"
> ```
> 
> 5. We then deserialize the `List<String>` of values using the `List<Class>` of types, and combine the results with the `String[]` of keys to create a map, which is used to set the Custom Fields for the newly-created image
> 