### PR TITLE
Lps 109258

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewFileEntryMetadataSetsManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewFileEntryMetadataSetsManagementToolbarDisplayContext.java
@@ -14,17 +14,25 @@
 
 package com.liferay.document.library.web.internal.display.context;
 
+import com.liferay.document.library.constants.DLPortletKeys;
 import com.liferay.document.library.web.internal.display.context.util.DLRequestHelper;
+import com.liferay.document.library.web.internal.security.permission.resource.DDMStructurePermission;
 import com.liferay.frontend.taglib.clay.servlet.taglib.display.context.SearchContainerManagementToolbarDisplayContext;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenuBuilder;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.staging.StagingGroupHelper;
+import com.liferay.staging.StagingGroupHelperUtil;
 
 import javax.portlet.PortletURL;
 
@@ -49,6 +57,10 @@ public class DLViewFileEntryMetadataSetsManagementToolbarDisplayContext
 			dlViewFileEntryMetadataSetsDisplayContext.getStructureSearch());
 
 		_dlRequestHelper = new DLRequestHelper(httpServletRequest);
+		_dlViewFileEntryMetadataSetsDisplayContext =
+			dlViewFileEntryMetadataSetsDisplayContext;
+		_themeDisplay = (ThemeDisplay)liferayPortletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
 	}
 
 	@Override
@@ -101,6 +113,20 @@ public class DLViewFileEntryMetadataSetsManagementToolbarDisplayContext
 	}
 
 	@Override
+	public Boolean isShowCreationMenu() {
+		try {
+			return _isShowAddButton();
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug("Unable to get creation menu", portalException);
+			}
+
+			return false;
+		}
+	}
+
+	@Override
 	protected String[] getNavigationKeys() {
 		return new String[] {"all"};
 	}
@@ -110,6 +136,42 @@ public class DLViewFileEntryMetadataSetsManagementToolbarDisplayContext
 		return new String[] {"modified-date", "id"};
 	}
 
+	private boolean _isShowAddButton() throws PortalException {
+		Group group = _themeDisplay.getScopeGroup();
+
+		if (group.isLayout()) {
+			group = group.getParentGroup();
+		}
+
+		StagingGroupHelper stagingGroupHelper =
+			StagingGroupHelperUtil.getStagingGroupHelper();
+
+		if ((stagingGroupHelper.isLocalLiveGroup(group) ||
+			 stagingGroupHelper.isRemoteLiveGroup(group)) &&
+			stagingGroupHelper.isStagedPortlet(
+				group, DLPortletKeys.DOCUMENT_LIBRARY)) {
+
+			return false;
+		}
+
+		if (DDMStructurePermission.containsAddDDMStructurePermission(
+				_themeDisplay.getPermissionChecker(),
+				_themeDisplay.getScopeGroupId(),
+				_dlViewFileEntryMetadataSetsDisplayContext.
+					getStructureClassNameId())) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DLViewFileEntryMetadataSetsManagementToolbarDisplayContext.class);
+
 	private final DLRequestHelper _dlRequestHelper;
+	private final DLViewFileEntryMetadataSetsDisplayContext
+		_dlViewFileEntryMetadataSetsDisplayContext;
+	private final ThemeDisplay _themeDisplay;
 
 }

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewFileEntryMetadataSetsManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewFileEntryMetadataSetsManagementToolbarDisplayContext.java
@@ -14,7 +14,6 @@
 
 package com.liferay.document.library.web.internal.display.context;
 
-import com.liferay.document.library.constants.DLPortletKeys;
 import com.liferay.document.library.web.internal.display.context.util.DLRequestHelper;
 import com.liferay.document.library.web.internal.security.permission.resource.DDMStructurePermission;
 import com.liferay.frontend.taglib.clay.servlet.taglib.display.context.SearchContainerManagementToolbarDisplayContext;
@@ -31,8 +30,6 @@ import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.staging.StagingGroupHelper;
-import com.liferay.staging.StagingGroupHelperUtil;
 
 import javax.portlet.PortletURL;
 
@@ -59,8 +56,6 @@ public class DLViewFileEntryMetadataSetsManagementToolbarDisplayContext
 		_dlRequestHelper = new DLRequestHelper(httpServletRequest);
 		_dlViewFileEntryMetadataSetsDisplayContext =
 			dlViewFileEntryMetadataSetsDisplayContext;
-		_themeDisplay = (ThemeDisplay)liferayPortletRequest.getAttribute(
-			WebKeys.THEME_DISPLAY);
 	}
 
 	@Override
@@ -137,26 +132,16 @@ public class DLViewFileEntryMetadataSetsManagementToolbarDisplayContext
 	}
 
 	private boolean _isShowAddButton() throws PortalException {
-		Group group = _themeDisplay.getScopeGroup();
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)liferayPortletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
 
-		if (group.isLayout()) {
-			group = group.getParentGroup();
-		}
+		Group group = themeDisplay.getScopeGroup();
 
-		StagingGroupHelper stagingGroupHelper =
-			StagingGroupHelperUtil.getStagingGroupHelper();
-
-		if ((stagingGroupHelper.isLocalLiveGroup(group) ||
-			 stagingGroupHelper.isRemoteLiveGroup(group)) &&
-			stagingGroupHelper.isStagedPortlet(
-				group, DLPortletKeys.DOCUMENT_LIBRARY)) {
-
-			return false;
-		}
-
-		if (DDMStructurePermission.containsAddDDMStructurePermission(
-				_themeDisplay.getPermissionChecker(),
-				_themeDisplay.getScopeGroupId(),
+		if ((!group.hasLocalOrRemoteStagingGroup() || group.isStagingGroup()) &&
+			DDMStructurePermission.containsAddDDMStructurePermission(
+				_dlRequestHelper.getPermissionChecker(),
+				_dlRequestHelper.getScopeGroupId(),
 				_dlViewFileEntryMetadataSetsDisplayContext.
 					getStructureClassNameId())) {
 
@@ -172,6 +157,5 @@ public class DLViewFileEntryMetadataSetsManagementToolbarDisplayContext
 	private final DLRequestHelper _dlRequestHelper;
 	private final DLViewFileEntryMetadataSetsDisplayContext
 		_dlViewFileEntryMetadataSetsDisplayContext;
-	private final ThemeDisplay _themeDisplay;
 
 }


### PR DESCRIPTION
Notes from @kevhlee :

> https://issues.liferay.com/browse/LPS-109258
>
> The issue was that the user's Metadata Sets permissions were not being checked by the Metadata Sets management display context. Previously, by default, the add button and the rest of the creation menu were always to be shown if not `null`:
> 
> https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/display/context/ManagementToolbarDisplayContext.java#L149-L151
> 
> https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/display/context/ManagementToolbarDefaults.java#L38-L44
> 
> 
> To fix this, I overrided the `isShowCreationMenu` method in the management display context and added permission checking there to determine if the creation menu is to be displayed to the user. Specifically, I followed the permission-checking pattern found in `journal/journal-web/JournalManagementToolbarDisplayContext.java`:
> 
> https://github.com/liferay/liferay-portal/blob/master/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalManagementToolbarDisplayContext.java
> 
> 
> With regards,
> Kevin