### PR TITLE
LPS-109170 Add missinig normalization before check

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -361,7 +361,8 @@ public class FriendlyURLEntryLocalServiceImpl
 			prefix = _getURLEncodedSubstring(
 				urlTitle, prefix, maxLength - suffix.length());
 
-			curUrlTitle = prefix + suffix;
+			curUrlTitle = FriendlyURLNormalizerUtil.normalizeWithEncoding(
+				prefix + suffix);
 		}
 
 		return curUrlTitle;


### PR DESCRIPTION
Hi @adolfopa ,

Roberto helped us out in this one, I've tested the solution.
UrlTitles and FriendlyUrls now follow the same pattern of double normalisation, so the double dash is no longer an issue.

Can you please review?
https://issues.liferay.com/browse/LPS-109170

Thanks,
Balázs

cc @robertoDiaz