### PR TITLE
LPS-109457 | No succesful message when reply a comment on Page Comments

### DIFF
--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
@@ -692,7 +692,7 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 					'<%= portletDisplay.getId() %>:portletRefreshed',
 					function(event) {
 						var randomNamespaceNodes = document.querySelectorAll(
-							'input[id^="<%= namespace + randomNamespace %>randomNamespace"]'
+							'input[id^="<%= namespace %>"][id$="randomNamespace"]'
 						);
 
 						Array.prototype.forEach.call(randomNamespaceNodes, function(

--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
@@ -692,7 +692,7 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 					'<%= portletDisplay.getId() %>:portletRefreshed',
 					function(event) {
 						var randomNamespaceNodes = document.querySelectorAll(
-							'input[id^="<%= namespace %>randomNamespace"]'
+							'input[id^="<%= namespace + randomNamespace %>randomNamespace"]'
 						);
 
 						Array.prototype.forEach.call(randomNamespaceNodes, function(
@@ -728,7 +728,7 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 
 				if (response.commentId) {
 					var messageTextNode = document.querySelector(
-						'input[name^="<%= namespace %>body"]'
+						'input[name^="<%= namespace + randomNamespace %>body"]'
 					);
 
 					if (messageTextNode) {

--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/view_message_thread.jsp
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/view_message_thread.jsp
@@ -209,7 +209,7 @@ Format dateFormatDateTime = FastDateFormatFactoryUtil.getDateTime(locale, timeZo
 							<div class="editor-wrapper"></div>
 
 							<aui:button-row>
-								<aui:button cssClass="btn-comment btn-primary btn-sm" name='<%= randomNamespace + "editReplyButton" + index %>' onClick='<%= randomNamespace + "updateMessage(" + index + ");" %>' value="<%= commentTreeDisplayContext.getPublishButtonLabel(locale) %>" />
+								<aui:button cssClass="btn-comment btn-primary btn-sm" name='<%= "editReplyButton" + index %>' onClick='<%= randomNamespace + "updateMessage(" + index + ");" %>' value="<%= commentTreeDisplayContext.getPublishButtonLabel(locale) %>" />
 
 								<%
 								String taglibCancel = randomNamespace + "showEl('" + namespace + "discussionMessage" + index + "');" + randomNamespace + "hideEditor('" + randomNamespace + "editReplyBody" + index + "', '" + namespace + "editForm" + index + "');";


### PR DESCRIPTION
Hi @adolfopa, 

QA found a regression for LPS-107603 about success notifications not showing up. 

Fixed it by adding and removing the necessary randomNamespaces. After a comment is posted, the portlet is refreshed and all randomNamespaces change so we have to take that into account for one query selector (last commit). 

Please let me know if you have any questions. Thanks!