### PR TITLE
[TS] LPS-108098

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/upload/DLUploadFileEntryHandler.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/upload/DLUploadFileEntryHandler.java
@@ -14,9 +14,12 @@
 
 package com.liferay.document.library.web.internal.upload;
 
+import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.service.DLAppService;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.document.library.kernel.util.DLValidator;
+import com.liferay.expando.kernel.model.ExpandoBridge;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -83,6 +86,22 @@ public class DLUploadFileEntryHandler implements UploadFileEntryHandler {
 			ServiceContext serviceContext = ServiceContextFactory.getInstance(
 				DLFileEntry.class.getName(), uploadPortletRequest);
 
+			try {
+				long fileEntryId = Long.valueOf(
+					uploadPortletRequest.getParameter("fileEntryId"));
+
+				DLFileEntry fileEntry = _dlFileEntryLocalService.getFileEntry(
+					fileEntryId);
+
+				ExpandoBridge expandoBridge = fileEntry.getExpandoBridge();
+
+				serviceContext.setExpandoBridgeAttributes(
+					expandoBridge.getAttributes());
+			}
+			catch (NoSuchFileEntryException noSuchFileEntryException) {
+				_log.error("Unable to copy metadata", noSuchFileEntryException);
+			}
+
 			return _dlAppService.addFileEntry(
 				themeDisplay.getScopeGroupId(), folderId, uniqueFileName,
 				contentType, uniqueFileName, description, StringPool.BLANK,
@@ -116,6 +135,9 @@ public class DLUploadFileEntryHandler implements UploadFileEntryHandler {
 
 	@Reference
 	private DLAppService _dlAppService;
+
+	@Reference
+	private DLFileEntryLocalService _dlFileEntryLocalService;
 
 	@Reference
 	private DLValidator _dlValidator;

--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/java/com/liferay/frontend/image/editor/web/internal/portlet/action/ViewMVCRenderCommand.java
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/java/com/liferay/frontend/image/editor/web/internal/portlet/action/ViewMVCRenderCommand.java
@@ -88,6 +88,11 @@ public class ViewMVCRenderCommand implements MVCRenderCommand {
 
 		template.put("saveFileDescription", saveFileDescription);
 
+		String saveFileEntryId = ParamUtil.getString(
+			renderRequest, "saveFileEntryId");
+
+		template.put("saveFileEntryId", saveFileEntryId);
+
 		String saveFileName = ParamUtil.getString(
 			renderRequest, "saveFileName");
 

--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditor.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditor.es.js
@@ -394,12 +394,14 @@ class ImageEditor extends PortletBase {
 		const saveFileName = this.saveFileName;
 		const saveParamName = this.saveParamName;
 		const saveFileDescription = this.saveFileDescription;
+		const saveFileEntryId = this.saveFileEntryId;
 
 		const promise = new Promise((resolve, reject) => {
 			const formData = new FormData();
 
 			formData.append(saveParamName, imageBlob, saveFileName);
 			formData.append('description', saveFileDescription);
+			formData.append('fileEntryId', saveFileEntryId);
 
 			this.fetch(this.saveURL, formData)
 				.then(response => response.json())
@@ -536,6 +538,14 @@ ImageEditor.STATE = {
 	 * @type {String}
 	 */
 	saveFileDescription: {
+		validator: core.isString,
+	},
+
+	/**
+	 * ID of the saved image to send to the server for the save action.
+	 * @type {String}
+	 */
+	saveFileEntryId: {
 		validator: core.isString,
 	},
 

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/ItemSelectorPreview.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/ItemSelectorPreview.es.js
@@ -215,6 +215,7 @@ const ItemSelectorPreview = ({
 		};
 
 		const editedItem = {
+			fileentryid: currentItem.fileentryid,
 			metadata: JSON.stringify(editedItemMetadata),
 			returntype: uploadItemReturnType,
 			title: itemData.title,

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/ItemSelectorPreview.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/ItemSelectorPreview.es.js
@@ -131,6 +131,7 @@ const ItemSelectorPreview = ({
 				urlParams: {
 					entityURL: currentItem.url,
 					saveFileDescription: currentItem.description,
+					saveFileEntryId: currentItem.fileentryid,
 					saveFileName: itemTitle,
 					saveParamName: 'imageSelectorFileName',
 					saveURL: uploadItemURL,

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
@@ -318,6 +318,7 @@ ItemSelectorRepositoryEntryManagementToolbarDisplayContext itemSelectorRepositor
 									Map<String, Object> data = new HashMap<>();
 
 									data.put("description", fileEntry.getDescription());
+									data.put("fileEntryId", fileEntry.getFileEntryId());
 
 									String thumbnailSrc = DLURLHelperUtil.getThumbnailSrc(fileEntry, themeDisplay);
 


### PR DESCRIPTION
From @jesseyeh-liferay:

> [LPS-108098](https://issues.liferay.com/browse/LPS-108098)
> 
> ## Previous Pull Requests
> 
> https://github.com/wanderlast/liferay-portal/pull/43 > https://github.com/ChrisKian/liferay-portal/pull/187 > https://github.com/adolfopa/liferay-portal/pull/1300
> 
> ## Changelog
> 
> This introduces an alternative solution to propagate Custom Fields that avoids JSON serialization. Instead, the `fileEntryId` from the original image is forwarded, which the upload request uses to retrieve the `FileEntry`, from which it then obtains the original Custom Fields.
> 
> ## Additional Notes
> 
> An edge case for this solution occurs if the original `FileEntry` is deleted before the upload request is completed. This raises a `NoSuchFileEntryException`, which is handled [here](https://github.com/wanderlast/liferay-portal/blob/e5325fadead2b204b5e5407a6667531a203c5710/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/upload/DLUploadFileEntryHandler.java#L88-L100). Logic then proceeds normally and a new `FileEntry` is added (sans Custom Fields).

CC @wanderlast 