### PR TITLE
[TS] LPS-110418

### DIFF
--- a/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/user_notification_entry.jspf
+++ b/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/user_notification_entry.jspf
@@ -52,7 +52,7 @@ if (notificationUnread) {
 			<liferay-ui:message key="notification-no-longer-applies" />
 		</liferay-ui:search-container-column-text>
 	</c:when>
-	<c:when test="<%= !userNotificationFeedEntry.isApplicable() %>">
+	<c:when test="<%= (userNotificationFeedEntry != null) && !userNotificationFeedEntry.isApplicable() %>">
 		<liferay-ui:search-container-column-text
 			colspan="<%= 2 %>"
 		>

--- a/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/user_notification_entry.jspf
+++ b/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/user_notification_entry.jspf
@@ -52,49 +52,53 @@ if (notificationUnread) {
 			<liferay-ui:message key="notification-no-longer-applies" />
 		</liferay-ui:search-container-column-text>
 	</c:when>
-	<c:when test="<%= (userNotificationFeedEntry != null) && !userNotificationFeedEntry.isApplicable() %>">
-		<liferay-ui:search-container-column-text
-			colspan="<%= 2 %>"
-		>
-			<liferay-ui:message key="<%= userNotificationFeedEntry.getBody() %>" />
-		</liferay-ui:search-container-column-text>
-	</c:when>
 	<c:otherwise>
-		<portlet:actionURL name="markNotificationAsRead" var="markNotificationAsReadURL">
-			<portlet:param name="userNotificationEventId" value="<%= String.valueOf(userNotificationEvent.getUserNotificationEventId()) %>" />
+		<c:choose>
+			<c:when test="<%= !userNotificationFeedEntry.isApplicable() %>">
+				<liferay-ui:search-container-column-text
+					colspan="<%= 2 %>"
+				>
+					<liferay-ui:message key="<%= userNotificationFeedEntry.getBody() %>" />
+				</liferay-ui:search-container-column-text>
+			</c:when>
+			<c:otherwise>
+				<portlet:actionURL name="markNotificationAsRead" var="markNotificationAsReadURL">
+					<portlet:param name="userNotificationEventId" value="<%= String.valueOf(userNotificationEvent.getUserNotificationEventId()) %>" />
 
-			<c:choose>
-				<c:when test="<%= Validator.isNotNull(userNotificationFeedEntry.getLink()) %>">
-					<portlet:param name="redirect" value="<%= PortalUtil.addPreservedParameters(themeDisplay, userNotificationFeedEntry.getLink(), false, true) %>" />
-				</c:when>
-				<c:otherwise>
-					<portlet:param name="redirect" value="<%= currentURL %>" />
-				</c:otherwise>
-			</c:choose>
-		</portlet:actionURL>
+					<c:choose>
+						<c:when test="<%= Validator.isNotNull(userNotificationFeedEntry.getLink()) %>">
+							<portlet:param name="redirect" value="<%= PortalUtil.addPreservedParameters(themeDisplay, userNotificationFeedEntry.getLink(), false, true) %>" />
+						</c:when>
+						<c:otherwise>
+							<portlet:param name="redirect" value="<%= currentURL %>" />
+						</c:otherwise>
+					</c:choose>
+				</portlet:actionURL>
 
-		<liferay-ui:search-container-column-text
-			colspan="<%= 2 %>"
-		>
-			<c:if test="<%= notificationUnread %>">
-				<h4>
-			</c:if>
-				<a href="<%= markNotificationAsReadURL.toString() %>">
-					<%= userNotificationFeedEntry.getBody() %>
-				</a>
-			<c:if test="<%= notificationUnread %>">
-				</h4>
-			</c:if>
+				<liferay-ui:search-container-column-text
+					colspan="<%= 2 %>"
+				>
+					<c:if test="<%= notificationUnread %>">
+						<h4>
+					</c:if>
+						<a href="<%= markNotificationAsReadURL.toString() %>">
+							<%= userNotificationFeedEntry.getBody() %>
+						</a>
+					<c:if test="<%= notificationUnread %>">
+						</h4>
+					</c:if>
 
-			<h5 class="text-default">
-				<span title="<%= dateFormatDateTime.format(userNotificationEvent.getTimestamp()) %>">
-					<%= Time.getRelativeTimeDescription(userNotificationEvent.getTimestamp(), themeDisplay.getLocale(), themeDisplay.getTimeZone(), dateFormatDateTime) %>
-				</span>
-			</h5>
-		</liferay-ui:search-container-column-text>
+					<h5 class="text-default">
+						<span title="<%= dateFormatDateTime.format(userNotificationEvent.getTimestamp()) %>">
+							<%= Time.getRelativeTimeDescription(userNotificationEvent.getTimestamp(), themeDisplay.getLocale(), themeDisplay.getTimeZone(), dateFormatDateTime) %>
+						</span>
+					</h5>
+				</liferay-ui:search-container-column-text>
 
-		<liferay-ui:search-container-column-jsp
-			path="/notifications/notification_action.jsp"
-		/>
+				<liferay-ui:search-container-column-jsp
+					path="/notifications/notification_action.jsp"
+				/>
+			</c:otherwise>
+		</c:choose>
 	</c:otherwise>
 </c:choose>


### PR DESCRIPTION
From @kevhlee:

> <https://issues.liferay.com/browse/LPS-110418>
> 
> The issue was that the notification portlet tried to invoke a method on the `userNotificationFeedEntry` variable when it was set to `null`.
> 
> * <https://github.com/kevhlee/liferay-portal/blob/4c6f47997f515e43e4ee78f52b5a64df6d9fdcec/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/user_notification_entry.jspf#L55>
> 
> When a notification comes from a module that is uninstalled or deactivated, its corresponding `userNotificationFeedEntry` variable is set to `null`, which causes the problem described in [LPS-110418](https://issues.liferay.com/browse/LPS-110418).
> 
> With regards,
> Kevin

There was also some incorrect logic in the jspf file, as the "when" clause was assumed to be working as a "switch" clause, which isn't the case.  I've updated the logic and confirmed with Kevin the changes work as intended.  Please let me know if you have any questions, thanks!

CC @wanderlast 