### PR TITLE
LPS-110134

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/upload/DLUploadFileEntryHandler.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/upload/DLUploadFileEntryHandler.java
@@ -73,10 +73,17 @@ public class DLUploadFileEntryHandler implements UploadFileEntryHandler {
 
 		String contentType = uploadPortletRequest.getContentType(
 			_PARAMETER_NAME);
-		String description = uploadPortletRequest.getParameter("description");
 
 		try (InputStream inputStream = uploadPortletRequest.getFileAsStream(
 				_PARAMETER_NAME)) {
+
+			String description = StringPool.BLANK;
+			DLFileEntry dlFileEntry = _getOriginalDLFileEntry(
+				uploadPortletRequest);
+
+			if (dlFileEntry != null) {
+				description = dlFileEntry.getDescription();
+			}
 
 			String uniqueFileName = _uniqueFileNameProvider.provide(
 				fileName,
@@ -109,28 +116,31 @@ public class DLUploadFileEntryHandler implements UploadFileEntryHandler {
 		}
 	}
 
-	private ServiceContext _getServiceContext(
-			UploadPortletRequest uploadPortletRequest)
-		throws PortalException {
+	private DLFileEntry _getOriginalDLFileEntry(
+		UploadPortletRequest uploadPortletRequest) {
 
 		long fileEntryId = GetterUtil.getLong(
 			uploadPortletRequest.getParameter("fileEntryId"));
 
 		if (fileEntryId == 0) {
-			return ServiceContextFactory.getInstance(
-				DLFileEntry.class.getName(), uploadPortletRequest);
+			return null;
 		}
 
-		DLFileEntry dlFileEntry = _dlFileEntryLocalService.fetchDLFileEntry(
-			fileEntryId);
+		return _dlFileEntryLocalService.fetchDLFileEntry(fileEntryId);
+	}
 
-		if (dlFileEntry == null) {
-			return ServiceContextFactory.getInstance(
-				DLFileEntry.class.getName(), uploadPortletRequest);
-		}
+	private ServiceContext _getServiceContext(
+			UploadPortletRequest uploadPortletRequest)
+		throws PortalException {
 
 		ServiceContext serviceContext = ServiceContextFactory.getInstance(
 			DLFileEntry.class.getName(), uploadPortletRequest);
+
+		DLFileEntry dlFileEntry = _getOriginalDLFileEntry(uploadPortletRequest);
+
+		if (dlFileEntry == null) {
+			return serviceContext;
+		}
 
 		ExpandoBridge expandoBridge = dlFileEntry.getExpandoBridge();
 

--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/java/com/liferay/frontend/image/editor/web/internal/portlet/action/ViewMVCRenderCommand.java
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/java/com/liferay/frontend/image/editor/web/internal/portlet/action/ViewMVCRenderCommand.java
@@ -83,11 +83,6 @@ public class ViewMVCRenderCommand implements MVCRenderCommand {
 
 		template.put("saveEventName", eventName);
 
-		String saveFileDescription = ParamUtil.getString(
-			renderRequest, "saveFileDescription");
-
-		template.put("saveFileDescription", saveFileDescription);
-
 		String saveFileEntryId = ParamUtil.getString(
 			renderRequest, "saveFileEntryId");
 

--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditor.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditor.es.js
@@ -393,14 +393,12 @@ class ImageEditor extends PortletBase {
 	submitBlob_(imageBlob) {
 		const saveFileName = this.saveFileName;
 		const saveParamName = this.saveParamName;
-		const saveFileDescription = this.saveFileDescription;
 		const saveFileEntryId = this.saveFileEntryId;
 
 		const promise = new Promise((resolve, reject) => {
 			const formData = new FormData();
 
 			formData.append(saveParamName, imageBlob, saveFileName);
-			formData.append('description', saveFileDescription);
 			formData.append('fileEntryId', saveFileEntryId);
 
 			this.fetch(this.saveURL, formData)
@@ -530,14 +528,6 @@ ImageEditor.STATE = {
 	 * @type {String}
 	 */
 	saveEventName: {
-		validator: core.isString,
-	},
-
-	/**
-	 * Description of the saved image to send to the server for the save action.
-	 * @type {String}
-	 */
-	saveFileDescription: {
 		validator: core.isString,
 	},
 

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/ItemSelectorPreview.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/ItemSelectorPreview.es.js
@@ -130,7 +130,6 @@ const ItemSelectorPreview = ({
 				uri: editItemURL,
 				urlParams: {
 					entityURL: currentItem.url,
-					saveFileDescription: currentItem.description,
 					saveFileEntryId: currentItem.fileentryid,
 					saveFileName: itemTitle,
 					saveParamName: 'imageSelectorFileName',


### PR DESCRIPTION
From @jesseyeh-liferay:

> [LPS-110134](https://issues.liferay.com/browse/LPS-110134)
> 
> This handles an edge case from the solution introduced by [LPS-107966](https://issues.liferay.com/browse/LPS-107966), which propagates the image description when creating a new image via an image edit in Web Content.
> 
> ![image](https://user-images.githubusercontent.com/56003471/76664712-81e90380-6542-11ea-9921-97098d3d3fa8.png)
> 
> After the first edited image is created, creating another image from this image edit results in the new image having a description of "undefined." To resolve this, we use the `fileEntryId` field introduced by [LPS-108098](https://issues.liferay.com/browse/LPS-108098), since this field gets propagated to edits of image edits (see [`editedItem` in `handleSaveEdit`](https://github.com/wanderlast/liferay-portal/blob/0b53476f588a4afbd7e22fc074a97d558d902967/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/ItemSelectorPreview.es.js#L217)) and can be used to obtain the image description. Additionally, we remove the old `description` field and its references to eliminate redundancy.

CC @wanderlast