### PR TITLE
LPS-99141 Add tests

### DIFF
--- a/modules/apps/subscription/subscription-service/src/test/java/com/liferay/subscriptions/internal/util/SubscriptionSenderContextAttributeTest.java
+++ b/modules/apps/subscription/subscription-service/src/test/java/com/liferay/subscriptions/internal/util/SubscriptionSenderContextAttributeTest.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.subscriptions.internal.util;
+
+import com.liferay.portal.kernel.util.EscapableObject;
+import com.liferay.portal.kernel.util.HtmlUtil;
+import com.liferay.portal.kernel.util.SubscriptionSender;
+import com.liferay.portal.util.HtmlImpl;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class SubscriptionSenderContextAttributeTest {
+
+	@Before
+	public void setUp() {
+		new HtmlUtil().setHtml(new HtmlImpl());
+	}
+
+	@Test
+	public void testContextAttributesAreHtmlEscapedByDefault() {
+		SubscriptionSender subscriptionSender = new SubscriptionSender();
+
+		subscriptionSender.setContextAttribute("[$X$]", "<>");
+
+		Assert.assertEquals(
+			"&lt;&gt;",
+			_getEscapedValue(subscriptionSender.getContextAttribute("[$X$]")));
+	}
+
+	@Test
+	public void testContextAttributesPreserveValueIfNotEscaped() {
+		SubscriptionSender subscriptionSender = new SubscriptionSender();
+
+		subscriptionSender.setContextAttribute("[$X$]", "<>", false);
+
+		Assert.assertEquals(
+			"<>",
+			_getEscapedValue(subscriptionSender.getContextAttribute("[$X$]")));
+	}
+
+	@Test
+	public void testHtmlEscapedContextAttributeIsAlwaysCreated() {
+		SubscriptionSender subscriptionSender = new SubscriptionSender();
+
+		subscriptionSender.setContextAttribute("[$X$]", "<>");
+		subscriptionSender.setContextAttribute("[$Y$]", "<>", false);
+
+		Assert.assertEquals(
+			"&lt;&gt;",
+			_getEscapedValue(
+				subscriptionSender.getContextAttribute("[$X|html$]")));
+		Assert.assertEquals(
+			"&lt;&gt;",
+			_getEscapedValue(
+				subscriptionSender.getContextAttribute("[$Y|html$]")));
+	}
+
+	@Test
+	public void testAttributeEscapedContextAttributeIsAlwaysCreated() {
+		SubscriptionSender subscriptionSender = new SubscriptionSender();
+
+		subscriptionSender.setContextAttribute("[$X$]", "<>");
+		subscriptionSender.setContextAttribute("[$Y$]", "<>", false);
+
+		Assert.assertEquals(
+			"&lt;&gt;",
+			_getEscapedValue(
+				subscriptionSender.getContextAttribute("[$X|attr$]")));
+		Assert.assertEquals(
+			"&lt;&gt;",
+			_getEscapedValue(
+				subscriptionSender.getContextAttribute("[$Y|attr$]")));
+	}
+
+	@Test
+	public void testUriEscapedContextAttributeIsAlwaysCreated() {
+		SubscriptionSender subscriptionSender = new SubscriptionSender();
+
+		subscriptionSender.setContextAttribute("[$X$]", "&");
+		subscriptionSender.setContextAttribute("[$Y$]", "&", false);
+
+		Assert.assertEquals(
+			"%26",
+			_getEscapedValue(
+				subscriptionSender.getContextAttribute("[$X|uri$]")));
+		Assert.assertEquals(
+			"%26",
+			_getEscapedValue(
+				subscriptionSender.getContextAttribute("[$Y|uri$]")));
+	}
+
+	private String _getEscapedValue(Object object) {
+		EscapableObject<?> escapableObject = (EscapableObject<?>)object;
+
+		return escapableObject.getEscapedValue();
+	}
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/util/SubscriptionSender.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/SubscriptionSender.java
@@ -360,6 +360,16 @@ public class SubscriptionSender implements Serializable {
 
 	public void setContextAttribute(String key, EscapableObject<String> value) {
 		_context.put(key, value);
+
+		_context.put(
+			_getFilterKey(key, "attr"),
+			new HtmlAtributeEscapableObject<>(value.getOriginalValue(), true));
+		_context.put(
+			_getFilterKey(key, "html"),
+			new HtmlEscapableObject<>(value.getOriginalValue(), true));
+		_context.put(
+			_getFilterKey(key, "uri"),
+			new UriEscapableObject<>(value.getOriginalValue(), true));
 	}
 
 	public void setContextAttribute(String key, Object value) {
@@ -1036,6 +1046,19 @@ public class SubscriptionSender implements Serializable {
 			_getBasicMailTemplateContext(locale));
 	}
 
+	private String _getFilterKey(String key, String escapeMode) {
+		int i = key.lastIndexOf("$]");
+
+		if (i != (key.length() - 2)) {
+			throw new IllegalArgumentException(
+				"Subscription template key is not syntactically correct: " +
+					key);
+		}
+
+		return StringBundler.concat(
+			key.substring(0, i), StringPool.PIPE, escapeMode, "$]");
+	}
+
 	private <T> List<Hook<T>> _getHooks(Hook.Event<T> event) {
 		return (List)_hooks.computeIfAbsent(event, key -> new ArrayList<>());
 	}
@@ -1120,5 +1143,40 @@ public class SubscriptionSender implements Serializable {
 	private final List<ObjectValuePair<String, String>>
 		_runtimeSubscribersOVPs = new ArrayList<>();
 	private final Set<String> _sentEmailAddresses = new HashSet<>();
+
+	private static class HtmlAtributeEscapableObject<T>
+		extends EscapableObject<T> {
+
+		public HtmlAtributeEscapableObject(T originalValue) {
+			super(originalValue);
+		}
+
+		public HtmlAtributeEscapableObject(T originalValue, boolean escape) {
+			super(originalValue, escape);
+		}
+
+		@Override
+		protected String escape(T value) {
+			return HtmlUtil.escapeAttribute(String.valueOf(value));
+		}
+
+	}
+
+	private static class UriEscapableObject<T> extends EscapableObject<T> {
+
+		public UriEscapableObject(T originalValue) {
+			super(originalValue);
+		}
+
+		public UriEscapableObject(T originalValue, boolean escape) {
+			super(originalValue, escape);
+		}
+
+		@Override
+		protected String escape(T value) {
+			return URLCodec.encodeURL(String.valueOf(value));
+		}
+
+	}
 
 }


### PR DESCRIPTION
Hey Brian,

Currently, we allow to escape template variables only by hardcoding it in the code (and only HTML escaping is supported). The problem is that, usually, whether to escape or not a value depends a lot on the context, and that's something we cannot predict.

In this PR, I add the concept of "filters" to the template engine. When referencing a template variable, template writers can use the [$VARIABLE|filter$] syntax to specify a context dependent filtering (html, attr and uri are supported).

I've chosen this particular syntax because it is conventional (it is used in other template engines like Jinja), and also clearly conveys the idea of piping the value through a filter.

Thanks!