### PR TITLE
LPS-111598 Make pending comment visible to the content reviewer

### DIFF
--- a/modules/apps/comment/comment-taglib/src/main/java/com/liferay/comment/taglib/internal/context/DefaultCommentTreeDisplayContext.java
+++ b/modules/apps/comment/comment-taglib/src/main/java/com/liferay/comment/taglib/internal/context/DefaultCommentTreeDisplayContext.java
@@ -93,7 +93,9 @@ public class DefaultCommentTreeDisplayContext
 
 	@Override
 	public boolean isDiscussionVisible() throws PortalException {
-		if (!isCommentApproved() && !isCommentAuthor() && !isGroupAdmin()) {
+		if (!isCommentApproved() && !isCommentAuthor() &&
+			!isContentReviewer() && !isGroupAdmin()) {
+
 			return false;
 		}
 
@@ -238,6 +240,15 @@ public class DefaultCommentTreeDisplayContext
 		}
 
 		return pending;
+	}
+
+	protected boolean isContentReviewer() {
+		PermissionChecker permissionChecker =
+			_discussionRequestHelper.getPermissionChecker();
+
+		return permissionChecker.isContentReviewer(
+			_discussionRequestHelper.getCompanyId(),
+			_discussionRequestHelper.getScopeGroupId());
 	}
 
 	protected boolean isGroupAdmin() {


### PR DESCRIPTION
From @IstvanD:

> I enabled Content Reviewers to see pending comments. However, they now also see the Action menu of the comments, so they can Edit and Delete them without assigning the reviewing task to themselves. Normally, then can only do that after opening their review notifications and assigning the task to themselves.
>
>Is this something that has to be dealt with in this solution?
>
>Thank you and best regards,
>István

Thx