### PR TITLE
LPS-111962 | Guest users cannot see blog image for a site imported as copy as new

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FolderStagedModelDataHandler.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FolderStagedModelDataHandler.java
@@ -254,51 +254,48 @@ public class FolderStagedModelDataHandler
 
 		Folder importedFolder = null;
 
-		if (portletDataContext.isDataStrategyMirror()) {
-			boolean rootFolder = GetterUtil.getBoolean(
-				folderElement.attributeValue("rootFolder"));
+		boolean rootFolder = GetterUtil.getBoolean(
+			folderElement.attributeValue("rootFolder"));
 
-			if (rootFolder) {
-				Repository repository = _repositoryLocalService.getRepository(
-					repositoryId);
+		if (rootFolder) {
+			Repository repository = _repositoryLocalService.getRepository(
+				repositoryId);
 
-				importedFolder = _dlAppLocalService.getFolder(
-					repository.getDlFolderId());
-			}
-			else {
-				Folder existingFolder = fetchStagedModelByUuidAndGroupId(
-					folder.getUuid(), portletDataContext.getScopeGroupId());
-
-				if (existingFolder == null) {
-					String name = _dlFolderLocalService.getUniqueFolderName(
-						null, portletDataContext.getScopeGroupId(),
-						parentFolderId, folder.getName(), 2);
-
-					serviceContext.setUuid(folder.getUuid());
-
-					importedFolder = _dlAppLocalService.addFolder(
-						userId, repositoryId, parentFolderId, name,
-						folder.getDescription(), serviceContext);
-				}
-				else {
-					String name = _dlFolderLocalService.getUniqueFolderName(
-						folder.getUuid(), portletDataContext.getScopeGroupId(),
-						parentFolderId, folder.getName(), 2);
-
-					importedFolder = _dlAppLocalService.updateFolder(
-						existingFolder.getFolderId(), parentFolderId, name,
-						folder.getDescription(), serviceContext);
-				}
-			}
+			importedFolder = _dlAppLocalService.getFolder(
+				repository.getDlFolderId());
 		}
 		else {
-			String name = _dlFolderLocalService.getUniqueFolderName(
-				null, portletDataContext.getScopeGroupId(), parentFolderId,
-				folder.getName(), 2);
+			Folder existingFolder = fetchStagedModelByUuidAndGroupId(
+				folder.getUuid(), portletDataContext.getScopeGroupId());
 
-			importedFolder = _dlAppLocalService.addFolder(
-				userId, repositoryId, parentFolderId, name,
-				folder.getDescription(), serviceContext);
+			if ((existingFolder == null) ||
+				!portletDataContext.isDataStrategyMirror()) {
+
+				String uuid = null;
+
+				if (portletDataContext.isDataStrategyMirror()) {
+					uuid = folder.getUuid();
+
+					serviceContext.setUuid(uuid);
+				}
+
+				String name = _dlFolderLocalService.getUniqueFolderName(
+					uuid, portletDataContext.getScopeGroupId(), parentFolderId,
+					folder.getName(), 2);
+
+				importedFolder = _dlAppLocalService.addFolder(
+					userId, repositoryId, parentFolderId, name,
+					folder.getDescription(), serviceContext);
+			}
+			else {
+				String name = _dlFolderLocalService.getUniqueFolderName(
+					folder.getUuid(), portletDataContext.getScopeGroupId(),
+					parentFolderId, folder.getName(), 2);
+
+				importedFolder = _dlAppLocalService.updateFolder(
+					existingFolder.getFolderId(), parentFolderId, name,
+					folder.getDescription(), serviceContext);
+			}
 		}
 
 		importFolderFileEntryTypes(


### PR DESCRIPTION
Hi @adolfo, 

This issue was reported by a customer. 

The case we cover in the solution is the following: before importing folders, repositories will be imported and associated folders can be created; we should check for these folders when `rootFolder` is `true` in any import strategy, not just mirror. 

Please let me know if you have any questions. Thanks!