### PR TITLE
LPS-112061 Revert the BMP plugin back to 3.4.3

### DIFF
--- a/modules/apps/imageio-plugins/imageio-plugins/build.gradle
+++ b/modules/apps/imageio-plugins/imageio-plugins/build.gradle
@@ -2,7 +2,7 @@ dependencies {
 	compileInclude group: "com.twelvemonkeys.common", name: "common-image", version: "3.3.2"
 	compileInclude group: "com.twelvemonkeys.common", name: "common-io", version: "3.3.2"
 	compileInclude group: "com.twelvemonkeys.common", name: "common-lang", version: "3.3.2"
-	compileInclude group: "com.twelvemonkeys.imageio", name: "imageio-bmp", version: "3.5"
+	compileInclude group: "com.twelvemonkeys.imageio", name: "imageio-bmp", version: "3.4.3"
 	compileInclude group: "com.twelvemonkeys.imageio", name: "imageio-core", version: "3.5"
 	compileInclude group: "com.twelvemonkeys.imageio", name: "imageio-hdr", version: "3.5"
 	compileInclude group: "com.twelvemonkeys.imageio", name: "imageio-icns", version: "3.5"


### PR DESCRIPTION
Hey Brian,

I'm reverting the BMP plugin version due to some bugs in the latest 3.5 version.  This was causing some test failures in the CI.  The rest of the imageio plugins seem to be fine, so there's no need to revert everything.

Thanks!