### PR TITLE
LPS-113512 Vocabularies associated with other document types are presented for Basic Document

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/toolbar/contributor/helper/MenuItemProvider.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/toolbar/contributor/helper/MenuItemProvider.java
@@ -117,6 +117,10 @@ public class MenuItemProvider {
 			String.valueOf(_getRepositoryId(folder, themeDisplay)));
 		portletURL.setParameter("folderId", String.valueOf(folderId));
 
+		portletURL.setParameter(
+			"fileEntryTypeId",
+			String.valueOf(DLFileEntryTypeConstants.COMPANY_ID_BASIC_DOCUMENT));
+
 		urlMenuItem.setURL(portletURL.toString());
 
 		return urlMenuItem;

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
@@ -493,7 +493,7 @@ renderResponse.setTitle(headerTitle);
 						<liferay-asset:asset-categories-selector
 							className="<%= DLFileEntry.class.getName() %>"
 							classPK="<%= assetClassPK %>"
-							classTypePK="<%= fileEntryTypeId %>"
+							classTypePK="<%= (fileEntryTypeId < 0) ? DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT : fileEntryTypeId %>"
 						/>
 
 						<liferay-asset:asset-tags-selector


### PR DESCRIPTION
Hi @adolfopa 

Could you please review this pull request?

The root cause of the issue is that `fileEntryTypeId` is -1 (not defined) if a basic document is created. I don't know if this is intended or not, but on 7.1.x the `fileEntryTypeId` is 0 by default.

I used two methods to solve the issue, each in their own commits, but I'm not sure which one to go with.

Thank you and best regards,
István