### PR TITLE
Lps 86234 lima

### DIFF
--- a/modules/apps/comment/comment-page-comments-web/src/main/java/com/liferay/comment/page/comments/web/internal/exportimport/data/handler/PageCommentsPortletDataHandler.java
+++ b/modules/apps/comment/comment-page-comments-web/src/main/java/com/liferay/comment/page/comments/web/internal/exportimport/data/handler/PageCommentsPortletDataHandler.java
@@ -16,6 +16,7 @@ package com.liferay.comment.page.comments.web.internal.exportimport.data.handler
 
 import com.liferay.comment.page.comments.web.internal.constants.PageCommentsPortletKeys;
 import com.liferay.exportimport.kernel.lar.BasePortletDataHandler;
+import com.liferay.exportimport.kernel.lar.DataLevel;
 import com.liferay.exportimport.kernel.lar.ExportImportProcessCallbackRegistry;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.PortletDataHandler;
@@ -103,6 +104,7 @@ public class PageCommentsPortletDataHandler extends BasePortletDataHandler {
 	@Activate
 	protected void activate() {
 		setDataAlwaysStaged(true);
+		setDataLevel(DataLevel.PORTLET_INSTANCE);
 		setPublishToLiveByDefault(true);
 	}
 

--- a/modules/apps/comment/comment-web-test/src/testIntegration/java/com/liferay/comment/web/internal/exportimport/data/handler/test/PageCommentsPortletDataHandlerTest.java
+++ b/modules/apps/comment/comment-web-test/src/testIntegration/java/com/liferay/comment/web/internal/exportimport/data/handler/test/PageCommentsPortletDataHandlerTest.java
@@ -59,7 +59,7 @@ public class PageCommentsPortletDataHandlerTest
 
 	@Override
 	protected DataLevel getDataLevel() {
-		return DataLevel.SITE;
+		return DataLevel.PORTLET_INSTANCE;
 	}
 
 	@Override
@@ -74,12 +74,12 @@ public class PageCommentsPortletDataHandlerTest
 
 	@Override
 	protected boolean isDataPortletInstanceLevel() {
-		return false;
+		return true;
 	}
 
 	@Override
 	protected boolean isDataSiteLevel() {
-		return true;
+		return false;
 	}
 
 }

--- a/modules/apps/ratings/ratings-service/src/main/java/com/liferay/ratings/internal/page/ratings/exportimport/data/handler/PageRatingsPortletDataHandler.java
+++ b/modules/apps/ratings/ratings-service/src/main/java/com/liferay/ratings/internal/page/ratings/exportimport/data/handler/PageRatingsPortletDataHandler.java
@@ -15,6 +15,7 @@
 package com.liferay.ratings.internal.page.ratings.exportimport.data.handler;
 
 import com.liferay.exportimport.kernel.lar.BasePortletDataHandler;
+import com.liferay.exportimport.kernel.lar.DataLevel;
 import com.liferay.exportimport.kernel.lar.ExportImportHelper;
 import com.liferay.exportimport.kernel.lar.ExportImportProcessCallbackRegistry;
 import com.liferay.exportimport.kernel.lar.ManifestSummary;
@@ -71,6 +72,7 @@ public class PageRatingsPortletDataHandler extends BasePortletDataHandler {
 	@Activate
 	protected void activate() {
 		setDataAlwaysStaged(true);
+		setDataLevel(DataLevel.PORTLET_INSTANCE);
 		setDeletionSystemEventStagedModelTypes(
 			new StagedModelType(RatingsEntry.class));
 		setExportControls(

--- a/modules/apps/ratings/ratings-test/src/testIntegration/java/com/liferay/ratings/internal/exportimport/data/handler/test/PageRatingsPortletDataHandlerTest.java
+++ b/modules/apps/ratings/ratings-test/src/testIntegration/java/com/liferay/ratings/internal/exportimport/data/handler/test/PageRatingsPortletDataHandlerTest.java
@@ -68,7 +68,7 @@ public class PageRatingsPortletDataHandlerTest
 
 	@Override
 	protected DataLevel getDataLevel() {
-		return DataLevel.SITE;
+		return DataLevel.PORTLET_INSTANCE;
 	}
 
 	@Override
@@ -83,12 +83,12 @@ public class PageRatingsPortletDataHandlerTest
 
 	@Override
 	protected boolean isDataPortletInstanceLevel() {
-		return false;
+		return true;
 	}
 
 	@Override
 	protected boolean isDataSiteLevel() {
-		return true;
+		return false;
 	}
 
 }


### PR DESCRIPTION
Hi @adolfopa 

PageComments and PageRatings are deployable portlets, and I believe their data handler needs to set a data level at portlet_instance rather than using the default level of SITE