### PR TITLE
[TS] LPS-109296

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -8194,11 +8194,11 @@ public class PortalImpl implements Portal {
 					alternateURLs.put(locale, canonicalURL);
 				}
 				else {
+					String i18nPath = _buildI18NPath(
+						locale, themeDisplay.getSiteGroup());
+
 					alternateURLs.put(
-						locale,
-						canonicalURL.concat(
-							_buildI18NPath(
-								locale, themeDisplay.getSiteGroup())));
+						locale, canonicalURL + i18nPath + StringPool.SLASH);
 				}
 			}
 


### PR DESCRIPTION
Hi @adolfopa ,

If I understood correctly, the issue is that alternate URLs are redirecting when the i18nPath is the end of the URL and there is no 
trailing slash.

Can you please review?
https://issues.liferay.com/browse/LPS-109296

Thanks,
Balázs