### PR TITLE
[TS] LPS-120924 Use DLUtil to support UTF-8 characters as well

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
@@ -561,11 +561,7 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 					rs.getString("extension"));
 				String title = GetterUtil.getString(rs.getString("title"));
 
-				int availableLength = 254 - extension.length();
-
-				String fileName =
-					title.substring(0, availableLength) + StringPool.PERIOD +
-						extension;
+				String fileName = DLUtil.getSanitizedFileName(title, extension);
 
 				ps2.setString(1, fileName);
 

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
@@ -557,6 +557,7 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 
 			while (rs.next()) {
 				long fileEntryId = rs.getLong("fileEntryId");
+
 				String extension = GetterUtil.getString(
 					rs.getString("extension"));
 				String title = GetterUtil.getString(rs.getString("title"));


### PR DESCRIPTION
Hi @adolfopa ,

On MySQL the LENGTH function checks the byte size of the title column, not the character number. So titles with 2 or 3 byte characters (like Greek, Chinese) would not trigger this SQL
https://github.com/balazssk/liferay-portal/blob/6c9a96e7c0eb6ed027e6cfe073788b04dba39b3e/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java#L163 

Instead it would fall into https://github.com/balazssk/liferay-portal/blob/6c9a96e7c0eb6ed027e6cfe073788b04dba39b3e/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java#L548 where title.subString() could result in a StringIndexOutOfBoundsException.

Can you please review?
https://issues.liferay.com/browse/LPS-120924

Thanks,
Balázs