### PR TITLE
LPP-64362 Fix folder default permissions after changing a Space ERC

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-api/src/main/java/com/liferay/site/cms/site/initializer/util/CMSDefaultPermissionUtil.java
+++ b/modules/apps/site/site-cms-site-initializer-api/src/main/java/com/liferay/site/cms/site/initializer/util/CMSDefaultPermissionUtil.java
@@ -5,11 +5,15 @@
 
 package com.liferay.site.cms.site.initializer.util;
 
+import com.liferay.depot.constants.DepotRolesConstants;
+import com.liferay.depot.model.DepotEntry;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.rest.filter.factory.FilterFactory;
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
+import com.liferay.object.service.ObjectEntryFolderLocalServiceUtil;
 import com.liferay.object.service.ObjectEntryLocalServiceUtil;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.string.StringBundler;
@@ -17,19 +21,102 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
+import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 
 import java.io.Serializable;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * @author Stefano Motta
  */
 public class CMSDefaultPermissionUtil {
+
+	public static void addCMSDefaultPermissions(
+			ObjectEntryFolder objectEntryFolder,
+			FilterFactory<Predicate> filterFactory)
+		throws PortalException {
+
+		JSONObject defaultPermissionsJSONObject =
+			getCMSDefaultPermissionJSONObject(objectEntryFolder, filterFactory);
+
+		if ((defaultPermissionsJSONObject == null) ||
+			JSONUtil.isEmpty(defaultPermissionsJSONObject)) {
+
+			return;
+		}
+
+		if (!Objects.equals(
+				objectEntryFolder.getExternalReferenceCode(),
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS) &&
+			!Objects.equals(
+				objectEntryFolder.getExternalReferenceCode(),
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES)) {
+
+			addOrUpdateObjectEntry(
+				null, objectEntryFolder.getCompanyId(),
+				objectEntryFolder.getUserId(),
+				objectEntryFolder.getExternalReferenceCode(),
+				objectEntryFolder.getModelClassName(),
+				defaultPermissionsJSONObject, objectEntryFolder.getGroupId(),
+				objectEntryFolder.getTreePath());
+		}
+
+		JSONObject objectEntryFoldersJSONObject =
+			defaultPermissionsJSONObject.getJSONObject("OBJECT_ENTRY_FOLDERS");
+
+		if (objectEntryFoldersJSONObject == null) {
+			return;
+		}
+
+		List<String> resourceActions = ResourceActionsUtil.getResourceActions(
+			ObjectEntryFolder.class.getName());
+
+		List<Role> roles = RoleLocalServiceUtil.getGroupRolesAndTeamRoles(
+			objectEntryFolder.getCompanyId(), null,
+			Arrays.asList(
+				RoleConstants.ADMINISTRATOR,
+				DepotRolesConstants.ASSET_LIBRARY_OWNER),
+			null, null,
+			new int[] {RoleConstants.TYPE_REGULAR, RoleConstants.TYPE_DEPOT},
+			null, 0, 0, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+		for (Role role : roles) {
+			String[] actionIds = JSONUtil.toStringArray(
+				objectEntryFoldersJSONObject.getJSONArray(role.getName()));
+
+			if (objectEntryFolder.getParentObjectEntryFolderId() ==
+					ObjectEntryFolderConstants.
+						PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT) {
+
+				actionIds = ArrayUtil.remove(actionIds, ActionKeys.DELETE);
+			}
+
+			ResourcePermissionLocalServiceUtil.setResourcePermissions(
+				objectEntryFolder.getCompanyId(),
+				ObjectEntryFolder.class.getName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(objectEntryFolder.getObjectEntryFolderId()),
+				role.getRoleId(),
+				ArrayUtil.filter(actionIds, resourceActions::contains));
+		}
+	}
 
 	public static ObjectEntry addOrUpdateObjectEntry(
 			String externalReferenceCode, long companyId, long userId,
@@ -61,32 +148,97 @@ public class CMSDefaultPermissionUtil {
 			new ServiceContext());
 	}
 
+	public static void ensureCMSDefaultPermissions(
+			ObjectEntryFolder objectEntryFolder,
+			FilterFactory<Predicate> filterFactory)
+		throws PortalException {
+
+		if (Objects.equals(
+				objectEntryFolder.getExternalReferenceCode(),
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS) ||
+			Objects.equals(
+				objectEntryFolder.getExternalReferenceCode(),
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES)) {
+
+			return;
+		}
+
+		ObjectEntry objectEntry = fetchObjectEntry(
+			objectEntryFolder.getCompanyId(), objectEntryFolder.getUserId(),
+			objectEntryFolder.getExternalReferenceCode(),
+			objectEntryFolder.getModelClassName(), filterFactory);
+
+		if (objectEntry != null) {
+			return;
+		}
+
+		addCMSDefaultPermissions(objectEntryFolder, filterFactory);
+	}
+
 	public static ObjectEntry fetchObjectEntry(
 			long companyId, long userId, String classExternalReferenceCode,
 			String className, FilterFactory<Predicate> filterFactory)
 		throws PortalException {
 
-		ObjectDefinition objectDefinition =
-			ObjectDefinitionLocalServiceUtil.
-				getObjectDefinitionByExternalReferenceCode(
-					"L_CMS_DEFAULT_PERMISSION", companyId);
-
-		Predicate predicate = filterFactory.create(
+		return _fetchObjectEntry(
+			companyId, userId,
 			StringBundler.concat(
 				"(classExternalReferenceCode eq '", classExternalReferenceCode,
 				"') and (className eq '", className, "')"),
-			objectDefinition);
+			filterFactory);
+	}
 
-		List<Long> primaryKeys = ObjectEntryLocalServiceUtil.getPrimaryKeys(
-			new Long[0], companyId, userId,
-			objectDefinition.getObjectDefinitionId(), predicate, false, null,
-			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	public static ObjectEntry fetchObjectEntryByDepotGroupId(
+			long companyId, long userId, long depotGroupId, String className,
+			FilterFactory<Predicate> filterFactory)
+		throws PortalException {
 
-		if (ListUtil.isEmpty(primaryKeys)) {
+		return _fetchObjectEntry(
+			companyId, userId,
+			StringBundler.concat(
+				"(depotGroupId eq ", depotGroupId, ") and (className eq '",
+				className, "')"),
+			filterFactory);
+	}
+
+	public static JSONObject getCMSDefaultPermissionJSONObject(
+			ObjectEntryFolder objectEntryFolder,
+			FilterFactory<Predicate> filterFactory)
+		throws PortalException {
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionLocalServiceUtil.
+				fetchObjectDefinitionByExternalReferenceCode(
+					"L_CMS_DEFAULT_PERMISSION",
+					objectEntryFolder.getCompanyId());
+
+		if (objectDefinition == null) {
 			return null;
 		}
 
-		return ObjectEntryLocalServiceUtil.fetchObjectEntry(primaryKeys.get(0));
+		if (objectEntryFolder.getParentObjectEntryFolderId() != 0) {
+			ObjectEntryFolder parentObjectEntryFolder =
+				ObjectEntryFolderLocalServiceUtil.getObjectEntryFolder(
+					objectEntryFolder.getParentObjectEntryFolderId());
+
+			JSONObject jsonObject = getJSONObject(
+				parentObjectEntryFolder.getCompanyId(),
+				parentObjectEntryFolder.getUserId(),
+				parentObjectEntryFolder.getExternalReferenceCode(),
+				parentObjectEntryFolder.getModelClassName(), filterFactory);
+
+			if ((jsonObject != null) && !JSONUtil.isEmpty(jsonObject)) {
+				return jsonObject;
+			}
+		}
+
+		Group group = GroupLocalServiceUtil.getGroup(
+			objectEntryFolder.getGroupId());
+
+		return getJSONObject(
+			group.getCompanyId(), group.getCreatorUserId(),
+			group.getExternalReferenceCode(), DepotEntry.class.getName(),
+			filterFactory);
 	}
 
 	public static JSONObject getJSONObject(
@@ -114,6 +266,56 @@ public class CMSDefaultPermissionUtil {
 
 		return JSONFactoryUtil.createJSONObject(
 			String.valueOf(values.getOrDefault("defaultPermissions", "{}")));
+	}
+
+	public static void updateClassExternalReferenceCode(
+			ObjectEntry objectEntry, String classExternalReferenceCode,
+			long userId)
+		throws PortalException {
+
+		Map<String, Serializable> values = objectEntry.getValues();
+
+		if (Objects.equals(
+				values.get("classExternalReferenceCode"),
+				classExternalReferenceCode)) {
+
+			return;
+		}
+
+		ObjectEntryLocalServiceUtil.updateObjectEntry(
+			userId, objectEntry.getObjectEntryId(),
+			objectEntry.getObjectEntryFolderId(),
+			HashMapBuilder.<String, Serializable>putAll(
+				values
+			).put(
+				"classExternalReferenceCode", classExternalReferenceCode
+			).build(),
+			new ServiceContext());
+	}
+
+	private static ObjectEntry _fetchObjectEntry(
+			long companyId, long userId, String filterString,
+			FilterFactory<Predicate> filterFactory)
+		throws PortalException {
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionLocalServiceUtil.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_CMS_DEFAULT_PERMISSION", companyId);
+
+		Predicate predicate = filterFactory.create(
+			filterString, objectDefinition);
+
+		List<Long> primaryKeys = ObjectEntryLocalServiceUtil.getPrimaryKeys(
+			new Long[0], companyId, userId,
+			objectDefinition.getObjectDefinitionId(), predicate, false, null,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+
+		if (ListUtil.isEmpty(primaryKeys)) {
+			return null;
+		}
+
+		return ObjectEntryLocalServiceUtil.fetchObjectEntry(primaryKeys.get(0));
 	}
 
 }

--- a/modules/apps/site/site-cms-site-initializer-test/build.gradle
+++ b/modules/apps/site/site-cms-site-initializer-test/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:site:site-cms-site-initializer")
 	testIntegrationImplementation project(":apps:site:site-cms-site-initializer-api")
 	testIntegrationImplementation project(":apps:site:site-cms-site-initializer-test-util")
+	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")
 	testIntegrationImplementation project(":apps:translation:translation-api")
 	testIntegrationImplementation project(":apps:trash:trash-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/model/listener/test/GroupModelListenerTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/model/listener/test/GroupModelListenerTest.java
@@ -9,12 +9,16 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.rest.filter.factory.FilterFactory;
+import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -26,6 +30,7 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.site.cms.site.initializer.test.util.CMSTestUtil;
+import com.liferay.site.cms.site.initializer.util.CMSDefaultPermissionUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -79,6 +84,40 @@ public class GroupModelListenerTest {
 				depotGroup.getTypeSettingsProperty("trashEnabled")));
 	}
 
+	@Test
+	public void testUpdateExternalReferenceCode() throws Exception {
+		DepotEntry depotEntry = _addDepotEntry();
+
+		Group depotGroup = depotEntry.getGroup();
+
+		String originalExternalReferenceCode =
+			depotGroup.getExternalReferenceCode();
+
+		Assert.assertNotNull(
+			CMSDefaultPermissionUtil.fetchObjectEntry(
+				depotGroup.getCompanyId(), depotGroup.getCreatorUserId(),
+				originalExternalReferenceCode, DepotEntry.class.getName(),
+				_filterFactory));
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		depotGroup.setExternalReferenceCode(externalReferenceCode);
+
+		depotGroup = _groupLocalService.updateGroup(depotGroup);
+
+		Assert.assertNull(
+			CMSDefaultPermissionUtil.fetchObjectEntry(
+				depotGroup.getCompanyId(), depotGroup.getCreatorUserId(),
+				originalExternalReferenceCode, DepotEntry.class.getName(),
+				_filterFactory));
+
+		Assert.assertNotNull(
+			CMSDefaultPermissionUtil.fetchObjectEntry(
+				depotGroup.getCompanyId(), depotGroup.getCreatorUserId(),
+				externalReferenceCode, DepotEntry.class.getName(),
+				_filterFactory));
+	}
+
 	private DepotEntry _addDepotEntry() throws Exception {
 		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
 			HashMapBuilder.put(
@@ -121,6 +160,11 @@ public class GroupModelListenerTest {
 
 	@Inject
 	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject(
+		filter = "filter.factory.key=" + ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT
+	)
+	private FilterFactory<Predicate> _filterFactory;
 
 	@Inject
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/upgrade/v1_0_0/test/CMSDefaultPermissionsUpgradeProcessTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/upgrade/v1_0_0/test/CMSDefaultPermissionsUpgradeProcessTest.java
@@ -1,0 +1,184 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.upgrade.v1_0_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.rest.filter.factory.FilterFactory;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.petra.sql.dsl.expression.Predicate;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.upgrade.UpgradeStep;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.site.cms.site.initializer.test.util.CMSTestUtil;
+import com.liferay.site.cms.site.initializer.util.CMSDefaultPermissionUtil;
+
+import java.util.Objects;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Marco Leo
+ */
+@FeatureFlag("LPD-17564")
+@RunWith(Arquillian.class)
+public class CMSDefaultPermissionsUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		CMSTestUtil.getOrAddGroup(
+			CMSDefaultPermissionsUpgradeProcessTest.class);
+
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.US, StringUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.US, StringUtil.randomString()
+			).build(),
+			DepotConstants.TYPE_SPACE,
+			ServiceContextTestUtil.getServiceContext());
+
+		_group = depotEntry.getGroup();
+	}
+
+	@Test
+	public void testUpgrade() throws Exception {
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.addObjectEntryFolder(
+				RandomTestUtil.randomString(), _group.getGroupId(),
+				_group.getCreatorUserId(), 0, "",
+				HashMapBuilder.put(
+					LocaleUtil.ENGLISH, RandomTestUtil.randomString()
+				).build(),
+				RandomTestUtil.randomString(),
+				ServiceContextTestUtil.getServiceContext());
+
+		ObjectEntry objectEntryFolderObjectEntry = _fetchObjectEntry(
+			objectEntryFolder);
+
+		Assert.assertNotNull(objectEntryFolderObjectEntry);
+
+		ObjectEntry depotEntryObjectEntry = _fetchDepotEntryObjectEntry();
+
+		Assert.assertNotNull(depotEntryObjectEntry);
+
+		CMSDefaultPermissionUtil.updateClassExternalReferenceCode(
+			depotEntryObjectEntry, RandomTestUtil.randomString(),
+			_group.getCreatorUserId());
+
+		Assert.assertNull(_fetchDepotEntryObjectEntry());
+
+		_objectEntryLocalService.deleteObjectEntry(
+			objectEntryFolderObjectEntry.getObjectEntryId());
+
+		Assert.assertNull(_fetchObjectEntry(objectEntryFolder));
+
+		_runUpgrade();
+
+		Assert.assertNotNull(_fetchDepotEntryObjectEntry());
+
+		Assert.assertNotNull(_fetchObjectEntry(objectEntryFolder));
+	}
+
+	private ObjectEntry _fetchDepotEntryObjectEntry() throws Exception {
+		return CMSDefaultPermissionUtil.fetchObjectEntry(
+			_group.getCompanyId(), _group.getCreatorUserId(),
+			_group.getExternalReferenceCode(), DepotEntry.class.getName(),
+			_filterFactory);
+	}
+
+	private ObjectEntry _fetchObjectEntry(ObjectEntryFolder objectEntryFolder)
+		throws Exception {
+
+		return CMSDefaultPermissionUtil.fetchObjectEntry(
+			objectEntryFolder.getCompanyId(), objectEntryFolder.getUserId(),
+			objectEntryFolder.getExternalReferenceCode(),
+			objectEntryFolder.getModelClassName(), _filterFactory);
+	}
+
+	private UpgradeProcess _getUpgradeProcess() {
+		UpgradeProcess[] upgradeProcesses = new UpgradeProcess[1];
+
+		_upgradeStepRegistrator.register(
+			(fromSchemaVersionString, toSchemaVersionString, upgradeSteps) -> {
+				for (UpgradeStep upgradeStep : upgradeSteps) {
+					Class<? extends UpgradeStep> clazz = upgradeStep.getClass();
+
+					if (Objects.equals(clazz.getName(), _CLASS_NAME)) {
+						upgradeProcesses[0] = (UpgradeProcess)upgradeStep;
+
+						break;
+					}
+				}
+			});
+
+		return upgradeProcesses[0];
+	}
+
+	private void _runUpgrade() throws Exception {
+		UpgradeProcess upgradeProcess = _getUpgradeProcess();
+
+		upgradeProcess.upgrade();
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.site.cms.site.initializer.internal.upgrade.v1_0_0." +
+			"CMSDefaultPermissionsUpgradeProcess";
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject(
+		filter = "filter.factory.key=" + ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT
+	)
+	private FilterFactory<Predicate> _filterFactory;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject(
+		filter = "(component.name=com.liferay.site.cms.site.initializer.internal.upgrade.registry.SiteCMSSiteInitializerUpgradeStepRegistrator)"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/build.gradle
+++ b/modules/apps/site/site-cms-site-initializer/build.gradle
@@ -49,6 +49,7 @@ dependencies {
 	compileOnly project(":apps:site:site-api")
 	compileOnly project(":apps:site:site-cms-site-initializer-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	compileOnly project(":apps:static:portal:portal-upgrade-api")
 	compileOnly project(":apps:subscription:subscription-api")
 	compileOnly project(":apps:translation:translation-api")
 	compileOnly project(":apps:trash:trash-api")

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/GroupModelListener.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/GroupModelListener.java
@@ -8,7 +8,13 @@ package com.liferay.site.cms.site.initializer.internal.model.listener;
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.rest.filter.factory.FilterFactory;
+import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
@@ -18,6 +24,7 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.site.cms.site.initializer.util.CMSDefaultPermissionUtil;
 import com.liferay.trash.TrashHelper;
 
 import java.util.Objects;
@@ -63,38 +70,79 @@ public class GroupModelListener extends BaseModelListener<Group> {
 	private void _onAfterUpdate(Group originalGroup, Group group)
 		throws Exception {
 
-		if (group.isDepot()) {
-			DepotEntry depotEntry =
-				_depotEntryLocalService.fetchGroupDepotEntry(
-					group.getGroupId());
-
-			if ((depotEntry == null) ||
-				!(depotEntry.getType() == DepotConstants.TYPE_SPACE) ||
-				Objects.equals(
-					originalGroup.getTypeSettingsProperty("trashEnabled"),
-					group.getTypeSettingsProperty("trashEnabled")) ||
-				!FeatureFlagManagerUtil.isEnabled(
-					group.getCompanyId(), "LPD-17564")) {
-
-				return;
-			}
-
-			Group siteGroup = _groupLocalService.fetchGroup(
-				group.getCompanyId(), GroupConstants.CMS);
-
-			if (siteGroup == null) {
-				return;
-			}
-
-			Long[] groupIds = _getDepotGroupIds(group.getCompanyId());
-
-			if (groupIds.length > 0) {
-				_updateRecycleBinLayout(siteGroup, false);
-			}
-			else {
-				_updateRecycleBinLayout(siteGroup, true);
-			}
+		if (!group.isDepot()) {
+			return;
 		}
+
+		DepotEntry depotEntry = _depotEntryLocalService.fetchGroupDepotEntry(
+			group.getGroupId());
+
+		if ((depotEntry == null) ||
+			(depotEntry.getType() != DepotConstants.TYPE_SPACE) ||
+			!FeatureFlagManagerUtil.isEnabled(
+				group.getCompanyId(), "LPD-17564")) {
+
+			return;
+		}
+
+		_updateCMSDefaultPermissionExternalReferenceCode(originalGroup, group);
+
+		if (Objects.equals(
+				originalGroup.getTypeSettingsProperty("trashEnabled"),
+				group.getTypeSettingsProperty("trashEnabled"))) {
+
+			return;
+		}
+
+		Group siteGroup = _groupLocalService.fetchGroup(
+			group.getCompanyId(), GroupConstants.CMS);
+
+		if (siteGroup == null) {
+			return;
+		}
+
+		Long[] groupIds = _getDepotGroupIds(group.getCompanyId());
+
+		if (groupIds.length > 0) {
+			_updateRecycleBinLayout(siteGroup, false);
+		}
+		else {
+			_updateRecycleBinLayout(siteGroup, true);
+		}
+	}
+
+	private void _updateCMSDefaultPermissionExternalReferenceCode(
+			Group originalGroup, Group group)
+		throws Exception {
+
+		if (Objects.equals(
+				originalGroup.getExternalReferenceCode(),
+				group.getExternalReferenceCode())) {
+
+			return;
+		}
+
+		ObjectDefinition cmsDefaultPermissionObjectDefinition =
+			_objectDefinitionLocalService.
+				fetchObjectDefinitionByExternalReferenceCode(
+					"L_CMS_DEFAULT_PERMISSION", group.getCompanyId());
+
+		if (cmsDefaultPermissionObjectDefinition == null) {
+			return;
+		}
+
+		ObjectEntry objectEntry =
+			CMSDefaultPermissionUtil.fetchObjectEntryByDepotGroupId(
+				group.getCompanyId(), group.getCreatorUserId(),
+				group.getGroupId(), DepotEntry.class.getName(), _filterFactory);
+
+		if (objectEntry == null) {
+			return;
+		}
+
+		CMSDefaultPermissionUtil.updateClassExternalReferenceCode(
+			objectEntry, group.getExternalReferenceCode(),
+			group.getCreatorUserId());
 	}
 
 	private void _updateRecycleBinLayout(Group group, boolean hidden)
@@ -115,11 +163,19 @@ public class GroupModelListener extends BaseModelListener<Group> {
 	@Reference
 	private DepotEntryLocalService _depotEntryLocalService;
 
+	@Reference(
+		target = "(filter.factory.key=" + ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT + ")"
+	)
+	private FilterFactory<Predicate> _filterFactory;
+
 	@Reference
 	private GroupLocalService _groupLocalService;
 
 	@Reference
 	private LayoutLocalService _layoutLocalService;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
 	@Reference
 	private TrashHelper _trashHelper;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/ObjectEntryFolderModelListener.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/ObjectEntryFolderModelListener.java
@@ -5,43 +5,24 @@
 
 package com.liferay.site.cms.site.initializer.internal.model.listener;
 
-import com.liferay.depot.constants.DepotRolesConstants;
-import com.liferay.depot.model.DepotEntry;
 import com.liferay.object.constants.ObjectDefinitionConstants;
-import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.rest.filter.factory.FilterFactory;
 import com.liferay.object.service.ObjectDefinitionLocalService;
-import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.petra.sql.dsl.expression.Predicate;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
-import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.ModelListener;
-import com.liferay.portal.kernel.model.ResourceConstants;
-import com.liferay.portal.kernel.model.Role;
-import com.liferay.portal.kernel.model.role.RoleConstants;
-import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
-import com.liferay.portal.kernel.service.GroupLocalService;
-import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
-import com.liferay.portal.kernel.service.RoleLocalService;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.sharing.service.SharingEntryLocalService;
 import com.liferay.site.cms.site.initializer.util.CMSDefaultPermissionUtil;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -96,113 +77,6 @@ public class ObjectEntryFolderModelListener
 		}
 	}
 
-	private void _addCMSDefaultPermissions(ObjectEntryFolder objectEntryFolder)
-		throws Exception {
-
-		JSONObject defaultPermissionsJSONObject =
-			_getCMSDefaultPermissionJSONObject(objectEntryFolder);
-
-		if ((defaultPermissionsJSONObject == null) ||
-			JSONUtil.isEmpty(defaultPermissionsJSONObject)) {
-
-			return;
-		}
-
-		if (!Objects.equals(
-				objectEntryFolder.getExternalReferenceCode(),
-				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS) &&
-			!Objects.equals(
-				objectEntryFolder.getExternalReferenceCode(),
-				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES)) {
-
-			CMSDefaultPermissionUtil.addOrUpdateObjectEntry(
-				null, objectEntryFolder.getCompanyId(),
-				objectEntryFolder.getUserId(),
-				objectEntryFolder.getExternalReferenceCode(),
-				objectEntryFolder.getModelClassName(),
-				defaultPermissionsJSONObject, objectEntryFolder.getGroupId(),
-				objectEntryFolder.getTreePath());
-		}
-
-		JSONObject objectEntryFoldersJSONObject =
-			defaultPermissionsJSONObject.getJSONObject("OBJECT_ENTRY_FOLDERS");
-
-		if (objectEntryFoldersJSONObject == null) {
-			return;
-		}
-
-		List<String> resourceActions = ResourceActionsUtil.getResourceActions(
-			ObjectEntryFolder.class.getName());
-
-		List<Role> roles = _roleLocalService.getGroupRolesAndTeamRoles(
-			objectEntryFolder.getCompanyId(), null,
-			Arrays.asList(
-				RoleConstants.ADMINISTRATOR,
-				DepotRolesConstants.ASSET_LIBRARY_OWNER),
-			null, null,
-			new int[] {RoleConstants.TYPE_REGULAR, RoleConstants.TYPE_DEPOT},
-			null, 0, 0, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
-
-		for (Role role : roles) {
-			String[] actionIds = JSONUtil.toStringArray(
-				objectEntryFoldersJSONObject.getJSONArray(role.getName()));
-
-			if (objectEntryFolder.getParentObjectEntryFolderId() ==
-					ObjectEntryFolderConstants.
-						PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT) {
-
-				actionIds = ArrayUtil.remove(actionIds, ActionKeys.DELETE);
-			}
-
-			_resourcePermissionLocalService.setResourcePermissions(
-				objectEntryFolder.getCompanyId(),
-				ObjectEntryFolder.class.getName(),
-				ResourceConstants.SCOPE_INDIVIDUAL,
-				String.valueOf(objectEntryFolder.getObjectEntryFolderId()),
-				role.getRoleId(),
-				ArrayUtil.filter(actionIds, resourceActions::contains));
-		}
-	}
-
-	private JSONObject _getCMSDefaultPermissionJSONObject(
-			ObjectEntryFolder objectEntryFolder)
-		throws Exception {
-
-		ObjectDefinition cmsDefaultPermissionObjectDefinition =
-			_objectDefinitionLocalService.
-				fetchObjectDefinitionByExternalReferenceCode(
-					"L_CMS_DEFAULT_PERMISSION",
-					objectEntryFolder.getCompanyId());
-
-		if (cmsDefaultPermissionObjectDefinition == null) {
-			return null;
-		}
-
-		if (objectEntryFolder.getParentObjectEntryFolderId() != 0) {
-			ObjectEntryFolder parentObjectEntryFolder =
-				_objectEntryFolderLocalService.getObjectEntryFolder(
-					objectEntryFolder.getParentObjectEntryFolderId());
-
-			JSONObject jsonObject = CMSDefaultPermissionUtil.getJSONObject(
-				parentObjectEntryFolder.getCompanyId(),
-				parentObjectEntryFolder.getUserId(),
-				parentObjectEntryFolder.getExternalReferenceCode(),
-				parentObjectEntryFolder.getModelClassName(), _filterFactory);
-
-			if ((jsonObject != null) && !JSONUtil.isEmpty(jsonObject)) {
-				return jsonObject;
-			}
-		}
-
-		Group group = _groupLocalService.getGroup(
-			objectEntryFolder.getGroupId());
-
-		return CMSDefaultPermissionUtil.getJSONObject(
-			group.getCompanyId(), group.getCreatorUserId(),
-			group.getExternalReferenceCode(), DepotEntry.class.getName(),
-			_filterFactory);
-	}
-
 	private void _onAfterCreate(ObjectEntryFolder objectEntryFolder)
 		throws Exception {
 
@@ -212,7 +86,8 @@ public class ObjectEntryFolderModelListener
 			return;
 		}
 
-		_addCMSDefaultPermissions(objectEntryFolder);
+		CMSDefaultPermissionUtil.addCMSDefaultPermissions(
+			objectEntryFolder, _filterFactory);
 	}
 
 	private void _onAfterRemove(ObjectEntryFolder objectEntryFolder)
@@ -262,7 +137,8 @@ public class ObjectEntryFolderModelListener
 		}
 
 		JSONObject defaultPermissionsJSONObject =
-			_getCMSDefaultPermissionJSONObject(objectEntryFolder);
+			CMSDefaultPermissionUtil.getCMSDefaultPermissionJSONObject(
+				objectEntryFolder, _filterFactory);
 
 		if ((defaultPermissionsJSONObject == null) ||
 			JSONUtil.isEmpty(defaultPermissionsJSONObject)) {
@@ -280,7 +156,8 @@ public class ObjectEntryFolderModelListener
 				objectEntry.getObjectEntryId());
 		}
 
-		_addCMSDefaultPermissions(objectEntryFolder);
+		CMSDefaultPermissionUtil.addCMSDefaultPermissions(
+			objectEntryFolder, _filterFactory);
 	}
 
 	@Reference(
@@ -289,25 +166,13 @@ public class ObjectEntryFolderModelListener
 	private FilterFactory<Predicate> _filterFactory;
 
 	@Reference
-	private GroupLocalService _groupLocalService;
-
-	@Reference
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
-
-	@Reference
-	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
 
 	@Reference
 	private ObjectEntryLocalService _objectEntryLocalService;
 
 	@Reference
 	private Portal _portal;
-
-	@Reference
-	private ResourcePermissionLocalService _resourcePermissionLocalService;
-
-	@Reference
-	private RoleLocalService _roleLocalService;
 
 	@Reference
 	private SharingEntryLocalService _sharingEntryLocalService;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/upgrade/registry/SiteCMSSiteInitializerUpgradeStepRegistrator.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/upgrade/registry/SiteCMSSiteInitializerUpgradeStepRegistrator.java
@@ -1,0 +1,52 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.upgrade.registry;
+
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.rest.filter.factory.FilterFactory;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.petra.sql.dsl.expression.Predicate;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.site.cms.site.initializer.internal.upgrade.v1_0_0.CMSDefaultPermissionsUpgradeProcess;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Marco Leo
+ */
+@Component(service = UpgradeStepRegistrator.class)
+public class SiteCMSSiteInitializerUpgradeStepRegistrator
+	implements UpgradeStepRegistrator {
+
+	@Override
+	public void register(Registry registry) {
+		registry.registerInitialization();
+
+		registry.register(
+			"0.0.0", "1.0.0",
+			new CMSDefaultPermissionsUpgradeProcess(
+				_filterFactory, _groupLocalService,
+				_objectDefinitionLocalService, _objectEntryFolderLocalService));
+	}
+
+	@Reference(
+		target = "(filter.factory.key=" + ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT + ")"
+	)
+	private FilterFactory<Predicate> _filterFactory;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/upgrade/v1_0_0/CMSDefaultPermissionsUpgradeProcess.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/upgrade/v1_0_0/CMSDefaultPermissionsUpgradeProcess.java
@@ -1,0 +1,105 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.upgrade.v1_0_0;
+
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.rest.filter.factory.FilterFactory;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.petra.sql.dsl.expression.Predicate;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.site.cms.site.initializer.util.CMSDefaultPermissionUtil;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author Marco Leo
+ */
+public class CMSDefaultPermissionsUpgradeProcess extends UpgradeProcess {
+
+	public CMSDefaultPermissionsUpgradeProcess(
+		FilterFactory<Predicate> filterFactory,
+		GroupLocalService groupLocalService,
+		ObjectDefinitionLocalService objectDefinitionLocalService,
+		ObjectEntryFolderLocalService objectEntryFolderLocalService) {
+
+		_filterFactory = filterFactory;
+		_groupLocalService = groupLocalService;
+		_objectDefinitionLocalService = objectDefinitionLocalService;
+		_objectEntryFolderLocalService = objectEntryFolderLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		int count = _objectEntryFolderLocalService.getObjectEntryFoldersCount();
+
+		Set<Long> repairedGroupIds = new HashSet<>();
+
+		for (int start = 0; start < count; start += _BATCH_SIZE) {
+			List<ObjectEntryFolder> objectEntryFolders =
+				_objectEntryFolderLocalService.getObjectEntryFolders(
+					start, start + _BATCH_SIZE);
+
+			for (ObjectEntryFolder objectEntryFolder : objectEntryFolders) {
+				ObjectDefinition objectDefinition =
+					_objectDefinitionLocalService.
+						fetchObjectDefinitionByExternalReferenceCode(
+							"L_CMS_DEFAULT_PERMISSION",
+							objectEntryFolder.getCompanyId());
+
+				if (objectDefinition == null) {
+					continue;
+				}
+
+				if (repairedGroupIds.add(objectEntryFolder.getGroupId())) {
+					_updateCMSDefaultPermissionExternalReferenceCode(
+						objectEntryFolder.getGroupId());
+				}
+
+				CMSDefaultPermissionUtil.ensureCMSDefaultPermissions(
+					objectEntryFolder, _filterFactory);
+			}
+		}
+	}
+
+	private void _updateCMSDefaultPermissionExternalReferenceCode(long groupId)
+		throws Exception {
+
+		Group group = _groupLocalService.fetchGroup(groupId);
+
+		if (group == null) {
+			return;
+		}
+
+		ObjectEntry objectEntry =
+			CMSDefaultPermissionUtil.fetchObjectEntryByDepotGroupId(
+				group.getCompanyId(), group.getCreatorUserId(),
+				group.getGroupId(), DepotEntry.class.getName(), _filterFactory);
+
+		if (objectEntry == null) {
+			return;
+		}
+
+		CMSDefaultPermissionUtil.updateClassExternalReferenceCode(
+			objectEntry, group.getExternalReferenceCode(),
+			group.getCreatorUserId());
+	}
+
+	private static final int _BATCH_SIZE = 100;
+
+	private final FilterFactory<Predicate> _filterFactory;
+	private final GroupLocalService _groupLocalService;
+	private final ObjectDefinitionLocalService _objectDefinitionLocalService;
+	private final ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+}


### PR DESCRIPTION
A Space's default permissions are stored as a CMS default permission object entry keyed by the group's external reference code. Changing the Space external reference code left that entry pointing at the old value, so folder creation could no longer resolve the Space defaults. Newly created folders received no per-folder default permission entry and opening their default permissions modal failed with a system error, which also persisted for folders created while the custom external reference code was set.

This keeps the Space entry's class external reference code in sync when the group external reference code changes, and adds an upgrade process that repairs already affected environments by re-syncing the Space entries and backfilling the missing per-folder entries.